### PR TITLE
feat(moe): partial-pin serving to beat the Windows/WSL2 pinned-memory quota (--pin-exempt-layers)

### DIFF
--- a/python/freetoken/engine/config.py
+++ b/python/freetoken/engine/config.py
@@ -48,6 +48,12 @@ class EngineConfig:
     # fraction ("0.5"). None/"" = all layers on GPU (plain offload). --moe-backend cpu
     # already means all layers on CPU and ignores this.
     moe_cpu_layers: str | None = None
+    # Partial-pin serving (--moe-backend offload only): MoE layers whose host banks
+    # are NOT cudaHostRegistered, for platforms whose pin quota cannot cover every
+    # layer (WSL2/WDDM caps at ~50% of physical RAM). Same grammar as
+    # moe_cpu_layers ("48,52", "15", "0.25"); "auto" is reserved (v2). Exempt
+    # layers are unioned into the CPU-decode set and prefill via staged copies.
+    pin_exempt_layers: str | None = None
     # Hybrid MoE backend (--moe-backend hybrid): max experts fetched over PCIe per
     # (layer, decode step); the rest of that step's misses are computed on the CPU.
     # -1 (default) = auto: fetch the benched pcie_bw/cpu_bw fraction of each step's

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -15,6 +15,7 @@ from freetoken.models import create_model, load_weight
 from freetoken.moe import create_moe_backend, is_offload_moe_backend
 from freetoken.moe.expert_banks import load_expert_banks
 from freetoken.moe.offload_cache import OffloadMoeCache, attach_offload_moe_cache
+from freetoken.moe.pin_policy import resolve_pin_exempt_layers
 from freetoken.utils import align_ceil, init_logger, is_sm90_family, is_sm100_family, mem_GB, torch_dtype
 
 from .config import EngineConfig
@@ -512,6 +513,15 @@ class Engine:
         # layout; the GPU slot-cache GEMM reads those same native rows. decode_target also
         # gates the CPU executor build below.
         cpu_layer_ids = _resolve_cpu_layers(config, config.model_config.num_moe_layers)
+        # Partial-pin: exempt layers have no device address, so their decode MUST
+        # run on the CPU executor; union them in rather than making the user pass
+        # two coherent flags. The union also forces decode_target "cpu" below,
+        # which makes the nvfp4 provider keep the CPU-readable native layout.
+        pin_exempt = resolve_pin_exempt_layers(
+            config.pin_exempt_layers, config.model_config.num_moe_layers
+        )
+        if pin_exempt:
+            cpu_layer_ids = frozenset(cpu_layer_ids | pin_exempt)
         if config.moe_backend == "hybrid":
             decode_target = "hybrid"
         elif cpu_layer_ids:
@@ -533,6 +543,7 @@ class Engine:
                 dummy=config.use_dummy_weight,
                 parallel=expert_parallel,
                 decode_target=("cpu" if decode_target in ("cpu", "hybrid") else "gpu"),
+                pin_exempt_layers=pin_exempt,
             )
             if config.moe_cache_auto:
                 size, pages, overlap = self._resolve_auto_moe_cache_size(config, banks)
@@ -565,9 +576,24 @@ class Engine:
                 quant_format=banks.quant_format,
                 decode_target=decode_target,
                 hybrid_max_fetch=config.moe_hybrid_max_fetch,
+                # Known here (unlike the factory branch, which assigns it below):
+                # set_bank_sources validates exempt layers against this set.
+                cpu_layer_ids=cpu_layer_ids,
             )
             cache.set_bank_sources(banks.sources, layer_residency=banks.layer_residency)
             cache.set_alphas(banks.gate_up_alpha, banks.down_alpha)
+            if pin_exempt:
+                layer_bytes = sum(
+                    src[0].numel() * src[0].element_size() for src in banks.sources.values()
+                )
+                pinned = config.model_config.num_moe_layers - len(pin_exempt)
+                logger.info_rank0(
+                    f"partial-pin plan: {pinned}/{config.model_config.num_moe_layers} "
+                    f"layers pinned ({pinned * layer_bytes / 2**30:.1f} GiB), "
+                    f"{len(pin_exempt)} exempt/pageable "
+                    f"({len(pin_exempt) * layer_bytes / 2**30:.1f} GiB, CPU decode + "
+                    f"staged prefill): layers {sorted(pin_exempt)}"
+                )
         else:
             cache = cache_factory(config, self.device)
             cache.decode_target = decode_target
