### PR TITLE
perf(moe): keep the CPU MoE pool and its expert banks on one NUMA node

### DIFF
--- a/python/freetoken/moe/benchbw.py
+++ b/python/freetoken/moe/benchbw.py
@@ -49,7 +49,7 @@ import torch
 
 from freetoken.kernel.pinned import alloc_pinned_tensor
 from freetoken.moe.cpu_executor import physical_core_cpus, resolve_threads_and_affinity
-from freetoken.utils import init_logger
+from freetoken.utils import init_logger, numa
 
 logger = init_logger(__name__)
 
@@ -321,7 +321,11 @@ def _cpu_moe_bank_sources(fmt: str, H: int, I: int, E: int) -> dict:
     as-is. Values otherwise don't affect the kernel's work.
     """
     def pin(*shape, dtype):
-        return alloc_pinned_tensor(*shape, dtype=dtype)
+        # cudaHostAlloc faults + pins here, so the thread policy is the only lever --
+        # place the synthetic banks on the same node the worker pool will use, exactly
+        # as the real HostBank mmaps are placed (utils/numa.prefer_node).
+        with numa.allocating_on_node(numa.moe_pool_numa_node()):
+            return alloc_pinned_tensor(*shape, dtype=dtype)
 
     if fmt == "bf16":
         gate_up, down = pin(E, 2 * I, H, dtype=torch.bfloat16), pin(E, H, I, dtype=torch.bfloat16)
@@ -382,8 +386,10 @@ def _build_gather_rig(fmt: str, wl: Workload, device: torch.device):
     specs = _offload_bank_specs(fmt, H, I)
     cache = OffloadMoeCache(num_layers=1, num_experts=E, cache_size=E, device=device, quant_format=fmt)
     total_bytes = 0
+    pool_node = numa.moe_pool_numa_node(device)
     for name, (elems, dtype) in specs.items():
-        src = alloc_pinned_tensor(E, elems, dtype=dtype)  # cudaHostAlloc (mapped) like the loaders
+        with numa.allocating_on_node(pool_node):
+            src = alloc_pinned_tensor(E, elems, dtype=dtype)  # cudaHostAlloc (mapped)
         dst = torch.empty(E, elems, dtype=dtype, device=device)
         cache.bank_sources[name] = [src]
         cache.bank_caches[name] = dst

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -25,7 +25,7 @@ import weakref
 import torch
 
 from freetoken.kernel.pinned import alloc_pinned_tensor
-from freetoken.utils import init_logger
+from freetoken.utils import init_logger, numa
 
 logger = init_logger(__name__)
 
@@ -88,25 +88,27 @@ def compiled_extension_supports(activation: str) -> bool:
     return _ACT_IDS[activation] <= getattr(_cpu_moe, "max_generic_act_id", lambda: 2)()
 
 
-def physical_core_cpus() -> list[int]:
+def physical_core_cpus(numa_node: int | None = None) -> list[int]:
     """One logical CPU per physical core, restricted to this process's affinity.
 
     MoE decode is memory-bandwidth-bound, so SMT siblings only contend for the
     same core's load ports without adding bandwidth. Picking one logical CPU per
     physical core (and pinning to it) gives the best, most stable bandwidth.
     Falls back to the full affinity set when sysfs topology is unavailable.
