### PR TITLE
gemma4/gguf: accept a scalar attention.head_count_kv

### DIFF
--- a/python/freetoken/models/gemma4/gguf.py
+++ b/python/freetoken/models/gemma4/gguf.py
@@ -60,7 +60,12 @@ def parse_gguf_config(shim: "GgufConfigShim") -> ModelConfig:
     num_layers = int(g("block_count"))
     hidden = int(g("embedding_length"))
     num_qo_heads = int(g("attention.head_count"))
-    kv_per_layer = g("attention.head_count_kv")  # per-layer list
+    # Per-layer list, or a single value when every layer shares it: llama.cpp collapses
+    # a uniform array to a scalar, which the official gemma-4 E2B QAT q4_0 GGUF hits
+    # (head_count_kv == 1 for all 35 blocks). Broadcast so the indexing below holds.
+    kv_per_layer = g("attention.head_count_kv")
+    if isinstance(kv_per_layer, (int, float)):
+        kv_per_layer = [int(kv_per_layer)] * num_layers
     # True -> sliding-window (SWA) layer, False -> full attention.
     swa_pattern = [bool(x) for x in g("attention.sliding_window_pattern")]
     assert len(swa_pattern) == num_layers, "sliding_window_pattern length != block_count"


### PR DESCRIPTION
Fixes #63.

`parse_gguf_config` treats `gemma4.attention.head_count_kv` as a per-layer array and indexes
it directly. llama.cpp collapses that array to a single value when every block shares it,
which the official [`google/gemma-4-E2B-it-qat-q4_0-gguf`](https://huggingface.co/google/gemma-4-E2B-it-qat-q4_0-gguf)
checkpoint hits (`head_count_kv == 1` across all 35 blocks), so `ft serve` dies during
`_adjust_config` with:

```
TypeError: 'int' object is not subscriptable
```

This broadcasts a scalar to one entry per block before the SWA/full lookups. Arrays are
unaffected — the `isinstance` guard only fires on the scalar form.

### Verification

Before: `ft serve --model gemma-4-E2B_q4_0-it.gguf` raises the `TypeError` above and the
frontend shuts the API server down.

After: config parsing completes and startup proceeds past this point.

Note my machine can't finish a full generation run on this checkpoint for unrelated reasons
(4 GB VRAM), so I've verified the parse fix rather than end-to-end inference — worth a second
look from someone with a supported card.