@@ -1078,6 +1104,7 @@ _DENSE_MOE_SETTINGS = {
     "moe_cache_rate": None,
     "moe_cache_auto": False,
     "moe_cpu_layers": None,
+    "pin_exempt_layers": None,
     "moe_cpu_threads": 0,
     "moe_hybrid_max_fetch": -1,
     "moe_prefill_overlap": True,
@@ -1212,13 +1239,18 @@ def _adjust_config(config: EngineConfig):
     if (
         is_moe
         and not _cpu_moe_act_ok
-        and (config.moe_backend in ("cpu", "hybrid") or config.moe_cpu_layers)
-    ):
-        asked = (
-            f"--moe-cpu-layers={config.moe_cpu_layers!r}"
-            if config.moe_backend not in ("cpu", "hybrid")
-            else f"--moe-backend {config.moe_backend!r}"
+        and (
+            config.moe_backend in ("cpu", "hybrid")
+            or config.moe_cpu_layers
+            or config.pin_exempt_layers
         )
+    ):
+        if config.moe_backend in ("cpu", "hybrid"):
+            asked = f"--moe-backend {config.moe_backend!r}"
+        elif config.moe_cpu_layers:
+            asked = f"--moe-cpu-layers={config.moe_cpu_layers!r}"
+        else:
+            asked = f"--pin-exempt-layers={config.pin_exempt_layers!r}"
         raise ValueError(
             f"{asked}: the CPU MoE executor does not support this model's expert "
             f"activation {getattr(model_config, 'hidden_act', None)!r}; drop the flag "
@@ -1346,6 +1378,16 @@ def _adjust_config(config: EngineConfig):
         raise ValueError(
             "--moe-cpu-layers requires --moe-backend offload (got "
             f"{config.moe_backend!r}); use --moe-backend cpu to run all layers on CPU"
+        )
+
+    if is_moe and config.pin_exempt_layers and config.moe_backend != "offload":
+        # Partial-pin rides the offload machinery: exempt layers CPU-decode from the
+        # host banks and prefill through the offload double buffer. 'hybrid' fetches
+        # over PCIe from EVERY layer's banks (device aliases), so it is incompatible
+        # by construction; 'cpu' pins nothing GPU-visible and has no quota problem.
+        raise ValueError(
+            "--pin-exempt-layers requires --moe-backend offload (got "
+            f"{config.moe_backend!r})"
         )
 
     if is_moe:

--- a/python/freetoken/models/minimax_m2/weight.py
+++ b/python/freetoken/models/minimax_m2/weight.py
@@ -93,6 +93,7 @@ def load_nvfp4_expert_sources(
     config,
     *,
     layer_sink=None,
+    pin_exempt_layers: frozenset[int] | None = None,
 ) -> dict[str, torch.Tensor]:
     """CPU NVFP4 expert source banks for the offload cache; see load_nvfp4_expert_source_banks."""
     return load_nvfp4_expert_source_banks(
@@ -102,11 +103,13 @@ def load_nvfp4_expert_sources(
         drop_page_cache=drop_page_cache,
         primary=get_tp_info().is_primary(),
         layer_sink=layer_sink,
+        pin_exempt_layers=pin_exempt_layers,
     )
 
 
 def load_nvfp4_expert_sources_parallel(
-    model_path: str, config, *, workers: int = 8, chunk: int = 8 << 20, layer_sink=None
+    model_path: str, config, *, workers: int = 8, chunk: int = 8 << 20, layer_sink=None,
+    pin_exempt_layers: frozenset[int] | None = None,
 ):
     """parallel: same NVFP4 source banks via the common chunked multi-threaded O_DIRECT reader."""
     from freetoken.models.nvfp4_banks import load_nvfp4_expert_source_banks_parallel
@@ -120,6 +123,7 @@ def load_nvfp4_expert_sources_parallel(
         workers=workers,
         chunk=chunk,
         layer_sink=layer_sink,
+        pin_exempt_layers=pin_exempt_layers,
     )
 
 

--- a/python/freetoken/models/nvfp4_banks.py
+++ b/python/freetoken/models/nvfp4_banks.py
@@ -70,6 +70,7 @@ def load_nvfp4_expert_source_banks(
     drop_page_cache: DropPageCache,
     primary: bool,
     layer_sink=None,
+    pin_exempt_layers: frozenset[int] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Build the 6 native NVFP4 source banks by streaming checkpoint shards (serial per-shard read).
 
@@ -184,9 +185,12 @@ def load_nvfp4_expert_source_banks(
         return placed
 
     if layer_sink is not None:
+        assert not pin_exempt_layers, (
+            "pin_exempt_layers is a serving concept; converters (layer_sink) pin nothing here"
+        )
         placed = _load(layer_sink)
     else:
-        with PinPipeline() as pins:
+        with PinPipeline(exempt=pin_exempt_layers) as pins:
             placed = _load(pins)
 
     expected = num_layers * E * 6
@@ -211,6 +215,7 @@ def load_nvfp4_expert_source_banks_parallel(
     workers: int = 8,
     chunk: int = 8 << 20,
     layer_sink=None,
+    pin_exempt_layers: frozenset[int] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """parallel counterpart of :func:`load_nvfp4_expert_source_banks`, byte-for-byte same
     placement. bulk weight/weight_scale read via chunked multi-threaded O_DIRECT reader
@@ -303,9 +308,12 @@ def load_nvfp4_expert_source_banks_parallel(
         return placed
 
     if layer_sink is not None:
+        assert not pin_exempt_layers, (
+            "pin_exempt_layers is a serving concept; converters (layer_sink) pin nothing here"
+        )
         placed = _load(layer_sink)
     else:
-        with PinPipeline() as pins:
+        with PinPipeline(exempt=pin_exempt_layers) as pins:
             placed = _load(pins)
 
     expected = num_layers * E * 6

--- a/python/freetoken/models/weight.py
+++ b/python/freetoken/models/weight.py
@@ -302,14 +302,31 @@ def load_nvfp4_moe_expert_sources(
     workers: int = 8,
     chunk: int = 8 << 20,
     layer_sink=None,
+    pin_exempt_layers=None,
 ) -> dict:
     """Load (or fabricate, with ``dummy=True``) packed NVFP4 expert source banks.
     ``parallel=True`` uses the model's ``load_nvfp4_expert_sources_parallel`` (common
     chunked multi-threaded O_DIRECT reader). ``layer_sink``: see
     ``models.nvfp4_banks.load_nvfp4_expert_source_banks``; forwarded to the per-model
-    loader, which forwards it on."""
+    loader, which forwards it on. ``pin_exempt_layers`` (partial-pin serving) is
+    forwarded only to loaders that declare it; requesting it from one that does not
+    is an error, not a silent pin-all."""
+    import inspect
+
+    def _forward_exempt(loader, kwargs):
+        if not pin_exempt_layers:
+            return kwargs
+        if "pin_exempt_layers" not in inspect.signature(loader).parameters:
+            raise NotImplementedError(
+                f"{spec.module} expert loader does not support pin_exempt_layers yet"
+            )
+        return {**kwargs, "pin_exempt_layers": pin_exempt_layers}
+
     _config, spec = _spec_for_model_path(model_path)
     if dummy:
+        assert not pin_exempt_layers, (
+            "pin_exempt_layers with --use-dummy-weight is not supported (dummy paths pin-all)"
+        )
         builder = (
             _model_override(spec, "dummy_nvfp4_expert_sources") or dummy_nvfp4_expert_sources
         )
@@ -319,9 +336,13 @@ def load_nvfp4_moe_expert_sources(
         if loader is None:  # no parallel reader -> let the caller fall back to serial
             raise NotImplementedError(
                 f"{spec.module} provides no load_nvfp4_expert_sources_parallel")
-        return loader(model_path, model_config, workers=workers, chunk=chunk, layer_sink=layer_sink)
+        kw = _forward_exempt(
+            loader, dict(workers=workers, chunk=chunk, layer_sink=layer_sink)
+        )
+        return loader(model_path, model_config, **kw)
     loader = _load_attr(spec.module, "load_nvfp4_expert_sources")
-    return loader(model_path, model_config, layer_sink=layer_sink)
+    kw = _forward_exempt(loader, dict(layer_sink=layer_sink))
+    return loader(model_path, model_config, **kw)
 
 
 def load_q4_0_moe_expert_sources(

--- a/python/freetoken/moe/expert_banks.py
+++ b/python/freetoken/moe/expert_banks.py
@@ -60,8 +60,13 @@ def _v4_unsupported(quant):
     )
 
 
-def _bf16_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None) -> ExpertBanks:
+def _bf16_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None, pin_exempt_layers=None) -> ExpertBanks:
     from freetoken.models.weight import load_moe_expert_sources
+
+    if pin_exempt_layers:
+        raise NotImplementedError(
+            "pin_exempt_layers is only implemented for the nvfp4 provider so far"
+        )
 
     # bf16 banks are written as-loaded -> streamable (dummy fabricates in one shot, so a
     # sink given alongside dummy=True would never fire; keep it materialize-only there).
@@ -158,8 +163,16 @@ class _Nvfp4RepackSink:
         return sources, gate_up_alpha, down_alpha
 
 
-def _nvfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None) -> ExpertBanks:
+def _nvfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None, pin_exempt_layers=None) -> ExpertBanks:
     from freetoken.models.weight import load_nvfp4_moe_expert_sources
+
+    if pin_exempt_layers and decode_target != "cpu":
+        # Exempt layers have no device address, so they must decode on the CPU
+        # executor; the engine unions them into cpu_layer_ids, which forces
+        # decode_target "cpu" for this provider. Anything else is a wiring bug.
+        raise NotImplementedError(
+            f"pin_exempt_layers requires CPU-decode native banks; got decode_target={decode_target!r}"
+        )
     from freetoken.moe.nvfp4_backends import (
         b12x_repack_layer,
         b12x_repack_sources_inplace,
@@ -195,14 +208,24 @@ def _nvfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False,
     # parallel only parallelizes the source read; the backend repack below is reused unchanged.
     sources = load_nvfp4_moe_expert_sources(
         model_path, model_config, dummy=dummy, parallel=parallel, workers=workers, chunk=chunk,
-        layer_sink=sink,
+        layer_sink=sink, pin_exempt_layers=pin_exempt_layers,
     )
     # CPU-compute decode (cpu/hybrid) reads the native ModelOpt rows directly (its
     # dequant-in-GEMV kernel), so keep the native "nvfp4" layout and skip the GPU-tiled
     # marlin/b12x repacks (which only the GPU W4A16 kernels can read).
     if decode_target == "cpu":
+        residency = None
+        if pin_exempt_layers:
+            from freetoken.moe.host_banks import HostResidency
+
+            n = len(sources["gate_up_packed"])
+            residency = [
+                HostResidency.PAGEABLE.value if i in pin_exempt_layers
+                else HostResidency.PINNED.value
+                for i in range(n)
+            ]
         return ExpertBanks("nvfp4", {name: sources[name] for name in _BANK_SCHEMAS["nvfp4"]},
-                           streamed=sink is not None)
+                           streamed=sink is not None, layer_residency=residency)
     # Pick the expert-GEMM backend by compute capability (and MoE width: auto keeps
     # small-I MoE on the Triton M=1 GEMV, which beats b12x's tensor cores at single-stream
     # decode) and repack the banks (in place; the tiled blocks are byte-identical per
@@ -230,7 +253,11 @@ def _nvfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False,
     )
 
 
-def _q4_0_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None) -> ExpertBanks:
+def _q4_0_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None, pin_exempt_layers=None) -> ExpertBanks:
+    if pin_exempt_layers:
+        raise NotImplementedError(
+            "pin_exempt_layers is only implemented for the nvfp4 provider so far"
+        )
     if parallel:
         raise NotImplementedError(
             "parallel reader not implemented for q4_0: GGUF is a single packed file "
@@ -250,7 +277,11 @@ def _q4_0_banks(model_path, model_config, device, dtype, dummy, parallel=False, 
     )
 
 
-def _dsfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None) -> ExpertBanks:
+def _dsfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False, workers=8, chunk=_PARALLEL_CHUNK, decode_target="gpu", layer_sink=None, pin_exempt_layers=None) -> ExpertBanks:
+    if pin_exempt_layers:
+        raise NotImplementedError(
+            "pin_exempt_layers is only implemented for the nvfp4 provider so far"
+        )
     args = model_config.dsv4_args
     assert args is not None, "ds_fp4 expert banks require dsv4_args on the model config"
     # DeepSeek-FP4: packed e2m1 + e8m0 per-32 block scales, no global scale -> 4 banks,
