### PR TITLE
fix: preload dense NVFP4 decode kernels before graph capture

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -18,7 +18,7 @@ from freetoken.moe.offload_cache import OffloadMoeCache, attach_offload_moe_cach
 from freetoken.utils import align_ceil, init_logger, is_sm90_family, is_sm100_family, mem_GB, torch_dtype
 
 from .config import EngineConfig
-from .graph import GraphRunner, get_free_memory
+from .graph import GraphRunner, _determine_cuda_graph_bs, get_free_memory
 from .sample import BatchSamplingArgs, Sampler
 from freetoken.kvcache import create_kv_pool, resolve_pool_class
 from freetoken.kvcache.base import CacheRebuildRejected
@@ -329,6 +329,25 @@ class Engine:
         # unlike a query-time mem_get_info it doesn't drift with allocator caching, CUDA
         # graphs, or other processes. Cross-rank MIN, deterministic across ranks.
         self._post_weights_free = post_weights_free
+
+        # Load dense NVFP4 decode modules before MoE/KV/GDN runtime caches take the
+        # remaining VRAM. The graph runner's eager forward is otherwise the first launch.
+        graph_bs = _determine_cuda_graph_bs(
+            config.cuda_graph_bs, config.cuda_graph_max_bs, init_free_memory
+        )
+        if graph_bs:
+            from freetoken.kernel.triton.nvfp4_linear import warmup_nvfp4_dense_decode
+
+            dense_warmup_bs = [1]
+            if max(graph_bs) > 1:
+                dense_warmup_bs.append(max(graph_bs))
+            logger.info_rank0(
+                f"Preloading dense NVFP4 decode kernels for batch sizes {dense_warmup_bs}"
+            )
+            loaded = warmup_nvfp4_dense_decode(self.model, dense_warmup_bs)
+            if loaded:
+                logger.info_rank0(f"Preloaded {loaded} dense NVFP4 kernel geometries")
+                torch.cuda.empty_cache()
         self.moe_offload_cache = None
         self.cpu_moe_executor = None
         if is_offload_moe_backend(config.moe_backend):

--- a/python/freetoken/kernel/triton/nvfp4_linear.py
+++ b/python/freetoken/kernel/triton/nvfp4_linear.py
@@ -930,6 +930,69 @@ class Nvfp4LMHead(BaseOP):
         return nvfp4_dense_linear(x, self.weight, self.weight_scale, self.weight_global)
 
 