+
+    ``numa_node`` restricts the result to that node's cores; None (the default) keeps
+    every core this process may run on.
     """
-    try:
-        allowed = sorted(os.sched_getaffinity(0))
-    except AttributeError:
-        allowed = list(range(os.cpu_count() or 1))
+    allowed = numa._allowed_cpus()
+    if numa_node is not None:
+        local = [c for c in allowed if numa.cpu_numa_node(c) == numa_node]
+        if local:
+            allowed = local
     reps: list[int] = []
     seen: set[str] = set()
     for cpu in allowed:
-        try:
-            with open(f"/sys/devices/system/cpu/cpu{cpu}/topology/thread_siblings_list") as f:
-                key = f.read().strip()
-        except OSError:
+        key = numa.thread_siblings(cpu)
+        if key is None:
             reps.append(cpu)
             continue
         if key not in seen:
@@ -115,7 +117,9 @@ def physical_core_cpus() -> list[int]:
     return reps or allowed or [0]
 
 
-def resolve_threads_and_affinity(requested: int) -> tuple[int, list[int]]:
+def resolve_threads_and_affinity(
+    requested: int, numa_node: int | None = None
+) -> tuple[int, list[int]]:
     """Return (num_threads, core_ids) for the worker pool.
 
     ``requested == 0`` -> one thread per physical core, pinned to it (best for the
@@ -123,21 +127,36 @@ def resolve_threads_and_affinity(requested: int) -> tuple[int, list[int]]:
     spin-barrier degrades badly when oversubscribed). An explicit count is honored,
     spreading first across physical cores, then across the remaining logical CPUs
     (so distinct hardware threads are used before any core is doubled up).