@@ -302,13 +333,15 @@ _PROVIDERS = {
 }
 
 
-def _build_expert_banks(model_path, model_config, device, dtype, dummy, parallel, workers, chunk, decode_target="gpu", layer_sink=None) -> ExpertBanks:
+def _build_expert_banks(model_path, model_config, device, dtype, dummy, parallel, workers, chunk, decode_target="gpu", layer_sink=None, pin_exempt_layers=None) -> ExpertBanks:
     """Dispatch to the model's setup-override or the per-quant provider. ``parallel=True``
     is the parallel read; a provider that hasn't implemented it raises NotImplementedError (the
     caller falls back to serial). ``decode_target`` lets the cpu backend force CPU-readable
     (native, non-GPU-tiled) bank layouts. ``layer_sink`` (converter only) is forwarded to
     setups/providers that declare the parameter; the rest ignore it and stay on the
-    materialize-and-write path (``ExpertBanks.streamed`` reports which happened)."""
+    materialize-and-write path (``ExpertBanks.streamed`` reports which happened).
+    ``pin_exempt_layers`` (partial-pin serving) is forwarded only to setups/providers
+    that implement it; anything else refuses loudly rather than silently pinning all."""
     setup = _model_setup_override(model_config)
     if setup is not None:
         import inspect
@@ -321,6 +354,12 @@ def _build_expert_banks(model_path, model_config, device, dtype, dummy, parallel
                 f"parallel reader not implemented for {arch} (model owns expert setup "
                 "via setup_offload_expert_banks; add a parallel path there)"
             )
+        if pin_exempt_layers and "pin_exempt_layers" not in params:
+            arch = getattr(model_config, "architectures", ["?"])[0]
+            raise NotImplementedError(
+                f"pin_exempt_layers not implemented for {arch} (model owns expert setup "
+                "via setup_offload_expert_banks; add plan-aware pinning there)"
+            )
         kw = dict(device=device, dtype=dtype, dummy=dummy)
         if supports_parallel:
             kw.update(parallel=parallel, workers=workers, chunk=chunk)
@@ -328,6 +367,8 @@ def _build_expert_banks(model_path, model_config, device, dtype, dummy, parallel
             kw["decode_target"] = decode_target
         if "layer_sink" in params and layer_sink is not None:
             kw["layer_sink"] = layer_sink
+        if pin_exempt_layers:
+            kw["pin_exempt_layers"] = pin_exempt_layers
         return setup(model_path, model_config, **kw)
 
     expert_quant = model_config.expert_quant
@@ -339,7 +380,7 @@ def _build_expert_banks(model_path, model_config, device, dtype, dummy, parallel
     return _PROVIDERS[expert_quant](
         model_path, model_config, device, dtype, dummy,
         parallel=parallel, workers=workers, chunk=chunk, decode_target=decode_target,
-        layer_sink=layer_sink,
+        layer_sink=layer_sink, pin_exempt_layers=pin_exempt_layers,
     )
 
 
@@ -383,6 +424,7 @@ def load_expert_banks(
     chunk: int = _PARALLEL_CHUNK,
     decode_target: str = "gpu",
     layer_sink=None,
+    pin_exempt_layers: frozenset[int] | None = None,
 ) -> ExpertBanks:
     """Load (or fabricate, with ``dummy=True``) the expert banks. Two paths, both returning
     the same normalized ``ExpertBanks`` and both pinning after fill:
