### PR TITLE
build(deps): make the torch CUDA build a uv group choice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,38 @@ accel = ["freetoken[fi,sgl]"]
 # indexes serve. `explicit = true` scopes each index to the one package that needs it
 # (the torch index also mirrors stale copies of common deps, e.g. packaging<=24.1,
 # which would otherwise shadow PyPI under uv's first-index strategy).
+#
+# Which CUDA build of torch to pin is a *group* choice. cu130 is the default, so a plain
+# `uv sync` resolves exactly as it did before this was split out. CUDA 13 dropped Maxwell,
+# Pascal and Volta, so its wheels carry no cubin below sm_75 and simply cannot run on those
+# cards; the cu126 build still ships sm_50/60/70/75/80/86/90, and its sm_60 cubin runs on
+# sm_61 under CUDA's minor-version binary compatibility guarantee. For a pre-Turing GPU:
+#
+#     uv sync --no-default-groups --group cu126
+#
+# The groups are declared conflicting, so the two can never resolve into one environment.
+[dependency-groups]
+cu130 = ["torch>=2.11,<2.12"]
+cu126 = ["torch>=2.11,<2.12"]
+
+[tool.uv]
+default-groups = ["cu130"]
+conflicts = [[{ group = "cu126" }, { group = "cu130" }]]
+
 [tool.uv.sources]
-torch = { index = "pytorch-cu130" }
+torch = [
+    { index = "pytorch-cu126", group = "cu126" },
+    { index = "pytorch-cu130", group = "cu130" },
+]
+# No cu126 counterpart on purpose: sglang-kernel publishes cu130 wheels only, and its AOT
+# kernels are sm_75+ regardless, so a pre-Turing install leaves the `sgl` extra off and
+# falls back to the pure-triton kernels. Same for flashinfer's `fi` extra (cu13 cubins).
 sglang-kernel = { index = "sglang-cu130" }
+
+[[tool.uv.index]]
+name = "pytorch-cu126"
+url = "https://download.pytorch.org/whl/cu126"
+explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cu130"


### PR DESCRIPTION
## The problem

`[tool.uv.sources]` pins torch to the cu130 index unconditionally, so `uv sync` in a checkout can only resolve the CUDA 13 build.

CUDA 13 dropped Maxwell, Pascal and Volta. Its wheels carry no cubin below sm_75. On a pre-Turing card that resolution produces a torch that cannot address the GPU at all.

## What this changes

The CUDA build becomes a group choice. cu130 stays the default, so nothing changes for anyone on supported hardware.

```
uv sync                                    # torch 2.11.0+cu130   (unchanged)
uv sync --no-default-groups --group cu126  # torch 2.11.0+cu126   (pre-Turing)
```

No version constraint moves. `torch 2.11.0+cu126` exists on the pytorch index and already satisfies the `torch>=2.11,<2.12` range. Its arch list is sm_50, 60, 70, 75, 80, 86 and 90, and the sm_60 cubin runs on sm_61 under CUDA's minor-version binary compatibility guarantee.

## Verified against the real dependency set

130 packages resolved. All three paths checked:

```
$ uv export                                     | grep ^torch==
torch==2.11.0+cu130
$ uv export --no-default-groups --group cu126   | grep ^torch==
torch==2.11.0+cu126
$ uv export --group cu126 --group cu130
error: Groups `cu126` and `cu130` are incompatible with the conflicts:
       {`freetoken:cu126`, `freetoken:cu130`}
```

The groups are declared conflicting, so the two can never resolve into one environment. Asking for both is a clean error rather than a silent winner.

## Why groups and not extras

Extras work, but every source entry then has to be disambiguated. uv rejects a list with one bare fallback entry, reporting `Requirements contain conflicting indexes for package torch in all marker environments`.

With extras there is no way to leave cu130 as the unconditional default, so a plain `uv sync` would fall back to PyPI instead of the pinned index. That changes the provenance of torch for every existing user. `default-groups = ["cu130"]` keeps today's behaviour exactly.

## Testing

This changes dependency resolution only, so it has no unit test. The three `uv export` commands above are the check, and they are cheap to re-run.
