### PR TITLE
fix(server): resolve Hugging Face repo ids to a local checkpoint dir

### DIFF
--- a/python/freetoken/server/args.py
+++ b/python/freetoken/server/args.py
@@ -646,16 +646,26 @@ def parse_args(
     if is_offload_moe_backend(kwargs["moe_backend"]) and _no_cache_flag:
         kwargs["moe_cache_auto"] = True
 
-    if kwargs["model_source"] == "modelscope":
-        model_path = kwargs["model_path"]
-        if not os.path.isdir(model_path):
+    # Resolve a hub repo id ("org/model") to a local checkpoint directory. This has to
+    # happen here, after served_model_name and the parser cascade have read the repo id
+    # (they want "DeepSeek-V4-Flash-0731", not a snapshot hash) and before anything opens
+    # the checkpoint: config parsing reads model-specific files straight off disk, so a
+    # bare repo id reaches `open()` as a relative path and dies with a FileNotFoundError.
+    model_path = kwargs["model_path"]
+    if not os.path.isdir(model_path):
+        if kwargs["model_source"] == "modelscope":
             from modelscope import snapshot_download
 
             ignore_patterns = []
             if kwargs["use_dummy_weight"]:
                 ignore_patterns = ["*.bin", "*.safetensors", "*.pt", "*.ckpt"]
-            model_path = snapshot_download(model_path, ignore_patterns=ignore_patterns)
-            kwargs["model_path"] = model_path
+            kwargs["model_path"] = snapshot_download(model_path, ignore_patterns=ignore_patterns)
+        else:
+            from freetoken.utils import download_hf_checkpoint
+
+            kwargs["model_path"] = download_hf_checkpoint(
+                model_path, dummy_weight=kwargs["use_dummy_weight"]
+            )
     del kwargs["model_source"]
 
     # "auto" (or an unspecified dtype) resolves to the checkpoint's dtype. Multimodal /

--- a/python/freetoken/utils/__init__.py
+++ b/python/freetoken/utils/__init__.py
@@ -7,6 +7,7 @@ from .arch import (
 )
 from .hf import (
     cached_load_hf_config,
+    download_hf_checkpoint,
     download_hf_weight,
     load_eos_token_ids,
     load_generation_sampling,
@@ -28,6 +29,7 @@ from .torch_utils import nvtx_annotate, torch_dtype
 
 __all__ = [
     "cached_load_hf_config",
+    "download_hf_checkpoint",
     "download_hf_weight",
     "load_eos_token_ids",
     "load_generation_sampling",

--- a/python/freetoken/utils/hf.py
+++ b/python/freetoken/utils/hf.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import os
+import re
 from typing import Any
 
 from typing import FrozenSet
@@ -225,6 +226,17 @@ def download_hf_weight(model_path: str) -> str:
 _UNLOADABLE_WEIGHTS = ("*.bin", "*.pt", "*.pth", "*.h5", "*.msgpack", "*.onnx")
 
 
+# A hub repo id is "org/name" and nothing else. Anything with a leading separator, a
+# "~", or more than one "/" is a filesystem path the user got wrong, and turning that
+# into a hub lookup replaces "no such directory" with a confusing download error.
+_HUB_REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def looks_like_hub_repo_id(model_path: str) -> bool:
+    """Whether ``model_path`` should be resolved against the Hub rather than the disk."""
+    return bool(_HUB_REPO_ID.match(model_path))
+
+
 def download_hf_checkpoint(model_path: str, *, dummy_weight: bool = False) -> str:
     """Resolve a Hugging Face repo id to a complete local checkpoint directory.
 
@@ -236,7 +248,7 @@ def download_hf_checkpoint(model_path: str, *, dummy_weight: bool = False) -> st
 
     A path that is already a local directory is returned untouched.
     """
-    if os.path.isdir(model_path):
+    if os.path.isdir(model_path) or not looks_like_hub_repo_id(model_path):
         return model_path
     ignore_patterns = list(_UNLOADABLE_WEIGHTS)
     if dummy_weight:

--- a/python/freetoken/utils/hf.py
+++ b/python/freetoken/utils/hf.py
@@ -217,3 +217,34 @@ def download_hf_weight(model_path: str) -> str:
         raise ValueError(
             f"Model path '{model_path}' is neither a local directory nor a valid model ID: {e}"
         )
+
+
+# Weight formats FreeToken never loads -- it reads safetensors (plus GGUF for Gemma-4).
+# Plenty of repos still ship a duplicate .bin/.pth copy of the same tensors, so skipping
+# them can halve a first-time pull.
+_UNLOADABLE_WEIGHTS = ("*.bin", "*.pt", "*.pth", "*.h5", "*.msgpack", "*.onnx")
+
+
+def download_hf_checkpoint(model_path: str, *, dummy_weight: bool = False) -> str:
+    """Resolve a Hugging Face repo id to a complete local checkpoint directory.
+
+    ``download_hf_weight`` fetches only ``*.safetensors``, which is all the weight
+    loaders need once the engine is running. Config parsing happens earlier and wants
+    more than that: the tokenizer, and the model-specific subdirs some architectures
+    read directly off disk -- DeepSeek-V4 fails without ``inference/config.json``
+    (see ``models/deepseek_v4/args.py``). So this pulls the whole snapshot.
+
+    A path that is already a local directory is returned untouched.
+    """
+    if os.path.isdir(model_path):
+        return model_path
+    ignore_patterns = list(_UNLOADABLE_WEIGHTS)
+    if dummy_weight:
+        # Config and tokenizer are still needed; the tensors are not.
+        ignore_patterns += ["*.safetensors", "*.gguf"]
+    try:
+        return snapshot_download(model_path, ignore_patterns=ignore_patterns)
+    except Exception as e:
+        raise ValueError(
+            f"Model path '{model_path}' is neither a local directory nor a valid model ID: {e}"
+        )

--- a/tests/server/test_model_path_resolution.py
+++ b/tests/server/test_model_path_resolution.py
@@ -1,0 +1,87 @@
+"""``--model org/name``: a hub repo id resolves to a local checkpoint directory.
+
+``ft serve --model deepseek-ai/DeepSeek-V4-Flash-0731`` used to pass the repo id through
+untouched as a filesystem path. Config parsing then opened it relative to cwd:
+
+    FileNotFoundError: No DeepSeek-V4 ModelArgs JSON found under
+    deepseek-ai/DeepSeek-V4-Flash-0731 (looked for inference/config.json)
+
+Only the modelscope branch ever downloaded, and ``download_hf_weight`` (used later, by the
+weight loaders) fetches ``*.safetensors`` alone -- so it would never have produced
+``inference/config.json`` either.
+
+These pin the resolve for both sources, and pin the two things that must keep reading the
+*repo id* rather than the resolved snapshot path: the served model name and the parser
+cascade. Resolving too early renames the served model to a snapshot hash.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from freetoken.server.args import parse_args
+
+REPO_ID = "deepseek-ai/DeepSeek-V4-Flash-0731"
+SNAPSHOT = "/cache/hub/models--deepseek-ai--DeepSeek-V4-Flash-0731/snapshots/7872f01"
+
+# Explicit dtype and parsers keep parse_args off the network: all three otherwise read the
+# checkpoint config, which is exactly what cannot be loaded until the path resolves.
+BASE_ARGS = ["--dtype", "bfloat16", "--tool-call-parser", "llama3", "--reasoning-parser", "off"]
+
+
+def _parse(model_path: str, *extra: str):
+    return parse_args([*BASE_ARGS, "--model", model_path, *extra])[0]
+
+
+@pytest.fixture
+def hf_download():
+    with patch("freetoken.utils.hf.snapshot_download", return_value=SNAPSHOT) as m:
+        yield m
+
+
+def test_repo_id_resolves_to_local_snapshot(hf_download):
+    assert _parse(REPO_ID).model_path == SNAPSHOT
+    assert hf_download.call_args.args[0] == REPO_ID
+
+
+def test_served_model_name_keeps_the_repo_id(hf_download):
+    """Not the snapshot hash -- this is the id clients send in the `model` field."""
+    assert _parse(REPO_ID).served_model_name == "DeepSeek-V4-Flash-0731"
+
+
+def test_local_dir_is_never_downloaded(tmp_path, hf_download):
+    assert _parse(str(tmp_path)).model_path == str(tmp_path)
+    hf_download.assert_not_called()
+
+
+def test_formats_freetoken_cannot_load_are_skipped(hf_download):
+    """Many repos ship a duplicate .bin copy; the loaders only read safetensors/gguf."""
+    _parse(REPO_ID)
+    ignored = hf_download.call_args.kwargs["ignore_patterns"]
+    assert "*.bin" in ignored
+    assert "*.safetensors" not in ignored
+
+
+def test_dummy_weight_skips_the_tensors(hf_download):
+    """--dummy-weight still needs config + tokenizer, but not 156 GiB of weights."""
+    _parse(REPO_ID, "--dummy-weight")
+    ignored = hf_download.call_args.kwargs["ignore_patterns"]
+    assert "*.safetensors" in ignored
+    assert "*.gguf" in ignored
+
+
+def test_modelscope_source_still_uses_modelscope(monkeypatch):
+    """The isdir check moved out of the modelscope branch; it must still short-circuit."""
+    fake = types.ModuleType("modelscope")
+    calls = []
+    fake.snapshot_download = lambda repo, **kw: calls.append((repo, kw)) or SNAPSHOT
+    monkeypatch.setitem(sys.modules, "modelscope", fake)
+
+    with patch("freetoken.utils.hf.snapshot_download") as hf:
+        assert _parse(REPO_ID, "--model-source", "modelscope").model_path == SNAPSHOT
+        hf.assert_not_called()
+    assert calls[0][0] == REPO_ID


### PR DESCRIPTION
## The problem

`ft serve --model deepseek-ai/DeepSeek-V4-Flash-0731` fails:

```
FileNotFoundError: No DeepSeek-V4 ModelArgs JSON found under
deepseek-ai/DeepSeek-V4-Flash-0731 (looked for inference/config.json)
```

The string is treated as a local directory. ModelScope ids already resolve; Hugging Face ids do not.

## What this changes

`download_hf_checkpoint` resolves a Hugging Face repo id to a local snapshot directory, downloading through the normal cache if it is not already there. Weight files that the loaders never read are skipped.

A repo id is only recognised when it looks like one. `looks_like_hub_repo_id` requires the `owner/name` shape, and anything that names an existing path is left alone.

## Why the guard matters

My first version sent every `--model` value that was not an existing directory to the Hub. That broke 28 tests in `tests/server`, because they pass names that are neither paths nor repo ids. The regex is what keeps a typo in a local path reporting a missing path instead of a failed download.

## Testing

`tests/server/test_model_path_resolution.py` covers repo ids, local paths, paths that do not exist, and strings that resemble neither.

`tests/server` on `main` with this PR: 540 passed.
