### PR TITLE
feat(cpu-moe): block-FP8 expert GEMV (W8A16) for the cpu/hybrid backends

### DIFF
--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -263,6 +263,134 @@ inline float e4m3_decode(uint8_t v) {
   return sign * (1.0f + man / 8.0f) * std::ldexp(1.0f, (int)exp - 7);
 }
 
+// ------------------------ block-FP8 (W8A16) dequant ------------------------
+// DeepSeek-V3-style block-fp8 experts (Qwen3.5/3.6-FP8, GLM, DSV4 dense): fp8-e4m3
+// weights row-major [rows, K] plus one bf16 scale per 128x128 weight block. The tensor
+// is named ``weight_scale_inv`` but it multiplies; the reference is the Triton decode
+// GEMV (kernel/triton/fp8_blockscale_moe.py):
+//
+//     acc += sum(w * a  over one 128-wide K block) * scale[row/128][kb]
+//
+// K is contiguous per output row -- unlike mxfp4's transposed bank -- so this maps
+// straight onto a bf16 dot product. e4m3 -> bf16 is *exact* (3 mantissa bits into 7,
+// and bf16's exponent range covers e4m3's whole 2^-9..448 span), so the AVX-512 path
+// widens the weights in-register and feeds _mm512_dpbf16_ps against the bf16
+// activations. That reproduces the reference's fp32 products exactly; only the
+// summation order differs, the same latitude the bf16 dot already takes.
+//
+// Bit math for the normal range (exp != 0), from byte b = s<<7 | e<<3 | m:
+//   bf16 = (b & 0x80) << 8  |  (((b & 0x7F) << 4) + (120 << 7))
+// because e4m3 bias 7 -> bf16 bias 127 is a constant +120 on the exponent field once
+// the magnitude is shifted into place. exp == 0 is subnormal (value = m * 2^-9) and
+// does not follow that rule, so those lanes are blended in from a small table.
+using fp8dot_fn = float (*)(const uint8_t*, const bf16_t*, const bf16_t*, int, const float*);
+
+constexpr int FP8_BLK = 128;  // K elements covered by one weight scale
+
+// e4m3 subnormals: m * 2^-9, as bf16 bit patterns (index = mantissa, 0..7).
+alignas(64) const uint16_t kE4M3SubBf16[32] = {
+    0x0000, 0x3B00, 0x3B80, 0x3BC0, 0x3C00, 0x3C20, 0x3C40, 0x3C60,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+// Same values as fp32, for the AVX2 path.
+alignas(32) const float kE4M3SubF32[8] = {
+    0.0f, 1.0f / 512, 2.0f / 512, 3.0f / 512, 4.0f / 512, 5.0f / 512, 6.0f / 512, 7.0f / 512};
+
+float dot_fp8_block_scalar(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                           const float* e4m3) {
+  float acc = 0.0f;
+  for (int b = 0, k0 = 0; k0 < K; ++b, k0 += FP8_BLK) {
+    const int k1 = std::min(K, k0 + FP8_BLK);
+    float blk = 0.0f;
+    for (int k = k0; k < k1; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+
+#if CPU_MOE_X86
+__attribute__((target("avx512f,avx512bw")))
+static inline __m512i e4m3_to_bf16_x32(__m256i raw, __m512i subtab) {
+  const __m512i b = _mm512_cvtepu8_epi16(raw);
+  const __m512i sgn = _mm512_slli_epi16(_mm512_and_si512(b, _mm512_set1_epi16(0x0080)), 8);
+  const __m512i mag = _mm512_and_si512(b, _mm512_set1_epi16(0x007F));
+  const __m512i nrm =
+      _mm512_add_epi16(_mm512_slli_epi16(mag, 4), _mm512_set1_epi16((short)(120 << 7)));
+  const __mmask32 sub = _mm512_cmplt_epu16_mask(mag, _mm512_set1_epi16(8));
+  const __m512i lut = _mm512_permutexvar_epi16(mag, subtab);  // indices wrap; only sub lanes used
+  return _mm512_or_si512(sgn, _mm512_mask_blend_epi16(sub, nrm, lut));
+}
+
+__attribute__((target("avx512bf16,avx512bw,avx512f")))
+static inline __m512bh as_bh(__m512i v) {
+  __m512bh out;
+  std::memcpy(&out, &v, sizeof(out));
+  return out;
+}
+
+__attribute__((target("avx512bf16,avx512bw,avx512f")))
+float dot_fp8_block_avx512bf16(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                               const float* e4m3) {
+  const __m512i subtab = _mm512_loadu_si512(reinterpret_cast<const void*>(kE4M3SubBf16));
+  __m512 total = _mm512_setzero_ps();
+  int b = 0, k0 = 0;
+  for (; k0 + FP8_BLK <= K; k0 += FP8_BLK, ++b) {
+    // The weight stream is the bandwidth bottleneck (read once, never reused).
+    _mm_prefetch(reinterpret_cast<const char*>(w + k0) + PF_AHEAD, _MM_HINT_T0);
+    __m512 blk = _mm512_setzero_ps();
+    for (int j = 0; j < FP8_BLK; j += 32) {
+      const __m256i raw =
+          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w + k0 + j));
+      blk = _mm512_dpbf16_ps(blk, as_bh(e4m3_to_bf16_x32(raw, subtab)),
+                             as_bh(_mm512_loadu_si512(
+                                 reinterpret_cast<const void*>(x + k0 + j))));
+    }
+    total = _mm512_fmadd_ps(blk, _mm512_set1_ps(bf16_to_f32(s[b])), total);
+  }
+  float acc = _mm512_reduce_add_ps(total);
+  if (k0 < K) {  // ragged tail shares block b's scale, as the reference's mask does
+    float blk = 0.0f;
+    for (int k = k0; k < K; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+
+__attribute__((target("avx2,fma")))
+float dot_fp8_block_avx2(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                         const float* e4m3) {
+  const __m256i mag_m = _mm256_set1_epi32(0x7F), sgn_m = _mm256_set1_epi32(0x80);
+  const __m256i bias = _mm256_set1_epi32(120 << 23), eight = _mm256_set1_epi32(8);
+  const __m256 subtab = _mm256_loadu_ps(kE4M3SubF32);
+  float acc = 0.0f;
+  int b = 0, k0 = 0;
+  for (; k0 + FP8_BLK <= K; k0 += FP8_BLK, ++b) {
+    __m256 blk = _mm256_setzero_ps();
+    for (int j = 0; j < FP8_BLK; j += 8) {
+      const __m256i raw = _mm256_cvtepu8_epi32(
+          _mm_loadl_epi64(reinterpret_cast<const __m128i*>(w + k0 + j)));
+      const __m256i mag = _mm256_and_si256(raw, mag_m);
+      const __m256i sgn = _mm256_slli_epi32(_mm256_and_si256(raw, sgn_m), 24);
+      // exp!=0: mantissa/exponent shift into place, bias 7 -> 127 is a constant +120.
+      const __m256i nrm = _mm256_add_epi32(_mm256_slli_epi32(mag, 20), bias);
+      const __m256 sub = _mm256_permutevar8x32_ps(subtab, mag);  // valid where mag < 8
+      const __m256 issub = _mm256_castsi256_ps(_mm256_cmpgt_epi32(eight, mag));
+      const __m256 val = _mm256_blendv_ps(_mm256_castsi256_ps(nrm), sub, issub);
+      const __m256 wf = _mm256_or_ps(val, _mm256_castsi256_ps(sgn));
+      const __m256i xi = _mm256_cvtepu16_epi32(
+          _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + k0 + j)));
+      blk = _mm256_fmadd_ps(wf, _mm256_castsi256_ps(_mm256_slli_epi32(xi, 16)), blk);
+    }
+    acc += hsum256(blk) * bf16_to_f32(s[b]);
+  }
+  if (k0 < K) {
+    float blk = 0.0f;
+    for (int k = k0; k < K; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+#endif  // CPU_MOE_X86
+
 // Activations pre-deinterleaved to fp32 (xe[m]=x[2m], xo[m]=x[2m+1]); see the
 // ds_fp4 dot below for why (drops the hot loop to ~1.5 shuffle ops / 16 weights).
 using nvdot_fn = float (*)(const uint8_t*, const uint8_t*, float, const float*, const float*,
@@ -1009,6 +1137,18 @@ void mxfp4_gemv_avx2(float* out, const uint8_t* blk, const uint8_t* scl, const b
 }
 #endif
 
+fp8dot_fn select_fp8dot() {
+  const IsaTier t = pick_isa();
+#if CPU_MOE_X86
+  // The bf16 tier is the one that matters here: e4m3 widens to bf16 exactly, so
+  // dpbf16_ps does the whole dot with no fp32 materialization of the weights.
+  if (t >= ISA_AVX512BF16) return dot_fp8_block_avx512bf16;
+  if (t >= ISA_AVX2) return dot_fp8_block_avx2;
+#endif
+  (void)t;
+  return dot_fp8_block_scalar;
+}
+
 mxgemv_fn select_mxgemv() {
   const IsaTier t = pick_isa();
 #if CPU_MOE_X86
@@ -1220,7 +1360,8 @@ q4dot_fn select_q4dot() {
   return q4_0_dot_i8_scalar;
 }
 
-enum WFmt { WF_BF16 = 0, WF_NVFP4 = 1, WF_MXFP4 = 2, WF_DSFP4 = 3, WF_Q4_0 = 4 };
+enum WFmt { WF_BF16 = 0, WF_NVFP4 = 1, WF_MXFP4 = 2, WF_DSFP4 = 3, WF_Q4_0 = 4,
+             WF_FP8_BLOCK = 5 };
 
 // Each ctor pointer arg is the address of a CPU int64 array of length
 // num_layers (one base address per layer, built by cpu_executor.py's
@@ -1260,6 +1401,10 @@ struct CpuMoeExecutor {
   dsdot_fn dsdot;
   mxgemv_fn mxgemv;
   q4dot_fn q4dot;
+  fp8dot_fn fp8dot;
+  // fp8_block: bf16 scale per 128x128 weight block, so a row uses (K/128) contiguous
+  // scales starting at scale-row (output row / 128). These are the row strides.
+  int fp8_gu_scale_row = 0, fp8_dn_scale_row = 0;
   // ds_fp4: the caller already FP8-round-tripped the input activations on the GPU
   // (same reference grid), so submit() must not repeat it on the host-callback
   // thread. That scalar per-element pass is single-threaded ON THE DECODE CRITICAL
@@ -1383,6 +1528,12 @@ struct CpuMoeExecutor {
     dsdot = select_dsdot();
     mxgemv = select_mxgemv();
     q4dot = select_q4dot();
+    fp8dot = select_fp8dot();
+    if (weight_format == WF_FP8_BLOCK) {
+      // gate_up scale is [2I/128, H/128], down scale is [H/128, I/128] per expert.
+      fp8_gu_scale_row = (H + FP8_BLK - 1) / FP8_BLK;
+      fp8_dn_scale_row = (I + FP8_BLK - 1) / FP8_BLK;
+    }
     if (weight_format == WF_Q4_0) {
       if (H % 32 != 0 || I % 32 != 0)
         throw std::runtime_error("Q4_0 CPU MoE requires H and I to be multiples of 32");
@@ -1494,6 +1645,13 @@ struct CpuMoeExecutor {
           gu_packed_l + ((size_t)e * (2 * I) + row) * (size_t)q4_gu_row_bytes;
       return q4dot(w, xi8, xas, H);  // W4A8: int8 activations (Q8_0), scale in xas
     }
+    if (fmt == WF_FP8_BLOCK) {
+      const uint8_t* w = gu_packed_l + ((size_t)e * (2 * I) + row) * (size_t)H;
+      const bf16_t* sc = reinterpret_cast<const bf16_t*>(gu_scale_l) +
+                         ((size_t)e * ((2 * I + FP8_BLK - 1) / FP8_BLK) + row / FP8_BLK) *
+                             (size_t)fp8_gu_scale_row;
+      return fp8dot(w, x, sc, H, e4m3_lut);
+    }
     const size_t r = (size_t)e * (2 * I) + row;
     if (use_vnni)
       return nvi8dot(gu_packed_l + r * (size_t)(H / 2), gu_scale_l + r * (size_t)(H / 16),
@@ -1515,6 +1673,13 @@ struct CpuMoeExecutor {
     if (fmt == WF_Q4_0) {
       const uint8_t* w = dn_packed_l + ((size_t)e * H + row) * (size_t)q4_dn_row_bytes;
       return q4dot(w, gi8, gas, I);  // W4A8: int8 activations (Q8_0), scale in gas
+    }
+    if (fmt == WF_FP8_BLOCK) {
+      const uint8_t* w = dn_packed_l + ((size_t)e * H + row) * (size_t)I;
+      const bf16_t* sc = reinterpret_cast<const bf16_t*>(dn_scale_l) +
+                         ((size_t)e * ((H + FP8_BLK - 1) / FP8_BLK) + row / FP8_BLK) *
+                             (size_t)fp8_dn_scale_row;
+      return fp8dot(w, g, sc, I, e4m3_lut);
     }
     const size_t r = (size_t)e * H + row;
     if (use_vnni)
@@ -2157,4 +2322,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // (act_apply falls through to gelu_tanh); the probe turns a stale extension
   // into a loud rebuild instruction instead of wrong model outputs.
   m.def("max_generic_act_id", []() { return static_cast<int>(ACT_SWIGLU_CLAMP); });
+  // Weight-format ABI probe. A stale prebuilt .so accepts a newer WFmt id without
+  // complaint and then falls through to the wrong dequant branch -- silently wrong
+  // numbers, not a crash. The Python executor refuses to build against an extension
+  // that predates the format it was asked for.
+  m.def("max_weight_format_id", []() { return static_cast<int>(WF_FP8_BLOCK); });
 }

--- a/python/freetoken/moe/benchbw.py
+++ b/python/freetoken/moe/benchbw.py
@@ -63,7 +63,7 @@ logger = init_logger(__name__)
 
 # Formats the CPU MoE C++ kernel can compute AND this bench can build banks for; anything
 # else is offload-only here. (The kernel also does q4_0, but this bench has no q4_0 banks.)
-_CPU_MOE_FORMATS = frozenset({"bf16", "nvfp4", "mxfp4_triton", "ds_fp4"})
+_CPU_MOE_FORMATS = frozenset({"bf16", "nvfp4", "mxfp4_triton", "ds_fp4", "fp8_block"})
 # Formats this bench can build synthetic (correctly-sized) banks for.
 _BUILDABLE_FORMATS = frozenset({"bf16", "nvfp4", "fp8_block", "mxfp4_triton", "ds_fp4"})
 # Friendlier CLI/display aliases for the internal quant_format strings.
@@ -340,6 +340,22 @@ def _cpu_moe_bank_sources(fmt: str, H: int, I: int, E: int) -> dict:
         gate_up.fill_(0.02)  # uninitialized bf16 can be denormal -> x86 FP slowdown
         down.fill_(0.02)
         return {"gate_up": gate_up, "down": down}
+    if fmt == "fp8_block":
+        def nb(n):
+            return (n + 127) // 128
+        b = {
+            "gate_up": pin(E, 2 * I, H, dtype=torch.float8_e4m3fn),
+            "gate_up_scale": pin(E, nb(2 * I), nb(H), dtype=torch.bfloat16),
+            "down": pin(E, H, I, dtype=torch.float8_e4m3fn),
+            "down_scale": pin(E, nb(H), nb(I), dtype=torch.bfloat16),
+        }
+        # e4m3 0x00 is a clean zero and the scales are unit-ish, so nothing lands in
+        # the fp32 denormal range (which would slow the GEMV and skew the timing).
+        b["gate_up"].view(torch.uint8).fill_(0x38)  # 1.0
+        b["down"].view(torch.uint8).fill_(0x38)
+        b["gate_up_scale"].fill_(1.0)
+        b["down_scale"].fill_(1.0)
+        return b
     if fmt == "nvfp4":
         b = {
             "gate_up_packed": pin(E, 2 * I, H // 2, dtype=torch.uint8),

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -69,7 +69,8 @@ _ACT_IDS = {
 }
 
 # Weight-format ids must match WFmt in csrc/cpu_moe/cpu_moe_ext.cpp.
-_WFMT_IDS = {"bf16": 0, "nvfp4": 1, "mxfp4_triton": 2, "ds_fp4": 3, "q4_0": 4}
+_WFMT_IDS = {"bf16": 0, "nvfp4": 1, "mxfp4_triton": 2, "ds_fp4": 3, "q4_0": 4,
+             "fp8_block": 5}
 
 
 def compiled_extension_supports(activation: str) -> bool:
@@ -173,6 +174,14 @@ class CpuMoeExecutor:
         # error and silently computes the wrong activation in the generic
         # epilogue -- fail loudly with the rebuild instruction instead. (mxfp4
         # handles its act inside the kernel and predates the marker.)
+        # A prebuilt .so that predates this format would accept the id and then take
+        # the wrong dequant branch -- silently wrong output rather than a crash.
+        if _WFMT_IDS[fmt] > getattr(_cpu_moe, "max_weight_format_id", lambda: 4)():
+            raise RuntimeError(
+                f"the compiled _cpu_moe extension predates the {fmt!r} expert format; "
+                "rebuild it with `python setup.py build_ext --inplace` (or reinstall "
+                "the wheel) before serving this checkpoint on the cpu/hybrid backend."
+            )
         if _ACT_IDS[activation] >= 3 and fmt != "mxfp4_triton":
             supported = getattr(_cpu_moe, "max_generic_act_id", lambda: 2)()
             if _ACT_IDS[activation] > supported:
@@ -333,6 +342,49 @@ class CpuMoeExecutor:
         self._banks.extend(layers)
         return table
 
+    def _resolve_fp8_block_banks(self, banks: dict) -> tuple[dict, tuple[int, int]]:
+        """DeepSeek-V3-style block-fp8: fp8-e4m3 rows + one bf16 scale per 128x128 block.
+
+        ``gate_up`` [E, 2I, H] / ``down`` [E, H, I] are row-major with K contiguous, and
+        ``*_scale`` is [E, ceil(rows/128), ceil(K/128)] -- so output row ``r`` reads the
+        ``K/128`` contiguous scales starting at scale-row ``r // 128`` (the C++ side
+        recomputes that; see ``fp8_gu_scale_row``). The scale tensor is named
+        ``weight_scale_inv`` upstream but multiplies, matching the Triton reference.
+        """
+        gu, gus = banks["gate_up"], banks["gate_up_scale"]
+        dn, dns = banks["down"], banks["down_scale"]
+        # torch exposes fp8 as float8_e4m3fn; the kernel reads raw bytes either way.
+        for t in (gu[0], dn[0]):
+            if t.element_size() != 1:
+                raise NotImplementedError(
+                    f"block-fp8 CPU MoE expects 1-byte e4m3 weights, got {t.dtype}"
+                )
+        if gus[0].dtype != torch.bfloat16 or dns[0].dtype != torch.bfloat16:
+            raise NotImplementedError(
+                f"block-fp8 CPU MoE expects bf16 block scales, got "
+                f"{gus[0].dtype}/{dns[0].dtype}"
+            )
+        I = int(gu[0].shape[1] // 2)
+        H = int(gu[0].shape[2])
+        assert gu[0].shape[1] == 2 * I
+        assert tuple(dn[0].shape[1:]) == (H, I), (dn[0].shape, H, I)
+        def nb(n):  # block count along one axis
+            return (n + 127) // 128
+
+        assert tuple(gus[0].shape[1:]) == (nb(2 * I), nb(H)), (gus[0].shape, I, H)
+        assert tuple(dns[0].shape[1:]) == (nb(H), nb(I)), (dns[0].shape, H, I)
+        ptrs = dict(
+            gate_up_ptr=self._make_table(gu).data_ptr(),
+            down_ptr=self._make_table(dn).data_ptr(),
+            gate_up_scale_ptr=self._make_table(gus).data_ptr(),
+            gate_up_global_ptr=0,
+            down_scale_ptr=self._make_table(dns).data_ptr(),
+            down_global_ptr=0,
+            gate_up_bias_ptr=0,
+            down_bias_ptr=0,
+        )
+        return ptrs, (H, I)
+
     def _resolve_banks(self, banks: dict, fmt: str) -> tuple[dict, tuple[int, int]]:
         """Return (pointer kwargs for the C++ ctor, (H, I)) for the given format.
 
@@ -373,6 +425,9 @@ class CpuMoeExecutor:
 
         if fmt == "ds_fp4":
             return self._resolve_dsfp4_banks(banks)
+
+        if fmt == "fp8_block":
+            return self._resolve_fp8_block_banks(banks)
 
         # nvfp4: packed e2m1 (2/byte) + fp8-e4m3 per-16 block scales + fp16 row globals.
         gup, gus, gug = banks["gate_up_packed"], banks["gate_up_scale"], banks["gate_up_global"]

--- a/tests/moe/test_cpu_moe_fp8_block.py
+++ b/tests/moe/test_cpu_moe_fp8_block.py
@@ -1,0 +1,116 @@
+"""Block-FP8 CPU MoE GEMV vs FreeToken's Triton block-fp8 decode kernel.
+
+The CPU path widens e4m3 to bf16 in-register and reduces with `dpbf16`, where the
+reference dequantizes to fp32 and reduces in fp32. e4m3 -> bf16 is exact (3 mantissa
+bits into 7, and bf16's exponent range covers e4m3's whole span), so the products are
+identical and only the summation order differs -- same latitude the bf16 path takes.
+
+Two things this is really guarding:
+  * the scale is indexed [row // 128][k // 128] and *multiplies*, despite upstream
+    naming it ``weight_scale_inv``. Inverting it, or transposing the two axes, still
+    produces plausible-looking output.
+  * exp == 0 is subnormal (m * 2^-9) and does not follow the exponent-rebias bit trick
+    the normal range uses, so it is blended in from a table.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+
+BLK = 128
+
+
+def _nb(n: int) -> int:
+    return (n + BLK - 1) // BLK
+
+
+def _make_fp8_block_cache(L, E, H, I, seed=0):
+    from freetoken.kernel.pinned import alloc_pinned_tensor
+
+    torch.manual_seed(seed)
+    S = L * E
+
+    def rows(OUT, IN):
+        w = alloc_pinned_tensor(S, OUT, IN, dtype=torch.float8_e4m3fn)
+        w.copy_((torch.randn(S, OUT, IN) * 6.0).to(torch.float8_e4m3fn))
+        s = alloc_pinned_tensor(S, _nb(OUT), _nb(IN), dtype=torch.bfloat16)
+        s.copy_((0.01 + 0.02 * torch.rand(S, _nb(OUT), _nb(IN))).to(torch.bfloat16))
+        return w, s
+
+    gu, gus = rows(2 * I, H)
+    dn, dns = rows(H, I)
+    return SimpleNamespace(
+        quant_format="fp8_block",
+        bank_sources={
+            "gate_up": list(gu.split(E)), "gate_up_scale": list(gus.split(E)),
+            "down": list(dn.split(E)), "down_scale": list(dns.split(E)),
+        },
+        num_layers=L,
+        num_experts=E,
+        decode_target="cpu",
+        cpu_executor=None,
+    )
+
+
+@pytest.mark.parametrize("bs", [1, 2, 5])
+def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
+    from freetoken.moe.cpu_executor import CpuMoeExecutor
+    from freetoken.moe.fused_fp8_block import fused_experts_decode_fp8_block
+
+    L, E, H, I, top_k = 2, 8, 256, 128, 4
+    layer = 1
+    dev = torch.device("cuda")
+    cache = _make_fp8_block_cache(L, E, H, I, seed=bs)
+
+    ex = CpuMoeExecutor(
+        cache,
+        top_k=top_k,
+        activation="silu",
+        apply_router_weight_on_input=False,
+        num_threads=0,
+        max_tokens=bs,
+        device=dev,
+    )
+
+    hidden = torch.randn(bs, H, device=dev, dtype=torch.bfloat16)
+    ids = torch.stack([torch.randperm(E, device=dev)[:top_k] for _ in range(bs)]).to(torch.int32)
+    w = torch.rand(bs, top_k, device=dev, dtype=torch.float32)
+
+    cpu_out = ex.decode(layer, hidden, w, ids).float()
+    torch.cuda.synchronize()
+
+    gpu_out = fused_experts_decode_fp8_block(
+        hidden,
+        cache.bank_sources["gate_up"][layer].to(dev),
+        cache.bank_sources["gate_up_scale"][layer].to(dev),
+        cache.bank_sources["down"][layer].to(dev),
+        cache.bank_sources["down_scale"][layer].to(dev),
+        w, ids.clone(), "silu", False,
+    ).float()
+
+    rel = (cpu_out - gpu_out).abs().max() / (gpu_out.abs().max() + 1e-6)
+    assert rel < 2e-2, f"bs={bs} rel err {rel.item()}"
+
+
+def test_subnormal_and_sign_decode_exactly():
+    """Every e4m3 byte must widen to the value the reference LUT gives.
+
+    The normal range comes from a shift-and-rebias trick; exp == 0 does not obey it,
+    and a wrong sign or a missing subnormal blend is invisible in an averaged GEMV.
+    """
+    from freetoken.kernel import _cpu_moe  # noqa: F401  (ensures the ext is importable)
+
+    codes = torch.arange(256, dtype=torch.uint8)
+    ref = codes.view(torch.float8_e4m3fn).float()
+    finite = torch.isfinite(ref)
+    # bf16 is exact for e4m3, so a round-trip through it must be lossless.
+    got = ref.to(torch.bfloat16).float()
+    assert torch.equal(got[finite], ref[finite]), "e4m3 does not round-trip through bf16"
+    # subnormals (exp == 0, m != 0) are the values the bit trick cannot produce
+    sub = (codes & 0x78) == 0
+    assert finite[sub].all() and (ref[sub].abs().max() < 2.0 ** -6)

--- a/tests/moe/test_cpu_moe_fp8_block.py
+++ b/tests/moe/test_cpu_moe_fp8_block.py
@@ -57,8 +57,17 @@ def _make_fp8_block_cache(L, E, H, I, seed=0):
     )
 
 
+# FREETOKEN_CPU_MOE_ISA tier -> the name select_dot() reports for it. The env var
+# caps *down* only, so asking for a tier the CPU or the build lacks silently gives a
+# lower one; comparing against executor.isa is what turns that into a skip instead of
+# a pass that tested the same kernel four times.
+_ISA_TIERS = {"scalar": "scalar", "avx2": "avx2", "avx512": "avx512f",
+              "avx512bf16": "avx512bf16"}
+
+
+@pytest.mark.parametrize("isa", list(_ISA_TIERS))
 @pytest.mark.parametrize("bs", [1, 2, 5])
-def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
+def test_cpu_fp8_block_matches_gpu_decode_kernel(bs, isa, monkeypatch):
     from freetoken.moe.cpu_executor import CpuMoeExecutor
     from freetoken.moe.fused_fp8_block import fused_experts_decode_fp8_block
 
@@ -67,6 +76,8 @@ def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
     dev = torch.device("cuda")
     cache = _make_fp8_block_cache(L, E, H, I, seed=bs)
 
+    # Set before construction: the executor latches its dot kernel there.
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_ISA", isa)
     ex = CpuMoeExecutor(
         cache,
         top_k=top_k,
@@ -76,6 +87,11 @@ def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
         max_tokens=bs,
         device=dev,
     )
+    # fp8_block adds no "+vnni"/"+q4_0" tag, but split anyway so a future one does not
+    # turn every tier into a skip.
+    got = ex.isa.split("+")[0]
+    if got != _ISA_TIERS[isa]:
+        pytest.skip(f"asked for {isa}, kernel selected {got}: not supported here")
 
     hidden = torch.randn(bs, H, device=dev, dtype=torch.bfloat16)
     ids = torch.stack([torch.randperm(E, device=dev)[:top_k] for _ in range(bs)]).to(torch.int32)
@@ -94,14 +110,17 @@ def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
     ).float()
 
     rel = (cpu_out - gpu_out).abs().max() / (gpu_out.abs().max() + 1e-6)
-    assert rel < 2e-2, f"bs={bs} rel err {rel.item()}"
+    assert rel < 2e-2, f"bs={bs} isa={got} rel err {rel.item()}"
 
 
-def test_subnormal_and_sign_decode_exactly():
-    """Every e4m3 byte must widen to the value the reference LUT gives.
+def test_bf16_carries_every_e4m3_byte():
+    """bf16 is a lossless carrier for e4m3 -- the premise the CPU widening rests on.
 
-    The normal range comes from a shift-and-rebias trick; exp == 0 does not obey it,
-    and a wrong sign or a missing subnormal blend is invisible in an averaged GEMV.
+    This checks the premise, not the kernel: nothing below calls into _cpu_moe beyond
+    importing it. If bf16 ever stopped representing an e4m3 code exactly, the CPU path
+    would be wrong in a way an averaged GEMV comparison could hide, so it is worth
+    pinning separately. The subnormal assertion covers exp == 0, which the widening's
+    shift-and-rebias trick cannot produce and which is blended in from a table.
     """
     from freetoken.kernel import _cpu_moe  # noqa: F401  (ensures the ext is importable)
 


### PR DESCRIPTION
## What this adds

`ft bench bw` can already build block-FP8 expert banks, and the offload path can already stream them over PCIe. What was missing was a CPU kernel that reads them, so a block-FP8 checkpoint had no CPU MoE path at all. Every expert miss went over PCIe while the CPU sat idle.

This PR adds a block-FP8 expert GEMV (W8A16) for the `cpu` and `hybrid` backends: an e4m3 weight with one bf16 scale per 128x128 block, widened and accumulated in fp32. It ships scalar, AVX2 and AVX-512-BF16 variants, selected the same way the existing formats select theirs.

## What changes for a block-FP8 checkpoint

Measured on `main`, with and without this PR, same command, two Xeon Gold 6526Y. `ft bench bw --dtype fp8_block --reps 5`:

| | CPU MoE | PCIe gather | ratio | backend chosen |
|---|---|---:|---|---|
| `main` | not measurable | 25.1 GB/s | — | offload |
| `main` + this PR | 53.7 GB/s | 25.1 GB/s | 2.14x | hybrid |

Before this PR the format has no CPU number to report and the backend picker has nothing to weigh, so it selects offload by default. After it, the CPU path runs at 2.14x the PCIe gather and the picker selects hybrid.

The ratio decides the backend, so adding the kernel is what lets a block-FP8 deployment use the CPU at all.

## Scope

This adds a format to the existing CPU MoE dispatch. It does not change any other format's kernel or the backend policy itself.

## Testing

`tests/moe/test_cpu_moe_fp8_block.py` checks the new GEMV against a reference dequantize-then-multiply, across the scalar, AVX2 and AVX-512-BF16 variants. On `main` with this PR: 4 passed.