+def warmup_nvfp4_dense_decode(model: BaseOP, batch_sizes: list[int]) -> int:
+    """Load dense NVFP4 decode kernels before runtime caches consume remaining VRAM.
+
+    Triton loads a compiled CUDA module on its first launch. On memory-constrained Ada
+    cards, postponing that load until the eager forward immediately before CUDA graph
+    capture can make ``cuModuleLoadData`` take minutes while the GPU reports misleading
+    100% SM utilisation. Run one representative of every distinct resident weight
+    geometry while startup still has its post-weights VRAM headroom.
+    """
+    wanted_m = sorted({m for m in batch_sizes if 0 < m <= _GEMM_MAX_INKERNEL_M})
+    if not wanted_m:
+        return 0
+
+    seen_objects: set[int] = set()
+    representatives: dict[tuple, Nvfp4DenseLinear | Nvfp4LMHead] = {}
+
+    def visit(value) -> None:
+        value_id = id(value)
+        if value_id in seen_objects:
+            return
+        seen_objects.add(value_id)
+        if isinstance(value, (Nvfp4DenseLinear, Nvfp4LMHead)):
+            if not value._transposed:
+                return
+            key = (
+                value.weight.shape,
+                value.weight.stride(),
+                value.weight_scale.shape,
+                value.weight_scale.stride(),
+                value.weight_global.shape,
+                value.weight.dtype,
+                value.weight_scale.dtype,
+            )
+            representatives.setdefault(key, value)
+            return
+        if isinstance(value, BaseOP):
+            for child in value.__dict__.values():
+                visit(child)
+        elif isinstance(value, (list, tuple)):
+            for child in value:
+                visit(child)
+        elif isinstance(value, dict):
+            for child in value.values():
+                visit(child)
+
+    visit(model)
+    launched = 0
+    with torch.inference_mode():
+        for op in representatives.values():
+            in_features = op.weight.shape[0] * 8
+            for m in wanted_m:
+                x = torch.zeros((m, in_features), dtype=torch.bfloat16, device=op.weight.device)
+                y = nvfp4_dense_linear_t(
+                    x, op.weight, op.weight_scale, op.weight_global,
+                    getattr(op, "bias", None),
+                )
+                # Compiling is insufficient: Triton's CUDA module is loaded lazily at launch.
+                torch.cuda.synchronize(op.weight.device)
+                del x, y
+                launched += 1
+    return launched
+
+
 __all__ = [
     "FP8",
     "nvfp4_dense_linear",
@@ -938,4 +1001,5 @@ __all__ = [
     "Nvfp4DenseLinear",
     "Nvfp4DenseColMerged",
     "Nvfp4LMHead",
+    "warmup_nvfp4_dense_decode",
 ]


### PR DESCRIPTION
## Summary

- preload each distinct dense NVFP4 decode kernel geometry immediately after model weights are resident
- force Triton's CUDA modules to load before MoE/KV/GDN runtime caches consume the remaining VRAM
- preserve the existing eager warmup and CUDA graph capture behavior

## Problem

On an RTX 4070 SUPER 12 GB (Ada, SM89), Qwen3.6-35B-A3B-NVFP4 could remain in `Capturing CUDA graphs / warming up` for many minutes. GPU telemetry showed 100% SM utilization but only 0-1% memory-controller utilization and about 54 W.

A native `py-spy` sample located the worker in:

```text
cuModuleLoadData
  Triton loadBinary / _init_handles / run
  freetoken.kernel.triton.nvfp4_linear._gemv
  _linear_impl
  nvfp4_dense_linear_t
  Nvfp4LMHead.forward
  Qwen3_5MoEForCausalLM.forward
  GraphRunner._capture_graphs
```

This is the ordinary eager `model.forward()` before the `torch.cuda.graph(...)` context, not graph capture itself. At that point automatic runtime-cache sizing had reduced free VRAM to roughly 0.7-0.8 GiB. Triton's first-launch module load was therefore occurring at the least favorable point in startup.

The behavior reproduced with both the portable routed-expert backend and vLLM Marlin. Installing vLLM changes the routed MoE implementation, but dense NVFP4 shared experts and the NVFP4 LM head still use FreeToken's Triton kernels.

## Fix

Traverse the `BaseOP` tree after weights load, deduplicate resident `Nvfp4DenseLinear` and `Nvfp4LMHead` operations by weight/scale geometry and strides, then launch representative `M=1` and maximum captured small-batch kernels. Each launch is synchronized so the CUDA module is actually loaded before runtime caches are allocated.

The preload is skipped when CUDA graphs are disabled.

## Validation

Test environment:

- Fedora Linux 44
- NVIDIA RTX 4070 SUPER 12 GB, SM89
- NVIDIA driver 610.43.03
- CUDA toolkit 13.3.73
- Python 3.13.14
- PyTorch 2.11.0+cu130
- Triton 3.6.0
- GCC/G++ 15
- Qwen3.6-35B-A3B-NVFP4
- offloaded MoE with automatic cache sizing
- vLLM 0.14.1 Marlin donor, rebuilt against the active PyTorch/CUDA ABI

With a completely fresh `TRITON_CACHE_DIR` and graph sizes `[1, 2, 4]`:

- six distinct dense NVFP4 kernel geometries preloaded in about 2 seconds
- all three CUDA graphs captured in about 9 seconds
- batch size 1 no longer stalled
- a real OpenAI-compatible chat-completion request completed with HTTP 200
- no NVIDIA Xid errors were present

`git diff --check` and Python AST parsing also pass. The project environment does not currently include pytest, so the existing pytest suite was not run.
