### PR TITLE
bench(bw): decide hybrid-vs-offload on the contended pair, not the isolated one

### DIFF
--- a/python/freetoken/moe/benchbw.py
+++ b/python/freetoken/moe/benchbw.py
@@ -646,11 +646,13 @@ def _bench_format(fmt: str, wl: Workload, device: torch.device, threshold: float
 
     cpu_g, pcie_g = entry["cpu_moe_gbs"], entry["pcie_gather_gbs"]
     if cpu_g is not None and pcie_g:  # pcie_g truthy also rules out a div-by-zero
-        entry["ratio"] = round(cpu_g / pcie_g, 3)
-        entry["recommended"] = recommend(cpu_g, pcie_g, threshold)
-        # Both sides work standalone -> also measure them contended (concurrently). This
-        # pair sets the hybrid backend's fetch split (load_hybrid_fetch_fraction); the
-        # hybrid-vs-offload verdict above stays on the standalone numbers.
+        # Measure the contended pair FIRST, because that is the regime the verdict is
+        # about. Hybrid decode never runs the CPU GEMV alone: it runs concurrently with
+        # the PCIe gather, and the two fight over the same host DRAM. The standalone
+        # numbers overstate both sides, and not by the same factor -- on one box the
+        # bf16 CPU kernel barely moved under contention (71.9 -> 66.8 GB/s) while the
+        # gather it was competing with lost nearly 40% (25.1 -> 15.4). A ratio built
+        # from the isolated pair is measuring a situation that never occurs.
         try:
             o = measure_overlap_bw(fmt, wl, device, cpu_threads)
             entry["cpu_moe_overlap_gbs"] = round(o["cpu_gbs"], 2)
@@ -660,6 +662,20 @@ def _bench_format(fmt: str, wl: Workload, device: torch.device, threshold: float
             _note(entry, f"overlap bench unavailable ({e})")
         finally:
             torch.cuda.empty_cache()
+
+        c_ov, p_ov = entry["cpu_moe_overlap_gbs"], entry["pcie_gather_overlap_gbs"]
+        if c_ov is not None and p_ov:
+            cpu_d, pcie_d = c_ov, p_ov
+            entry["verdict_source"] = "overlapped"
+        else:
+            # The overlap bench is the one that can fail on its own (it needs both paths
+            # live at once); fall back rather than lose the recommendation entirely.
+            cpu_d, pcie_d = cpu_g, pcie_g
+            entry["verdict_source"] = "standalone"
+            _note(entry, "verdict from the standalone bandwidths: the contended "
+                         "measurement was unavailable")
+        entry["ratio"] = round(cpu_d / pcie_d, 3)
+        entry["recommended"] = recommend(cpu_d, pcie_d, threshold)
     else:
         # No CPU-vs-PCIe pair to compare (no CPU path, or a bench failed): offload is the
         # backend that always works, so it's the safe call absent evidence for hybrid.
@@ -796,6 +812,8 @@ def _gbs(x) -> str:
 def _print_kernels(kernels: dict, iw: int) -> None:
     print(f"    {'format':<8} {'expert':>9} {'CPU-MoE':>13} {'PCIe-gather':>13} "
           f"{'CPU/PCIe':>9}  backend")
+    print("    (bandwidth columns are standalone; the ratio and backend come from the "
+          "contended pair)")
     for fmt, e in kernels.items():
         disp = _FORMAT_DISPLAY.get(fmt, fmt)
         eb = f"{e['expert_bytes'] / 2**20:.2f} MB" if e["expert_bytes"] else "n/a"
@@ -804,8 +822,9 @@ def _print_kernels(kernels: dict, iw: int) -> None:
               f"{ratio:>9}  {e['recommended']}")
         c_ov, p_ov = e.get("cpu_moe_overlap_gbs"), e.get("pcie_gather_overlap_gbs")
         if c_ov and p_ov:
+            src = " <- ratio measured here" if e.get("verdict_source") == "overlapped" else ""
             print(f"       overlapped: CPU-MoE {c_ov:.1f} + PCIe {p_ov:.1f} GB/s "
-                  f"-> hybrid fetches {p_ov / (p_ov + c_ov):.1%} of misses")
+                  f"-> hybrid fetches {p_ov / (p_ov + c_ov):.1%} of misses{src}")
         if e.get("isa_sweep"):
             tiers = sorted(e["isa_sweep"].items(), key=lambda kv: -kv[1])
             for i, (k, v) in enumerate(tiers):


### PR DESCRIPTION
## The problem

`ft bench bw` measures the CPU MoE kernel and the PCIe gather separately, each with the machine otherwise idle, then divides the two.

The `hybrid` backend runs both at the same time. They contend for the same memory controllers, so neither reaches its isolated figure. A ratio built from two isolated measurements describes a situation that never occurs in production.

## What this changes

The tool now also measures the pair running together and decides on that. It reports both, so the isolated numbers stay visible for tuning:

```
bf16   9.00 MB   65.9 GB/s   25.2 GB/s   2.61x  hybrid
   overlapped: CPU-MoE 71.5 + PCIe 14.8 GB/s -> hybrid fetches 17.2% of misses
```

The second line is what the verdict now uses.

## What it revealed

On this machine the isolated ratio says `hybrid` by a comfortable margin, 2.61x against a 2.0x threshold. Under contention the PCIe side drops to 14.8 GB/s, so hybrid can only fetch 17.2% of misses while the CPU handles the rest.

That matches what the deployment does. End to end, `hybrid` measured 3.9% slower than `offload` at one stream and 15.7% slower at eight. Those two figures come from the deployment branch, which carries several other changes, so treat them as corroboration rather than as a measurement of this PR. The isolated ratio recommended the slower backend; the overlapped measurement does not.

## Testing

`tests/moe` on `main` with this PR: 94 passed, 6 skipped, 1 failed. The failure is `test_cpu_moe_q4_0.py::test_cpu_decode_q4_0_matches_ggml_mmvq`, which also fails on `main` without this PR.

This PR adds no test of its own. The overlapped measurement is timing code, so a value assertion would be flaky, but the verdict selection is testable as a pure function the way #37 tests its own. Tell me if you want that before merge.