@@ -404,6 +446,11 @@ def load_expert_banks(
     from freetoken.checkpoint.ftw import is_ftw_checkpoint, load_ftw_banks
 
     if model_path and is_ftw_checkpoint(model_path) and not dummy:
+        if pin_exempt_layers:
+            raise NotImplementedError(
+                "pin_exempt_layers is not implemented for FTW checkpoints (their loader "
+                "pins internally); serve the original checkpoint instead"
+            )
         banks = load_ftw_banks(
             model_path, num_layers=model_config.num_moe_layers, workers=workers, chunk=chunk
         )
@@ -434,10 +481,10 @@ def load_expert_banks(
     # allocation) falls back to serial.
     try:
         return _build_expert_banks(model_path, model_config, device, dtype, dummy, parallel, workers, chunk,
-                                   decode_target, layer_sink)
+                                   decode_target, layer_sink, pin_exempt_layers)
     except NotImplementedError as exc:
         if not parallel:
             raise
         logger.warning_rank0(f"parallel reader unavailable ({exc}); falling back to serial build")
         return _build_expert_banks(model_path, model_config, device, dtype, dummy, False, workers, chunk,
-                                   decode_target, layer_sink)
+                                   decode_target, layer_sink, pin_exempt_layers)

--- a/python/freetoken/moe/host_banks.py
+++ b/python/freetoken/moe/host_banks.py
@@ -145,9 +145,16 @@ class PinPipeline:
     ~max(read, pin) instead of their sum. Use as a context manager: a clean exit
     drains the queue and re-raises the first pin failure; an exceptional exit
     still joins the thread but lets the original exception propagate.
+
+    ``exempt``: bank-layer ids whose banks are NOT pinned (partial-pin serving
+    on pin-quota platforms, e.g. Windows/WDDM). Exempt layers' banks stay
+    ``PAGEABLE``; they must be decoded by the CPU executor and prefilled via
+    the staged (non-DMA) copy path. Only the per-layer ``__call__`` sink
+    honors the plan; direct ``submit()`` has no layer identity and always pins.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, exempt: frozenset[int] | None = None) -> None:
+        self._exempt = exempt or frozenset()
         self._q: queue.SimpleQueue = queue.SimpleQueue()
         self._exc: BaseException | None = None
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -169,7 +176,11 @@ class PinPipeline:
         self._q.put(bank)
 
     def __call__(self, layer_id: int, banks: dict[str, HostBank]) -> None:
-        """Layer-completion sink: queue every bank of the completed layer."""
+        """Layer-completion sink: queue every bank of the completed layer.
+
+        Exempt layers are skipped entirely: their banks stay PAGEABLE."""
+        if layer_id in self._exempt:
+            return
         for bank in banks.values():
             self.submit(bank)
 

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -123,6 +123,12 @@ class OffloadMoeCache:
     # pcie_bw / cpu_bw ratio so the PCIe fetch and the CPU overflow GEMV take equal
     # time (perfect overlap): fetched : cpu = pcie : cpu - pcie.
     hybrid_fetch_fraction: float = 0.0
