### PR TITLE
Fix: minor issue of tqdm lock leak during termination with TP

### DIFF
--- a/python/freetoken/server/launch.py
+++ b/python/freetoken/server/launch.py
@@ -55,9 +55,19 @@ def _run_tokenize_worker(detach: bool, **kwargs) -> None:
     tokenize_worker(**kwargs)
 
 
+def _configure_worker_tqdm_lock() -> None:
+    import threading
+
+    from tqdm import tqdm
+
+    tqdm.set_lock(threading.RLock())
+
+
 def _run_scheduler(args: ServerArgs, ack_queue: mp.Queue[str]) -> None:
     if args.shell_mode:
         _detach_process_group()
+
+    _configure_worker_tqdm_lock()
 
     import torch
     from freetoken.scheduler import Scheduler


### PR DESCRIPTION
Use a process-local threading.RLock for scheduler-worker tqdm progress bars.

tqdm defaults to a multiprocessing lock, creating one POSIX semaphore per TP rank. FreeToken terminates workers before those locks are finalized, causing resource_tracker warnings. Only rank 0 renders progress, so cross-process locking is unnecessary. A thread lock provides the required in-process synchronization without allocating semaphores. thus removes the warning.
Example TP=4 warning:
```
/usr/lib/python3.10/multiprocessing/resource_tracker.py:224: UserWarning: resource_tracker: There appear to be 4 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```
Tested on Qwen2.5 and TinyLlama with TP=2 and 4.