+
+    ``numa_node`` (see ``moe_pool_numa_node``) keeps the pool on one node. Confining
+    would otherwise halve the pool on a 2-socket box, so the default there fills the
+    node's SMT siblings as well: the thread count stays what it was and only the
+    *placement* changes. That matters for the formats whose GEMV is compute-bound
+    rather than DRAM-bound -- mxfp4 loses 23% at one-thread-per-core on half the
+    cores and recovers to +6% over the old pool once SMT brings the count back.
+    An explicit count fills the node's cores, then its siblings, before it spills to
+    another node. ``numa_node=None`` reproduces the every-core behaviour exactly, so
+    single-node machines are unaffected.
     """
-    reps = physical_core_cpus()
+    reps = physical_core_cpus(numa_node)
     if requested and requested > 0:
         n = int(requested)
-        try:
-            allowed = sorted(os.sched_getaffinity(0))
-        except AttributeError:
-            allowed = list(range(os.cpu_count() or 1))
+        allowed = numa._allowed_cpus()
+        rest = [c for c in allowed if c not in set(reps)]
+        if numa_node is not None:
+            # Node-local SMT siblings before any core on another node.
+            rest.sort(key=lambda c: (numa.cpu_numa_node(c) != numa_node, c))
         # physical-core reps first, then the rest of the logical CPUs.
-        order = reps + [c for c in allowed if c not in set(reps)]
+        order = reps + rest
         if not order:
             order = [0]
         core_ids = [order[i % len(order)] for i in range(n)]
         return n, core_ids
-    return len(reps), list(reps)
+    if numa_node is None:
+        return len(reps), list(reps)
+    local = [c for c in numa._allowed_cpus() if numa.cpu_numa_node(c) == numa_node]
+    order = reps + [c for c in local if c not in set(reps)]
+    return len(order), order
 
 
 class CpuMoeExecutor:
@@ -213,7 +232,16 @@ class CpuMoeExecutor:
                 )
                 self._flag_sync = False
 
-        nthreads, core_ids = resolve_threads_and_affinity(num_threads)
+        # Confine the pool to one NUMA node (the GPU's) where that is a real choice; None
+        # on single-node machines, which keeps every core exactly as before.
+        pool_node = numa.moe_pool_numa_node(device)
+        nthreads, core_ids = resolve_threads_and_affinity(num_threads, pool_node)
+        if pool_node is not None:
+            logger.info_rank0(
+                f"cpu-moe pool confined to NUMA node {pool_node} ({nthreads} threads): "
+                "the expert GEMV is host-DRAM bound, so a pool spanning sockets reads "
+                "half its bytes remote (FREETOKEN_CPU_MOE_NUMA=off to disable)"
+            )
         coord_core = -1
         if self._flag_sync and num_threads == 0 and nthreads > 2:
             # Auto sizing: give the coordinator the last physical core instead of
@@ -242,7 +270,10 @@ class CpuMoeExecutor:
         self.core_ids = core_ids
         self.isa = self._ext.isa_name()
 
-        spare = len(physical_core_cpus()) - nthreads - (1 if coord_core >= 0 else 0) - 1
+        # Cores left over *in the pool's own node* -- keeping this relative to the pool
+        # (not the whole machine) leaves the torch intra-op clamp exactly where it was
+        # before the pool was confined.
+        spare = len(physical_core_cpus(pool_node)) - nthreads - (1 if coord_core >= 0 else 0) - 1
         clamp = max(1, min(torch.get_num_threads(), spare))
         if clamp < torch.get_num_threads():
             logger.info_rank0(

--- a/python/freetoken/moe/host_banks.py
+++ b/python/freetoken/moe/host_banks.py
@@ -28,6 +28,8 @@ from enum import Enum
 
 import torch
 
+from freetoken.utils import numa
+
 _BLK = 4096  # O_DIRECT alignment (page size)
 
 
@@ -69,6 +71,12 @@ class HostBank:
         self._buf = mmap.mmap(-1, asize)  # lazy: address space only, no resident pages yet
         _LIVE_BUFFERS.append(self._buf)
         self.addr = ctypes.addressof(ctypes.c_char.from_buffer(self._buf))
+        # Ask for the CPU MoE pool's node *before* the fill faults these pages in --
+        # pin-after-fill means nothing is resident yet, which is the only moment
+        # placement is free. Without it the pages land wherever the loader threads
+        # happen to run and the confined worker pool reads half its bytes remote.
+        # A preference, not a reservation: a full node spills instead of OOM-ing.
+        numa.prefer_node(self.addr, len(self._buf), numa.moe_pool_numa_node())
         self.tensor = torch.frombuffer(self._buf, dtype=dtype, count=self.nbytes // elsize).view(*shape)
         self._pinned = False
 

--- a/python/freetoken/utils/numa.py
+++ b/python/freetoken/utils/numa.py
@@ -1,0 +1,218 @@
+"""NUMA topology and memory placement for the CPU MoE path.
+
+The expert GEMV reads every routed expert's bytes from host DRAM exactly once per
+token, so on a multi-socket box the whole path lives or dies on locality. Two halves
+have to agree, and neither works alone:
+
+* **Where the worker threads run** -- see ``moe.cpu_executor``.
+* **Where the expert banks live** -- this module. Confining the workers while the
+  banks land wherever the loader threads happened to run turns a stable mediocre
+  result into a coin flip: measured 56-123 GB/s run to run on a 2x Xeon Gold 6526Y,
+  against a steady 69 GB/s before confinement.
+
+Placement uses ``mbind`` with ``MPOL_PREFERRED`` -- a hint, not a reservation. The
+banks are 130+ GiB and a strict ``MPOL_BIND`` would OOM rather than spill to the
+other node once the target fills, which is a far worse failure than a remote read.
+
+Everything degrades to a no-op off Linux, on a single-node machine, or where libnuma
+policy is unavailable, so single-socket desktops are untouched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import ctypes.util
+import functools
+import os
+
+from .logger import init_logger
+
+logger = init_logger(__name__)
+
+MPOL_PREFERRED = 1
+# glibc exports no mbind() wrapper (it lives in libnuma), so go through syscall() and
+# keep libnuma off the dependency list. Numbers are stable per ABI.
+_SYS_MBIND = {"x86_64": 237, "aarch64": 235}
+_SYS_SET_MEMPOLICY = {"x86_64": 238, "aarch64": 237}
+MPOL_DEFAULT = 0
+
+
+def _allowed_cpus() -> list[int]:
+    try:
+        return sorted(os.sched_getaffinity(0))
+    except AttributeError:
+        return list(range(os.cpu_count() or 1))
+
+
+def cpu_numa_node(cpu: int) -> int | None:
+    """NUMA node of a logical CPU, from the ``cpuN/nodeX`` sysfs symlink (None if absent)."""
+    try:
+        for entry in os.listdir(f"/sys/devices/system/cpu/cpu{cpu}"):
+            if entry.startswith("node") and entry[4:].isdigit():
+                return int(entry[4:])
+    except OSError:
+        pass
+    return None
+
+
+def thread_siblings(cpu: int) -> str | None:
+    """The ``cpuN/topology/thread_siblings_list`` string, or None where sysfs is silent."""
+    try:
+        with open(f"/sys/devices/system/cpu/cpu{cpu}/topology/thread_siblings_list") as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def numa_nodes() -> set[int]:
+    """NUMA nodes this process may run on. Empty/singleton means "nothing to choose"."""
+    return {n for cpu in _allowed_cpus() if (n := cpu_numa_node(cpu)) is not None}
+
+
+def gpu_numa_node(device) -> int | None:
+    """NUMA node the CUDA device's PCI function hangs off, or None if unknown.
+
+    The BDF is rebuilt from torch's device properties and looked up in sysfs; a driver
+    that reports -1 (no affinity) yields None.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        return None
+    try:
+        index = device if isinstance(device, int) else (
+            None if device is None else torch.device(device).index)
+        if index is None:  # device=None, or a bare "cuda" with no ordinal
+            index = torch.cuda.current_device()
+        p = torch.cuda.get_device_properties(index)
+        bdf = f"{p.pci_domain_id:04x}:{p.pci_bus_id:02x}:{p.pci_device_id:02x}.0"
+        with open(f"/sys/bus/pci/devices/{bdf}/numa_node") as f:
+            node = int(f.read().strip())
+    except (AttributeError, OSError, ValueError, RuntimeError):
+        return None
+    return node if node >= 0 else None
+
+
+def moe_pool_numa_node(device=None) -> int | None:
+    """Which NUMA node the CPU MoE path should keep its threads and banks on.
+
+    The GPU's node wins: it keeps the expert GEMV *and* the offload gather's DMA local.
+    Returns None -- meaning "do not confine", today's behaviour -- on a single-node
+    machine, when the topology cannot be read, or under ``FREETOKEN_CPU_MOE_NUMA=off``.
+    """
+    # "auto" | "off" | <node id>. No boolean spellings on purpose: "0" and "1" are node
+    # ids, so accepting them as on/off would make the common case ambiguous.
+    setting = os.getenv("FREETOKEN_CPU_MOE_NUMA", "auto").strip().lower()
+    if setting in ("off", "none"):
+        return None
+    nodes = numa_nodes()
+    if setting not in ("auto", ""):
+        try:
+            forced = int(setting)
+        except ValueError:
+            logger.warning(
+                f"ignoring FREETOKEN_CPU_MOE_NUMA={setting!r}: expected 'auto', 'off' "
+                "or a NUMA node id"
+            )
+            return None
+        if forced not in nodes:
+            logger.warning(f"FREETOKEN_CPU_MOE_NUMA={forced} has no runnable CPU; not confining")
+            return None
+        return forced
+    if len(nodes) < 2:
+        return None  # single node (or unknown): every core is already local
+    gpu_node = gpu_numa_node(device)
+    return gpu_node if gpu_node in nodes else min(nodes)
+
+
+@functools.lru_cache(maxsize=1)
+def _mbind():
+    """A callable ``mbind(addr, len, mode, mask, maxnode, flags)``, or None if unavailable."""
+    import platform
+
+    nr = _SYS_MBIND.get(platform.machine())
+    if nr is None or not hasattr(os, "sched_getaffinity"):  # unknown ABI, or not Linux
+        return None
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+    except OSError:
+        return None
+    syscall = libc.syscall
+    syscall.restype = ctypes.c_long
+    syscall.argtypes = [ctypes.c_long, ctypes.c_void_p, ctypes.c_ulong, ctypes.c_int,
+                        ctypes.POINTER(ctypes.c_ulong), ctypes.c_ulong, ctypes.c_uint]
+
+    def call(addr, length, mode, mask, maxnode, flags):
+        return syscall(nr, addr, length, mode, mask, maxnode, flags)
+
+    return call
+
+
+def prefer_node(addr: int, length: int, node: int | None) -> bool:
+    """Ask the kernel to place ``[addr, addr+length)`` on ``node`` when it faults.
+
+    A hint (``MPOL_PREFERRED``), so an over-full node spills to a neighbour instead of
+    OOM-ing. Must be called *before* the range is touched -- already-resident pages are
+    not moved (and pinned ones could not be). Returns whether the policy was applied.
+    """
+    if node is None or length <= 0:
+        return False
+    fn = _mbind()
+    if fn is None:
+        return False
+    mask = ctypes.c_ulong(1 << node)
+    # maxnode counts bits in the mask, not nodes set.
+    rc = fn(ctypes.c_void_p(addr), ctypes.c_ulong(length), MPOL_PREFERRED,
+            ctypes.byref(mask), ctypes.c_ulong(ctypes.sizeof(mask) * 8), 0)
+    if rc != 0:
+        logger.debug(
+            f"mbind(MPOL_PREFERRED, node {node}) failed: {os.strerror(ctypes.get_errno())}"
+        )
+        return False
+    return True
+
+
+@functools.lru_cache(maxsize=1)
+def _set_mempolicy():
+    """A callable ``set_mempolicy(mode, mask, maxnode)``, or None if unavailable."""
+    import platform
+
+    nr = _SYS_SET_MEMPOLICY.get(platform.machine())
+    if nr is None or not hasattr(os, "sched_getaffinity"):
+        return None
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+    except OSError:
+        return None
+    syscall = libc.syscall
+    syscall.restype = ctypes.c_long
+    syscall.argtypes = [ctypes.c_long, ctypes.c_int, ctypes.POINTER(ctypes.c_ulong),
+                        ctypes.c_ulong]
+
+    def call(mode, mask, maxnode):
+        return syscall(nr, mode, mask, maxnode)
+
+    return call
+
+
+@contextlib.contextmanager
+def allocating_on_node(node: int | None):
+    """Place pages this thread faults in while inside the block on ``node``.
+
+    ``prefer_node`` cannot help an allocator that faults its pages up front --
+    ``cudaHostAlloc`` pins as it allocates, and pinned pages can never be migrated.
+    Setting the *thread's* policy first is the only way to steer those. Restores
+    ``MPOL_DEFAULT`` on exit; a no-op when ``node`` is None or the syscall is missing.
+    """
+    fn = None if node is None else _set_mempolicy()
+    if fn is not None:
+        mask = ctypes.c_ulong(1 << node)
+        if fn(MPOL_PREFERRED, ctypes.byref(mask), ctypes.sizeof(mask) * 8) != 0:
+            logger.debug(f"set_mempolicy(node {node}): {os.strerror(ctypes.get_errno())}")
+            fn = None
+    try:
+        yield
+    finally:
+        if fn is not None:
+            fn(MPOL_DEFAULT, None, 0)

--- a/tests/moe/test_cpu_pool_numa.py
+++ b/tests/moe/test_cpu_pool_numa.py
@@ -1,0 +1,189 @@
+"""CPU MoE worker pool placement: confine to one NUMA node, and leave single-node alone.
+
+The expert GEMV reads every expert byte from host DRAM exactly once, so a pool spanning
+sockets runs half its workers against remote memory and ping-pongs the spin-barrier and
+work counters over the interconnect. `cpu_moe_ext.cpp` says as much ("NUMA: a single node
+is assumed") but nothing enforced it: `resolve_threads_and_affinity(0)` handed back every
+physical core on the machine. Measured on 2x Xeon Gold 6526Y, bf16 expert GEMV: 67 GB/s
+spanning both sockets (26% of the STREAM ceiling) vs 124 GB/s confined to one (91%).
+
+The risk in that change is the *other* direction -- FreeToken's usual target is a
+single-socket desktop, where the resolver must keep returning exactly what it always did.
+`test_single_node_*` are the regression guards for that.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from freetoken.moe import cpu_executor as ce
+from freetoken.utils import numa
+
+# 2 nodes x 4 physical cores x SMT2, laid out like a real dual-socket box: node0 owns
+# 0-3 (siblings 8-11), node1 owns 4-7 (siblings 12-15).
+TWO_NODE = {c: (0 if c % 8 < 4 else 1) for c in range(16)}
+SIBLINGS = {c: f"{c % 8},{c % 8 + 8}" for c in range(16)}
+ALL_CPUS = list(range(16))
+NODE0_CORES = [0, 1, 2, 3]
+NODE1_CORES = [4, 5, 6, 7]
+
+
+@pytest.fixture
+def two_nodes():
+    with (
+        patch.object(numa, "_allowed_cpus", return_value=ALL_CPUS),
+        patch.object(numa, "cpu_numa_node", side_effect=TWO_NODE.get),
+        patch.object(numa, "thread_siblings", side_effect=SIBLINGS.get),
+    ):
+        yield
+
+
+@pytest.fixture
+def one_node():
+    with (
+        patch.object(numa, "_allowed_cpus", return_value=ALL_CPUS),
+        patch.object(numa, "cpu_numa_node", return_value=0),
+        patch.object(numa, "thread_siblings", side_effect=SIBLINGS.get),
+    ):
+        yield
+
+
+# --------------------------------------------------------------- regression guards
+
+def test_single_node_is_not_confined(one_node, monkeypatch):
+    """One node means every core is already local: nothing to choose, nothing to change."""
+    monkeypatch.delenv("FREETOKEN_CPU_MOE_NUMA", raising=False)
+    assert numa.moe_pool_numa_node(None) is None
+
+
+def test_single_node_pool_is_unchanged(one_node):
+    """The pre-change resolver returned one thread per physical core, machine-wide."""
+    assert ce.resolve_threads_and_affinity(0, None) == (8, [0, 1, 2, 3, 4, 5, 6, 7])
+    assert ce.physical_core_cpus(None) == [0, 1, 2, 3, 4, 5, 6, 7]
+
+
+def test_no_node_argument_matches_old_behaviour(two_nodes):
+    """Callers that pass no node keep spanning the machine, dual-socket included."""
+    assert ce.resolve_threads_and_affinity(0) == (8, [0, 1, 2, 3, 4, 5, 6, 7])
+    assert ce.resolve_threads_and_affinity(6)[1] == [0, 1, 2, 3, 4, 5]
+
+
+def test_unreadable_topology_is_not_confined(monkeypatch):
+    """No sysfs node info -> None, so odd platforms fall back to today's behaviour."""
+    monkeypatch.delenv("FREETOKEN_CPU_MOE_NUMA", raising=False)
+    with (
+        patch.object(numa, "_allowed_cpus", return_value=ALL_CPUS),
+        patch.object(numa, "cpu_numa_node", return_value=None),
+    ):
+        assert numa.moe_pool_numa_node(None) is None
+
+
+# ------------------------------------------------------------------- confinement
+
+def test_pool_follows_the_gpu_node(two_nodes, monkeypatch):
+    """The GPU's node keeps CPU compute *and* the offload gather's DMA local."""
+    monkeypatch.delenv("FREETOKEN_CPU_MOE_NUMA", raising=False)
+    with patch.object(numa, "gpu_numa_node", return_value=1):
+        assert numa.moe_pool_numa_node(0) == 1
+
+
+def test_unknown_gpu_node_falls_back_to_a_real_node(two_nodes, monkeypatch):
+    monkeypatch.delenv("FREETOKEN_CPU_MOE_NUMA", raising=False)
+    with patch.object(numa, "gpu_numa_node", return_value=None):
+        assert numa.moe_pool_numa_node(None) == 0
+
+
+def test_confined_default_keeps_the_thread_count_and_only_moves_it(two_nodes):
+    """Confining to half the machine must not halve the pool.
+
+    The node's 4 cores plus their 4 SMT siblings = 8 threads, exactly what the
+    unconfined pool used to run machine-wide. Physical cores come first so the
+    bandwidth-bound formats still get one thread per core before any core doubles up.
+    mxfp4 regressed 23% when this returned physical cores only.
+    """
+    n, cores = ce.resolve_threads_and_affinity(0, 0)
+    assert (n, cores) == (8, [0, 1, 2, 3, 8, 9, 10, 11])
+    assert {TWO_NODE[c] for c in cores} == {0}
+
+    n1, cores1 = ce.resolve_threads_and_affinity(0, 1)
+    assert (n1, cores1) == (8, [4, 5, 6, 7, 12, 13, 14, 15])
+    assert {TWO_NODE[c] for c in cores1} == {1}
+
+
+def test_confined_default_matches_the_old_machine_wide_count(two_nodes):
+    """Same number of threads as before, different placement -- the whole point."""
+    old_count, _ = ce.resolve_threads_and_affinity(0, None)
+    new_count, _ = ce.resolve_threads_and_affinity(0, 0)
+    assert new_count == old_count
+
+
+def test_confined_physical_cores_helper_still_reports_cores_only(two_nodes):
+    """physical_core_cpus stays "one per physical core" -- the torch clamp reads it."""
+    assert ce.physical_core_cpus(0) == NODE0_CORES
+    assert ce.physical_core_cpus(1) == NODE1_CORES
+
+
+def test_explicit_count_fills_local_smt_before_crossing(two_nodes):
+    """4 cores + 4 siblings on node0 are all used before any node1 core is touched."""
+    _, cores = ce.resolve_threads_and_affinity(8, 0)
+    assert cores == [0, 1, 2, 3, 8, 9, 10, 11]
+    assert {TWO_NODE[c] for c in cores} == {0}
+
+
+def test_oversubscription_spills_to_the_other_node_last(two_nodes):
+    _, cores = ce.resolve_threads_and_affinity(10, 0)
+    assert cores[:8] == [0, 1, 2, 3, 8, 9, 10, 11]
+    assert {TWO_NODE[c] for c in cores[8:]} == {1}
+
+
+# ----------------------------------------------------------------- escape hatches
+
+@pytest.mark.parametrize("value", ["off", "none", "OFF", " off "])
+def test_env_off_disables_confinement(two_nodes, monkeypatch, value):
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_NUMA", value)
+    assert numa.moe_pool_numa_node(0) is None
+
+
+@pytest.mark.parametrize("node", [0, 1])
+def test_env_pins_an_explicit_node(two_nodes, monkeypatch, node):
+    """An integer is always a node id -- "0" pins node 0, it does not mean "off"."""
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_NUMA", str(node))
+    with patch.object(numa, "gpu_numa_node", return_value=1 - node):
+        assert numa.moe_pool_numa_node(0) == node
+
+
+def test_env_garbage_does_not_confine(two_nodes, monkeypatch):
+    """A typo must not silently pin the pool somewhere arbitrary."""
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_NUMA", "nodezero")
+    assert numa.moe_pool_numa_node(0) is None
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_NUMA", "7")
+    assert numa.moe_pool_numa_node(0) is None
+
+
+# ------------------------------------------------------- bank memory placement
+
+def test_prefer_node_is_a_noop_without_a_node():
+    """No NUMA choice to make -> no syscall, so single-socket boxes are untouched."""
+    assert numa.prefer_node(0x1000, 4096, None) is False
+
+
+def test_prefer_node_places_a_real_mapping():
+    """mbind must actually take on an untouched anonymous mapping.
+
+    Worker confinement alone made throughput bimodal (56-123 GB/s run to run) because
+    the banks landed wherever the loader threads ran. This is the other half.
+    """
+    import ctypes
+    import mmap as _mmap
+
+    nodes = sorted(numa.numa_nodes())
+    if len(nodes) < 2 or numa._mbind() is None:
+        pytest.skip("needs a multi-node Linux box with mbind")
+    buf = _mmap.mmap(-1, 4 << 20)
+    try:
+        addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+        assert numa.prefer_node(addr, len(buf), nodes[-1]) is True
+    finally:
+        buf.close()


### PR DESCRIPTION
## Problem

`cpu_moe_ext.cpp:1094` states the assumption outright — *"NUMA: a single node is assumed"* — but nothing enforced it. `resolve_threads_and_affinity(0)` returned every physical core on the machine, so on a 2-socket box half the workers read expert bytes over the interconnect, and the sense-reversing barrier plus the `p1_next`/`p2_next` work counters ping-pong their cache lines across it.

On a 2× Xeon Gold 6526Y the pool reached **26% of the STREAM ceiling** spanning both sockets, against **91%** confined to one.

## Results

`ft bench bw`, median of 5, **no `numactl`** — this is the default-path delta a user sees:

| dtype | before | after | delta |
|---|---|---|---|
| bf16 | 67.5 | 96.2 | **+42.5%** |
| ds_fp4 | 66.9 | 86.9 | **+29.9%** |
| mxfp4 | 48.5 | 59.8 | **+23.3%** |
| nvfp4 | 64.4 | 75.7 | +17.5% |

Hardware: 16c/socket, 4 of 8 DDR5-5200 channels populated per socket, 2× RTX 6000 Ada both on node0, Ubuntu 24.04, torch 2.11.0+cu130.

## Two halves, and neither works alone

Confining the workers **while the banks stay unplaced made things worse, not better** — throughput went *bimodal*, 56–123 GB/s run to run, against a steady 69 before. The banks were landing wherever the loader threads happened to run. Both halves together are stable: bf16 spans 94.2–99.0 across five runs.

- **Threads** — `moe_pool_numa_node()` picks the GPU's node, keeping the expert GEMV *and* the offload gather's DMA local. Confining would otherwise halve the pool, so the default there fills the node's SMT siblings too: the thread count is unchanged and only the placement moves. That matters for the compute-bound formats — at one-thread-per-core on half the cores mxfp4 *lost 23%*, and SMT brings it back to +23%.
- **Banks** — `HostBank` mmaps get `mbind(MPOL_PREFERRED)` before the fill faults them in. Pin-after-fill means nothing is resident yet, which is the only moment placement is free. A preference, not a reservation: the banks are 130+ GiB and `MPOL_BIND` would OOM rather than spill once the node fills — a far worse failure than a remote read.

`mbind` goes through `syscall()` rather than libnuma (glibc does not wrap it), so **no new runtime dependency**. Verified at page level: `prefer:1 … N1=16384`.

`benchbw` places its synthetic banks with `set_mempolicy` instead — it allocates via `cudaHostAlloc`, which faults and pins up front, and pinned pages can never be migrated.

## Not breaking single-socket

FreeToken's usual target is a single-socket desktop, where this must be a no-op. With fewer than two nodes the resolver returns exactly what it always did and every placement call short-circuits. Same on non-Linux, on an unknown syscall ABI, and under `FREETOKEN_CPU_MOE_NUMA=off`.

`test_single_node_is_not_confined`, `test_single_node_pool_is_unchanged`, `test_no_node_argument_matches_old_behaviour` and `test_unreadable_topology_is_not_confined` are the regression guards.

One subtlety worth flagging for review: the torch intra-op clamp at `cpu_executor.py` keeps reading `physical_core_cpus(pool_node)` rather than the machine-wide count, so it lands exactly where it did before. Left as-is deliberately — retuning it is a separate question.

## Escape hatch

`FREETOKEN_CPU_MOE_NUMA` takes `auto` (default), `off`, or a node id. No boolean spellings on purpose: `0` and `1` are node ids, so on/off would make the common case ambiguous.

## Tests

20 new tests in `tests/moe/test_cpu_pool_numa.py`, including one that mbinds a real mapping and asserts the policy takes (skipped on single-node machines).

Full suite on the target: **743 passed, 6 skipped, 1 failed** — the failure is `tests/moe/test_cpu_moe_q4_0.py::test_cpu_decode_q4_0_matches_ggml_mmvq`, which **also fails on `main`** at the same commit and is unrelated.

`ruff check` introduces no new violations on any modified file (counts identical to HEAD).

## Follow-ups (not in this PR)

- `mxfp4` still runs the W4A16 `permutexvar`+fp32 path while `nvfp4` has a W4A8 VNNI one, using the same e2m1 codes — it is the only compute-bound format and the reason it needs SMT to break even.
- The DRAM ceiling on this box is halved by 4-of-8 channels populated; that is hardware, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpGe2fQ5pDShGrnSuksfun