### PR TITLE
docs(install): document NCCL dev libraries for multi-GPU tensor parallelism

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,6 +5,10 @@
 - Linux x86_64, NVIDIA GPU, driver r580+ (CUDA 13)
 - Python >= 3.10, with [uv](https://docs.astral.sh/uv/) recommended (plain
   `pip` + `venv` works too)
+- Multi-GPU (`--tensor-parallel-size > 1`): NCCL development libraries for
+  the JIT link step, e.g. `sudo apt-get install libnccl2 libnccl-dev`.
+  Without them the first TP launch fails at link time with
+  `/usr/bin/ld: cannot find -lnccl`.
 
 ## Method 1: Install from PyPI
 


### PR DESCRIPTION
## Summary

Adds the NCCL development libraries as a documented prerequisite for `--tensor-parallel-size > 1`.

On a clean install (Ubuntu 24.04, PyPI wheels, CUDA 13 toolkit via NVIDIA apt repo), the first TP>1 launch fails during the JIT link step:

```
/usr/bin/ld: cannot find -lnccl
```

Resolved with:

```bash
sudo apt-get install libnccl2 libnccl-dev
```

`install.md` previously listed only driver r580+ / CUDA 13 and the `nvcc` requirement. Surfaced while testing TP=2 on 2x RTX 3090; also reported as a secondary finding in #29.