+    # MoE layer ids whose decode runs on the CPU executor; the rest use the GPU
+    # offload/PCIe path (empty = all-GPU, all layers = the plain --moe-backend cpu
+    # case). Passed at construction when known (partial-pin validation in
+    # set_bank_sources needs it); the engine may also (re)assign it afterwards for
+    # the custom-cache-factory path.
+    cpu_layer_ids: frozenset = frozenset()
 
     def __post_init__(self) -> None:
         policy_ids = {"lru": 0}
@@ -132,10 +138,9 @@ class OffloadMoeCache:
         # Attached by the engine for decode_target == "cpu" (CpuMoeExecutor); None
         # for the GPU decode path.
         self.cpu_executor = None
-        # MoE layer ids whose decode runs on the CPU executor; the rest use the GPU
-        # offload/PCIe path. Set by the engine after construction (empty = all-GPU,
-        # all layers = the plain --moe-backend cpu case).
-        self.cpu_layer_ids: frozenset = frozenset()
+        # Non-pinned bank layers (partial-pin serving); set by set_bank_sources
+        # from layer_residency. Empty until banks are registered.
+        self._exempt_layers: frozenset = frozenset()
         # num_experts floor + nvfp4_marlin slot cap, shared with the runtime-rebuild path.
         self.validate_rebuild(self.cache_size)
         assert not self.prefill_overlap or self.cache_size >= 2 * self.num_experts, (
@@ -277,8 +282,10 @@ class OffloadMoeCache:
 
         ``layer_residency`` labels each layer with a ``HostResidency`` value
         (default: all pinned). Non-pinned layers have no device address, so the
-        GPU movement paths cannot serve them and they are rejected here
-        (platform-specific residency policies are not implemented).
+        GPU movement paths cannot serve them; they are legal only under
+        partial-pin serving: their decode must run on the CPU executor (the
+        layer is in ``cpu_layer_ids``) and their prefill rides the staged
+        legacy full-layer copy, which requires the overlap double buffer.
         """
         from freetoken.moe.host_banks import HostResidency
 
@@ -288,12 +295,25 @@ class OffloadMoeCache:
         )
         residency = layer_residency or [HostResidency.PINNED.value] * self.num_layers
         assert len(residency) == self.num_layers, (len(residency), self.num_layers)
-        if any(r != HostResidency.PINNED.value for r in residency):
-            raise NotImplementedError(
-                "non-pinned host bank layers need platform-specific movement "
-                "paths that are not implemented; only pinned layers are served"
-            )
+        exempt = frozenset(
+            i for i, r in enumerate(residency) if r != HostResidency.PINNED.value
+        )
+        if exempt:
+            not_cpu = sorted(exempt - self.cpu_layer_ids)
+            if not_cpu:
+                raise ValueError(
+                    f"non-pinned bank layers {not_cpu} are not CPU-decode layers; "
+                    "partial-pin serving requires every exempt layer in cpu_layer_ids "
+                    "(the engine unions --pin-exempt-layers into --moe-cpu-layers)"
+                )
+            if not self.prefill_overlap:
+                raise ValueError(
+                    "non-pinned bank layers require moe_prefill_overlap=True: the "
+                    "staged prefill copy rides the overlap double buffer, and the "
+                    "materialize_layer path is pinned-only"
+                )
         self.layer_residency = list(residency)
+        self._exempt_layers = exempt
         for name in self.bank_schema:
             per_layer = sources[name]
             assert len(per_layer) == self.num_layers, (name, len(per_layer))
@@ -344,6 +364,13 @@ class OffloadMoeCache:
             if feat % 16 != 0 or cache.data_ptr() % 16 != 0:
                 return  # leave fused disabled; copy_missing uses the per-bank path
             for layer_id, source in enumerate(per_layer):
+                if layer_id in self._exempt_layers:
+                    # Non-pinned banks have no device alias to resolve. Decode never
+                    # reads these layers (CPU executor) and hit-D2D prefetch routes
+                    # them to the staged full-layer copy, so a zero placeholder
+                    # keeps the plan layer-indexed without ever being dereferenced.
+                    layer_src_ptrs[layer_id].append(0)
+                    continue
                 # The kernel dereferences these on the GPU, so store each host bank's
                 # device alias (== data_ptr() under UVA identity; differs on
                 # Windows/WDDM).
@@ -604,7 +631,12 @@ class OffloadMoeCache:
             for (per_layer, _), buffer in zip(self.banks, self.prefill_bank_buffers):
                 buffer[buffer_id].copy_(per_layer[layer_id], non_blocking=True)
 
-        if self._prefill_hit_d2d_active:
+        # Exempt (non-pinned) layers cannot ride the hit-D2D split: its batch
+        # memcpy needs the banks' device aliases. They take the legacy full-layer
+        # torch copy below, which the driver stages from pageable memory (slower,
+        # and the enqueuing host thread stalls for the staging, but correct under
+        # the same ready/release event discipline).
+        if self._prefill_hit_d2d_active and layer_id not in self._exempt_layers:
             self._prefetch_split(layer_id, buffer_id)
         elif self.prefill_copy_stream is None:
             copy()
@@ -684,6 +716,10 @@ class OffloadMoeCache:
         from freetoken.kernel.fast_index_copy import fast_index_copy_multi_jit
         from freetoken.moe.offload_kernels import prefill_hit_compact
 
+        assert layer_id not in self._exempt_layers, (
+            f"hit-D2D prefetch reached exempt layer {layer_id}; prefetch_prefill_layer "
+            "must route exempt layers to the staged full-layer copy"
+        )
         E = self.num_experts
         snap = self._prefill_snapshot_np[layer_id]
         hit_mask = snap >= 2 * E
@@ -761,6 +797,10 @@ class OffloadMoeCache:
     def ensure_experts(self, layer_id: int, expert_ids: torch.Tensor) -> None:
         from freetoken.moe.offload_kernels import ensure_experts
 
+        assert layer_id not in self._exempt_layers, (
+            f"GPU decode reached exempt (non-pinned) layer {layer_id}; it must be in "
+            "cpu_layer_ids and decode on the CPU executor"
+        )
         if self.collect_decode_freq:
             # ``expert_ids`` still holds raw expert ids here (the kernel rewrites them to
             # slot ids in place), so snapshot the routing histogram before that happens.
@@ -781,6 +821,10 @@ class OffloadMoeCache:
         miss count (for stats). All device-side / fixed-shape, so it is CUDA-graph safe."""
         from freetoken.moe.offload_kernels import ensure_experts_hybrid
 
+        assert layer_id not in self._exempt_layers, (
+            f"hybrid decode reached exempt (non-pinned) layer {layer_id}; hybrid "
+            "requires all-pinned banks"
+        )
         if self.collect_decode_freq:
             ids = expert_ids.reshape(-1).long()
             self.decode_freq[layer_id].scatter_add_(0, ids, torch.ones_like(ids))
@@ -792,6 +836,11 @@ class OffloadMoeCache:
     def materialize_layer(self, layer_id: int) -> None:
         from freetoken.moe.offload_kernels import materialize_layer
 
+        assert layer_id not in self._exempt_layers, (
+            f"materialize_layer reached exempt (non-pinned) layer {layer_id}; the "
+            "non-overlap prefill path is pinned-only (set_bank_sources enforces "
+            "prefill_overlap for partial-pin serving)"
+        )
         self._pending_src_layer = layer_id
         materialize_layer(self, layer_id)
 

--- a/python/freetoken/moe/pin_policy.py
+++ b/python/freetoken/moe/pin_policy.py
@@ -1,0 +1,75 @@
+"""Pin-exempt layer policy spec parser.
+
+Pure standard library.  No ``torch``, no ``freetoken`` imports.
+This module is importable by argument-parsing code and by tests without
+pulling in the CUDA stack.
+"""
+
+from __future__ import annotations
+
+
+def parse_layer_subset_spec(
+    spec: str, num_moe_layers: int, *, flag: str = "--pin-exempt-layers"
+) -> frozenset[int]:
+    """Parse a layer subset spec.
+
+    Grammar (mirrors ``_parse_cpu_layers_spec``):
+
+    * Contains a comma -> explicit id list, e.g. ``"3,7,11"``.
+    * Contains a dot (no comma) -> fraction in ``[0.0, 1.0]``.
+    * Otherwise -> integer count ``k`` with ``0 <= k <= num_moe_layers``.
+
+    Count and fraction resolve to *k* layers evenly strided across depth via
+    ``frozenset(round(i * num_moe_layers / k) for i in range(k))``.
+    ``k == 0`` yields the empty frozenset.
+    """
+    s = spec.strip()
+    if not s:
+        return frozenset()
+    if "," in s:
+        ids = {int(x) for x in s.split(",") if x.strip()}
+        for i in ids:
+            if not 0 <= i < num_moe_layers:
+                raise ValueError(
+                    f"{flag} id {i} out of range [0, {num_moe_layers})"
+                )
+        return frozenset(ids)
+    if "." in s:
+        frac = float(s)
+        if not 0.0 <= frac <= 1.0:
+            raise ValueError(f"{flag} fraction {frac} must be in [0, 1]")
+        k = round(frac * num_moe_layers)
+    else:
+        k = int(s)
+        if not 0 <= k <= num_moe_layers:
+            raise ValueError(
+                f"{flag} count {k} must be in [0, {num_moe_layers}]"
+            )
+    # k layers spread evenly across depth (frozenset dedups any rounding
+    # collisions; k == 0 yields an empty range, hence an empty set).
+    return frozenset(round(i * num_moe_layers / k) for i in range(k))
+
+
+def resolve_pin_exempt_layers(
+    spec: str | None, num_moe_layers: int
+) -> frozenset[int]:
+    """Return the pin-exempt layer ids for *spec* and *num_moe_layers*.
+
+    * ``None`` or empty/whitespace -> empty frozenset.
+    * The literal ``"auto"`` (case-insensitive, surrounding whitespace
+      ignored) -> raises ``NotImplementedError`` (planned v2: cached
+      pin-quota profile).
+    * Anything else -> delegate to :func:`parse_layer_subset_spec`.
+    """
+    if spec is None:
+        return frozenset()
+    s = spec.strip()
+    if not s:
+        return frozenset()
+    if s.lower() == "auto":
+        raise NotImplementedError(
+            "Auto pin-exempt fit policy is a planned v2 feature "
+            "(cached pin-quota profile). "
+            "Please pass an explicit id list, count, or fraction."
+        )
+    return parse_layer_subset_spec(s, num_moe_layers)

--- a/python/freetoken/server/args.py
+++ b/python/freetoken/server/args.py
@@ -537,6 +537,22 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--pin-exempt-layers",
+        type=str,
+        default=ServerArgs.pin_exempt_layers,
+        help=(
+            "Partial-pin serving with --moe-backend offload: which MoE layers' host "
+            "banks are NOT pinned (cudaHostRegister), so models whose banks exceed "
+            "the platform pin quota (WSL2/WDDM: ~50%% of physical RAM) can still "
+            "serve. Same grammar as --moe-cpu-layers: id list ('48,52'), count "
+            "('15' = evenly strided), or fraction ('0.25'). Exempt layers decode on "
+            "the CPU executor (auto-unioned into --moe-cpu-layers) and prefill via "
+            "driver-staged copies (slower). 'auto' is reserved for the planned "
+            "fit-to-quota policy. Unset = pin everything (upstream behavior)."
+        ),
+    )
+
+    parser.add_argument(
         "--moe-hybrid-max-fetch",
         type=int,
         default=ServerArgs.moe_hybrid_max_fetch,

--- a/tests/moe/test_pin_policy.py
+++ b/tests/moe/test_pin_policy.py
@@ -1,0 +1,66 @@
+"""Tests for pin-exempt layer spec parser (``--pin-exempt-layers``).
+
+CPU-only: exercises ``parse_layer_subset_spec`` / ``resolve_pin_exempt_layers``
+without a GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from freetoken.moe.pin_policy import parse_layer_subset_spec, resolve_pin_exempt_layers
+
+L = 40
+
+
+def test_explicit_list():
+    assert parse_layer_subset_spec("3,7,11", L) == frozenset({3, 7, 11})
+    assert parse_layer_subset_spec("3, 7 ,11,", L) == frozenset({3, 7, 11})
+    assert parse_layer_subset_spec("5,5,5", L) == frozenset({5})
+
+
+def test_count_exact_sets():
+    assert parse_layer_subset_spec("8", L) == frozenset({0, 5, 10, 15, 20, 25, 30, 35})
+    assert parse_layer_subset_spec("1", L) == frozenset({0})
+    assert len(parse_layer_subset_spec(str(L), L)) == L
+    assert parse_layer_subset_spec("0", L) == frozenset()
+
+
+def test_fraction():
+    assert len(parse_layer_subset_spec("0.5", L)) == 20
+    assert len(parse_layer_subset_spec("1.0", L)) == 40
+    assert parse_layer_subset_spec("0.0", L) == frozenset()
+
+
+def test_empty():
+    assert parse_layer_subset_spec("", L) == frozenset()
+    assert parse_layer_subset_spec("   ", L) == frozenset()
+    assert resolve_pin_exempt_layers(None, L) == frozenset()
+
+
+@pytest.mark.parametrize("spec", ["99", "40,1", "-1", "1.5", "abc"])
+def test_out_of_range_raises(spec: str) -> None:
+    with pytest.raises(ValueError):
+        parse_layer_subset_spec(spec, L)
+
+
+def test_error_message_contains_flag_name() -> None:
+    # Default flag name appears in the message
+    with pytest.raises(ValueError, match="--pin-exempt-layers"):
+        parse_layer_subset_spec("99", L)
+    # Custom flag name overrides
+    with pytest.raises(ValueError, match="--moe-cpu-layers"):
+        parse_layer_subset_spec("99", L, flag="--moe-cpu-layers")
+
+
+def test_auto_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        resolve_pin_exempt_layers("auto", L)
+    with pytest.raises(NotImplementedError):
+        resolve_pin_exempt_layers("  AUTO ", L)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/moe/test_residency_propagation.py
+++ b/tests/moe/test_residency_propagation.py
@@ -1,0 +1,140 @@
+"""Tests for OffloadMoeCache.set_bank_sources residency propagation.
+
+Covers the PARTIAL-PIN contract: non-pinned residency is accepted only when
+every non-pinned layer id is in cache.cpu_layer_ids and the cache was built
+with prefill_overlap=True.  Previously (before the partial-pin feature) this
+suite exercised an all-pinned-only contract where every non-pinned class
+raised NotImplementedError.
+
+CPU-only: imports torch and freetoken, runs inside the project venv.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from freetoken.moe.host_banks import HostResidency
+from freetoken.moe.offload_cache import OffloadMoeCache
+
+L, E = 4, 8
+
+
+def _cache() -> OffloadMoeCache:
+    return OffloadMoeCache(
+        num_layers=L,
+        num_experts=E,
+        cache_size=E,
+        device=torch.device("cpu"),
+        quant_format="bf16",
+    )
+
+
+def _sources() -> dict[str, list[torch.Tensor]]:
+    # bf16 bank schema is ("gate_up", "down"); one contiguous [E, ...] tensor
+    # per layer per bank, uniform shape and dtype across layers.
+    return {
+        "gate_up": [torch.zeros(E, 6, 4) for _ in range(L)],
+        "down": [torch.zeros(E, 4, 3) for _ in range(L)],
+    }
+
+
+def test_default_residency_is_all_pinned():
+    """set_bank_sources with no layer_residency succeeds and defaults to all PINNED."""
+    cache = _cache()
+    cache.set_bank_sources(_sources())
+    assert cache.layer_residency == [HostResidency.PINNED.value] * L
+
+
+def test_explicit_all_pinned_accepted():
+    """Passing all-pinned layer_residency is accepted and stored as a copy."""
+    cache = _cache()
+    residency = [HostResidency.PINNED.value] * L
+    cache.set_bank_sources(_sources(), layer_residency=residency)
+    assert cache.layer_residency == residency
+    # Mutating the passed list must not affect the stored copy.
+    residency[0] = "changed"
+    assert cache.layer_residency[0] == HostResidency.PINNED.value
+
+
+def test_pageable_not_cpu_layer_raises():
+    """A PAGEABLE entry whose index is not in cpu_layer_ids raises ValueError."""
+    cache = _cache()  # default: no cpu_layer_ids
+    residency = [HostResidency.PINNED.value] * L
+    residency[1] = HostResidency.PAGEABLE.value
+    with pytest.raises(ValueError, match="are not CPU-decode layers"):
+        cache.set_bank_sources(_sources(), layer_residency=residency)
+
+
+def test_locked_not_cpu_layer_raises():
+    """A LOCKED entry whose index is not in cpu_layer_ids raises ValueError."""
+    cache = _cache()  # default: no cpu_layer_ids
+    residency = [HostResidency.PINNED.value] * L
+    residency[2] = HostResidency.LOCKED.value
+    with pytest.raises(ValueError, match="are not CPU-decode layers"):
+        cache.set_bank_sources(_sources(), layer_residency=residency)
+
+
+def test_pageable_accepted_for_cpu_layer_with_overlap():
+    """PAGEABLE layer in cpu_layer_ids with prefill_overlap=True is accepted."""
+    cache = OffloadMoeCache(
+        num_layers=L,
+        num_experts=E,
+        cache_size=2 * E,
+        device=torch.device("cpu"),
+        quant_format="bf16",
+        prefill_overlap=True,
+        cpu_layer_ids=frozenset({1}),
+    )
+    residency = [HostResidency.PINNED.value] * L
+    residency[1] = HostResidency.PAGEABLE.value
+    cache.set_bank_sources(_sources(), layer_residency=residency)
+    assert cache.layer_residency == residency
+    assert cache._exempt_layers == frozenset({1})
+
+
+def test_pageable_without_overlap_raises():
+    """PAGEABLE layer in cpu_layer_ids but prefill_overlap=False raises ValueError."""
+    cache = OffloadMoeCache(
+        num_layers=L,
+        num_experts=E,
+        cache_size=E,
+        device=torch.device("cpu"),
+        quant_format="bf16",
+        cpu_layer_ids=frozenset({1}),
+    )
+    # prefill_overlap stays False (default for cache_size=E, not 2*E)
+    residency = [HostResidency.PINNED.value] * L
+    residency[1] = HostResidency.PAGEABLE.value
+    with pytest.raises(ValueError, match="prefill_overlap"):
+        cache.set_bank_sources(_sources(), layer_residency=residency)
+
+
+def test_wrong_length_asserts():
+    """A residency list shorter than num_layers raises AssertionError."""
+    cache = _cache()
+    residency = [HostResidency.PINNED.value] * (L - 1)
+    with pytest.raises(AssertionError):
+        cache.set_bank_sources(_sources(), layer_residency=residency)
+
+
+def test_schema_mismatch_asserts():
+    """Sources missing the 'down' bank key raises AssertionError."""
+    cache = _cache()
+    partial = {"gate_up": _sources()["gate_up"]}
+    with pytest.raises(AssertionError):
+        cache.set_bank_sources(partial)
+
+
+def test_expert_banks_residency_defaults_to_none():
+    """ExpertBanks layer_residency is None when omitted from the constructor."""
+    from freetoken.moe.expert_banks import ExpertBanks
+
+    banks = ExpertBanks("bf16", {})
+    assert banks.layer_residency is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
**Problem.** Windows caps cudaHostRegister-able host memory at roughly 50% of physical RAM (WDDM-managed; WSL2 inherits it and NVIDIA marks it not actionable:
see the long-standing threads on the NVIDIA forums, e.g. "Change limit of 50% for cudaHostAlloc pinned memory on Windows 10/11"). FreeToken pins every expert bank, so on any Windows/WSL2 machine the servable-model ceiling is the pin quota, not
RAM. We measured the quota at 94 GiB on a 192 GB box and confirmed it is independent of the WSL VM size (identical at 100 GB and 160 GB .wslconfig). MiniMax-M2.5's ~126 GB of banks cannot load at any setting; the paper's fallback
for unpinnable pools is the all-CPU backend.

**This PR adds the middle path the code already anticipates.** `HostResidency` has PAGEABLE, `ExpertBanks.layer_residency` and `set_bank_sources(..., layer_residency=...)` are already plumbed, and `offload_cache.py` raises NotImplementedError for non-pinned layers. This change implements that stub:

- New `--pin-exempt-layers` (same grammar as `--moe-cpu-layers`: ids, count evenly strided, or fraction). Exempt layers skip pinning at load (the per-layer `PinPipeline` sink honors an exempt set) and are auto-unioned into `cpu_layer_ids`, so their decode uses the existing CPU executor unchanged.
- Prefill for exempt layers uses the legacy full-layer `.copy_()` into the overlap double buffer; from pageable memory the driver stages it (slower, and the enqueuing thread stalls for the staging, but correct under the existing ready/release event discipline). The hit-D2D split prefetch and the fused copy plan skip exempt layers; `set_bank_sources` validates exempt is a subset of `cpu_layer_ids` and that `moe_prefill_overlap` is on.
- v1 scope: the nvfp4 provider path (that is where the >90 GB models live).  bf16/q4_0/ds_fp4 providers, `setup_offload_expert_banks` models, FTW checkpoints, and `--use-dummy-weight` raise NotImplementedError with clear messages rather than silently pinning everything. With the flag unset, behavior is byte-identical to main.

**Numbers** (RTX 5090 32 GB, 192 GB DDR5, Windows 11 + WSL2, MiniMax-M2.5-NVFP4, 229B, 62 MoE layers at 1.90 GiB of banks each): `--pin-exempt-layers 15` pins 47 layers (89.4 GiB, under the 94 GiB quota) and the model serves: READY in
127 s (129 GB expert read at 2.5 GB/s, parallel loader), decode 9.1-9.6 tok/s across context lengths, 28.9k-token prompt TTFT 34.8 s cold / 7.1 s on radix repeat. Without this change the same command dies at cudaHostRegister ~117 s in.

**Tests.** `tests/moe/test_pin_policy.py` (grammar, 11 cases) and `tests/moe/test_residency_propagation.py` (the set_bank_sources contract, 9 cases) run CPU-only. The existing CUDA suites most affected  (test_offload, test_fused_copy, test_prefill_hit_d2d, test_hybrid_fetch: 29 tests) pass unchanged on all-pinned defaults.

**Not in this PR, open to direction:** an `auto` fit-to-quota policy (needs a cached quota measurement; we prototyped a probe and would follow up), a pinned staging ring to restore fully-async prefill for exempt layers, and extending the plan to the other providers. Happy to adjust naming, split the change, or add coverage wherever you want it.