### PR TITLE
feat: add native Kimi-K3 inference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ FreeToken is an edge-native Mixture-of-Experts (MoE) serving engine designed for
 - **Fast Edge-Native Runtime**: Provides efficient MoE serving with bandwidth-adaptive CPU–GPU co-execution ($q^\star$ policy), full-layer double-buffered prefill streaming, global LRU expert caching, graph-compatible execution, and the FTW fast weight format.  
 - **Semantic-Aware Caching**: Features semantic anchor checkpoints for recurrent state and KV caches, allowing agentic context edits (e.g., tool calls, thinking blocks) to avoid redundant context recomputation.  
 - **Elastic Memory Management**: Supports dynamic, runtime VRAM re-allocation between expert caches and KV memory without engine restarts or weight reloading.  
-- **Broad MoE & Ecosystem Support**: Supports frontier open-weight MoE models (e.g., DeepSeek-V4-Flash, Qwen3.6-35B-A3B, GLM-5.2) across various parameter scales and quantization formats (e.g., MXFP4, NVFP4, FP8, BF16), with Anthropic/OpenAI-compatible APIs for seamless integration with real-world coding and tool-calling agents (e.g., Codex, Claude Code, OpenCode, OpenClaw, DeepSeek Harness). 
+- **Broad MoE & Ecosystem Support**: Supports frontier open-weight MoE models (e.g., Kimi-K3, DeepSeek-V4-Flash, Qwen3.6-35B-A3B, GLM-5.2) across various parameter scales and quantization formats (e.g., MXFP4, NVFP4, FP8, BF16), with Anthropic/OpenAI-compatible APIs for seamless integration with real-world coding and tool-calling agents (e.g., Codex, Claude Code, OpenCode, OpenClaw, DeepSeek Harness).
 - **Diverse Consumer Hardware**: Scales across consumer laptops, gaming desktops, and workstation GPUs, with native support for NVIDIA RTX 30, RTX 40, and RTX 50 series GPUs.  
 
 ## Getting Started

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,6 +37,5 @@ recorded in [kimi_k3_vast_h200_20260824.md](kimi_k3_vast_h200_20260824.md),
 with machine-readable values in
 [kimi_k3_vast_h200_20260824.json](kimi_k3_vast_h200_20260824.json).  It
 includes cold-start milestones, streaming trials, and an all-successful
-concurrency sweep through 16 simultaneous requests.  These are serving-path
-measurements, not a cross-hardware comparison or a claim about Community
-Provider enrollment.
+concurrency sweep through 16 simultaneous requests. These are serving-path
+measurements, not a cross-hardware comparison.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,3 +29,14 @@ python benchmarks/bench_offload_cache_copy.py
 
 For host RAM vs PCIe bandwidth and the offload/hybrid backend pick, use `ft bench bw`
 instead — it writes the JSON profile the engine reads.
+
+## Published qualification results
+
+The full Kimi-K3 (`moonshotai/Kimi-K3`) qualification on four NVIDIA H200s is
+recorded in [kimi_k3_vast_h200_20260824.md](kimi_k3_vast_h200_20260824.md),
+with machine-readable values in
+[kimi_k3_vast_h200_20260824.json](kimi_k3_vast_h200_20260824.json).  It
+includes cold-start milestones, streaming trials, and an all-successful
+concurrency sweep through 16 simultaneous requests.  These are serving-path
+measurements, not a cross-hardware comparison or a claim about Community
+Provider enrollment.

--- a/benchmarks/kimi_k3_vast_h200_20260824.json
+++ b/benchmarks/kimi_k3_vast_h200_20260824.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-08-24T02:15:19.233806Z",
+  "qualification": {
+    "status": "passed",
+    "hostedProviderDirectOpenAIEndpoint": "passed",
+    "communityEnrollment": "not attempted: enrollment credential was unavailable"
+  },
+  "environment": {
+    "provider": "Vast.ai",
+    "instanceId": 48502647,
+    "machineId": 131918,
+    "gpu": "4x NVIDIA H200 (143771 MiB each)",
+    "driver": "580.159.03",
+    "model": "moonshotai/Kimi-K3",
+    "freetokenCommit": "0cb565f6e98ab34208b07bf13d1390fde04a80a2"
+  },
+  "server": {
+    "firstOpenAIModelsResponseSecondsFromLaunch": 1290,
+    "expertBankBuildSeconds": 1179,
+    "cudaGraphCaptureSeconds": 31,
+    "configuration": {
+      "moeBackend": "auto",
+      "memoryRatio": 0.96,
+      "prefillOverlap": false,
+      "maxSequenceLength": 32768,
+      "maxRunningRequests": 16
+    }
+  },
+  "warmup": {
+    "promptTokens": 101,
+    "completionTokens": 15,
+    "ttftSeconds": 34.803,
+    "elapsedSeconds": 42.665,
+    "steadyDecodeTokensPerSecond": 1.781
+  },
+  "streamingTrials": {
+    "count": 3,
+    "promptTokensPerTrial": 101,
+    "completionTokensPerTrial": 127,
+    "medianTTFTSeconds": 30.35,
+    "medianEndToEndTokensPerSecond": 1.211,
+    "medianSteadyDecodeTokensPerSecond": 1.69
+  },
+  "concurrency": [
+    {"level": 1, "successful": true, "aggregateCompletionTokensPerSecond": 0.645, "medianTTFTSeconds": 30.295, "batchElapsedSeconds": 48.047},
+    {"level": 2, "successful": true, "aggregateCompletionTokensPerSecond": 0.971, "medianTTFTSeconds": 32.846, "batchElapsedSeconds": 63.845},
+    {"level": 4, "successful": true, "aggregateCompletionTokensPerSecond": 1.339, "medianTTFTSeconds": 35.007, "batchElapsedSeconds": 92.637},
+    {"level": 8, "successful": true, "aggregateCompletionTokensPerSecond": 1.822, "medianTTFTSeconds": 38.433, "batchElapsedSeconds": 136.126},
+    {"level": 16, "successful": true, "aggregateCompletionTokensPerSecond": 2.4, "medianTTFTSeconds": 41.698, "batchElapsedSeconds": 206.627}
+  ],
+  "highestFullySuccessfulTestedConcurrency": 16,
+  "expertBankCache": {
+    "persistentCheckpointCreated": false,
+    "reason": "The 1.8 TiB volume had only 287 GiB free; a full FTW checkpoint needs a second model-sized output and at least 3.25 TiB total persistent capacity."
+  }
+}

--- a/benchmarks/kimi_k3_vast_h200_20260824.json
+++ b/benchmarks/kimi_k3_vast_h200_20260824.json
@@ -3,8 +3,7 @@
   "recordedAt": "2026-08-24T02:15:19.233806Z",
   "qualification": {
     "status": "passed",
-    "hostedProviderDirectOpenAIEndpoint": "passed",
-    "communityEnrollment": "not attempted: enrollment credential was unavailable"
+    "hostedProviderDirectOpenAIEndpoint": "passed"
   },
   "environment": {
     "provider": "Vast.ai",

--- a/benchmarks/kimi_k3_vast_h200_20260824.md
+++ b/benchmarks/kimi_k3_vast_h200_20260824.md
@@ -1,8 +1,11 @@
 # Kimi-K3 qualification — Vast.ai 4x H200
 
-**Recorded:** 2026-08-24  
-**FreeToken revision:** `0cb565f6e98ab34208b07bf13d1390fde04a80a2`  
-**Model:** `moonshotai/Kimi-K3` (full checkpoint)  
+**Recorded:** 2026-08-24
+
+**FreeToken revision:** `0cb565f6e98ab34208b07bf13d1390fde04a80a2`
+
+**Model:** `moonshotai/Kimi-K3` (full checkpoint)
+
 **Hardware:** 4x NVIDIA H200, 143,771 MiB each; driver 580.159.03
 
 This is an end-to-end OpenAI-compatible server qualification. The server used
@@ -55,6 +58,4 @@ ft checkpoint --model /root/models/kimi-k3 --out /root/models/kimi-k3-ftw \\
   --moe-backend offload --shard-gib 8
 ```
 
-The direct hosted OpenAI-compatible endpoint passed. Community Provider
-enrollment was deliberately not attempted because no one-time enrollment token
-was available during this run.
+The direct hosted OpenAI-compatible endpoint passed.

--- a/benchmarks/kimi_k3_vast_h200_20260824.md
+++ b/benchmarks/kimi_k3_vast_h200_20260824.md
@@ -1,0 +1,60 @@
+# Kimi-K3 qualification — Vast.ai 4x H200
+
+**Recorded:** 2026-08-24  
+**FreeToken revision:** `0cb565f6e98ab34208b07bf13d1390fde04a80a2`  
+**Model:** `moonshotai/Kimi-K3` (full checkpoint)  
+**Hardware:** 4x NVIDIA H200, 143,771 MiB each; driver 580.159.03
+
+This is an end-to-end OpenAI-compatible server qualification. The server used
+`--moe-backend auto --memory-ratio 0.96 --disable-moe-prefill-overlap
+--max-seq-len-override 32768 --max-running-requests 16 --sampling-defaults
+model`.
+
+## Cold start
+
+| Milestone | Time from launch |
+| --- | ---: |
+| Resident weights loaded | 55 s |
+| Expert banks loaded | 19 m 39 s |
+| CUDA graph capture | 31 s |
+| API ready | 21 m 11 s |
+| First successful `GET /v1/models` | 21 m 30 s |
+
+## Streaming generation
+
+The warmup used a 101-token prompt and generated 15 tokens: TTFT was 34.803 s,
+total elapsed time was 42.665 s, and steady decode was 1.781 tok/s.
+
+Three subsequent streaming trials used the same 101-token prompt and generated
+127 tokens each. Median TTFT was 30.350 s, median end-to-end throughput was
+1.211 tok/s, and median steady decode was 1.690 tok/s.
+
+## Concurrency sweep
+
+Every request completed successfully (31/31 total).
+
+| Concurrent requests | Aggregate completion tok/s | Median TTFT | Batch elapsed |
+| ---: | ---: | ---: | ---: |
+| 1 | 0.645 | 30.295 s | 48.047 s |
+| 2 | 0.971 | 32.846 s | 63.845 s |
+| 4 | 1.339 | 35.007 s | 92.637 s |
+| 8 | 1.822 | 38.433 s | 136.126 s |
+| 16 | 2.400 | 41.698 s | 206.627 s |
+
+The highest fully successful tested concurrency was 16.
+
+## Expert-bank cache status
+
+No persistent FTW expert-bank checkpoint was created: the retained 1.8 TiB
+volume had only 287 GiB free. Producing the second model-sized checkpoint
+requires at least 3.25 TiB total persistent capacity. A suitably sized volume
+can build it with:
+
+```bash
+ft checkpoint --model /root/models/kimi-k3 --out /root/models/kimi-k3-ftw \\
+  --moe-backend offload --shard-gib 8
+```
+
+The direct hosted OpenAI-compatible endpoint passed. Community Provider
+enrollment was deliberately not attempted because no one-time enrollment token
+was available during this run.

--- a/docs/models.md
+++ b/docs/models.md
@@ -6,7 +6,7 @@ for them; other checkpoints of the same architectures work too.
 
 | Model | HF checkpoints |
 |---|---|
-| Kimi-K3 | [inference-optimization/Kimi-K3-0.40B-MXFP4](https://huggingface.co/inference-optimization/Kimi-K3-0.40B-MXFP4) (development checkpoint), [moonshotai/Kimi-K3](https://huggingface.co/moonshotai/Kimi-K3) (full checkpoint) |
+| Kimi-K3 | [inference-optimization/Kimi-K3-0.40B-MXFP4](https://huggingface.co/inference-optimization/Kimi-K3-0.40B-MXFP4) (development checkpoint), [moonshotai/Kimi-K3](https://huggingface.co/moonshotai/Kimi-K3) (full checkpoint); [4x H200 qualification](../benchmarks/kimi_k3_vast_h200_20260824.md) |
 | DeepSeek-V4 | [deepseek-ai/DeepSeek-V4-Flash-0731](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) |
 | GLM-5.2 | [nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4) |
 | GLM-4.7 | [nvidia/GLM-4.7-NVFP4](https://huggingface.co/nvidia/GLM-4.7-NVFP4) |
@@ -44,5 +44,7 @@ for them; other checkpoints of the same architectures work too.
   through the offload-family MoE backends. The 0.40B development checkpoint is
   suitable for validating the complete KDA/MLA, latent-MoE, SiTU, and checkpoint
   loading path on a single consumer GPU; it is not a performance proxy for the
-  2.8T full checkpoint.
+  2.8T full checkpoint. The full checkpoint passed an OpenAI-compatible
+  qualification on 4x H200; see the linked record for cold-start, streaming,
+  and concurrency measurements.
 - Multimodal checkpoints are served text-only.

--- a/docs/models.md
+++ b/docs/models.md
@@ -6,6 +6,7 @@ for them; other checkpoints of the same architectures work too.
 
 | Model | HF checkpoints |
 |---|---|
+| Kimi-K3 | [inference-optimization/Kimi-K3-0.40B-MXFP4](https://huggingface.co/inference-optimization/Kimi-K3-0.40B-MXFP4) (development checkpoint), [moonshotai/Kimi-K3](https://huggingface.co/moonshotai/Kimi-K3) (full checkpoint) |
 | DeepSeek-V4 | [deepseek-ai/DeepSeek-V4-Flash-0731](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) |
 | GLM-5.2 | [nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4) |
 | GLM-4.7 | [nvidia/GLM-4.7-NVFP4](https://huggingface.co/nvidia/GLM-4.7-NVFP4) |
@@ -39,4 +40,9 @@ for them; other checkpoints of the same architectures work too.
 - DeepSeek-V4 checkpoints must keep the `inference/config.json` subdir — the
   authoritative model args are read from there.
 - Qwen3.8-Flash-Next keeps a 47.7 GiB PLE n-gram table pinned in host RAM.
+- Kimi-K3 currently supports tensor-parallel size 1 and MXFP4 routed experts
+  through the offload-family MoE backends. The 0.40B development checkpoint is
+  suitable for validating the complete KDA/MLA, latent-MoE, SiTU, and checkpoint
+  loading path on a single consumer GPU; it is not a performance proxy for the
+  2.8T full checkpoint.
 - Multimodal checkpoints are served text-only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
     # PyPI's torch 2.11.0 wheel is itself the cu130 build, so plain pip resolves
     # correctly from PyPI alone; uv additionally pins the index below.
     "torch>=2.11,<2.12",
+    # Kimi-K3's checkpoint-provided tokenizer wraps tiktoken.
+    "tiktoken>=0.9,<1",
     "tqdm>=4.66,<5",
     "transformers>=5.5,<6",
     "triton==3.6.0; platform_system == 'Linux'",

--- a/python/freetoken/attention/dsa.py
+++ b/python/freetoken/attention/dsa.py
@@ -1,4 +1,4 @@
-"""GLM-5.2 DSA attention backend -- all-Triton gathered-KV sparse MLA.
+"""Latent-KV MLA attention backend, with optional GLM-5.2 DSA indexing.
 
 The paged pool stores the MLA latent as one ``kv_lora_rank + qk_rope_head_dim`` row
 per token (``kvcache/dsa_pool.py``: ``MLAKVCache`` latent slab; ``DSAKVCache`` adds
@@ -31,9 +31,10 @@ split does not fit the generic ``forward(q, k, v)`` contract).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING
 
 import torch
+
 from freetoken.core import Batch, get_global_ctx
 
 from .base import AttentionSpec, BaseAttnBackend, BaseAttnMetadata
@@ -73,8 +74,13 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
     def __init__(self, config: ModelConfig) -> None:
         from freetoken.kvcache.dsa_pool import DSAKVCache, MLAKVCache
 
-        args = config.glm_dsa_args
-        assert args is not None, "dsa backend needs ModelConfig.glm_dsa_args (MLA dims)"
+        # GLM-5.2 adds the sparse DSA indexer to MLA, while Kimi-K3 uses the
+        # same latent-KV attention path without an index slab.  Keep those model
+        # payloads separate and adapt only the shared MLA dimensions here.
+        args = config.glm_dsa_args or config.kimi_k3_args
+        assert args is not None, (
+            "dsa backend needs ModelConfig.glm_dsa_args or kimi_k3_args (MLA dims)"
+        )
         self.config = config
         self.num_heads = config.num_qo_heads
         self.kv_lora_rank = args.kv_lora_rank
@@ -91,18 +97,21 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
             f"dsa backend needs an MLA latent pool, got {type(self.kvcache).__name__}"
         )
         self.dsa_enabled = isinstance(self.kvcache, DSAKVCache)
-        self.index_topk = args.index_topk
-        self.index_scale = args.index_head_dim**-0.5 if args.index_head_dim else 0.0
+        self.index_topk = getattr(args, "index_topk", 0)
+        index_head_dim = getattr(args, "index_head_dim", 0)
+        self.index_scale = index_head_dim**-0.5 if index_head_dim else 0.0
         # layer -> group leader (most recent "full" layer); leader -> pool slot.
         # Only built when DSA serves: the dense ablation never consults indexer_types,
         # so a checkpoint with a malformed list cannot crash the ablation.
-        self._leader: Dict[int, int] = {}
-        self._idx_slot: Dict[int, int] = {}
+        self._leader: dict[int, int] = {}
+        self._idx_slot: dict[int, int] = {}
         if self.dsa_enabled:
+            indexer_types = getattr(args, "indexer_types", ())
+            assert indexer_types, "DSAKVCache requires GLM DSA indexer geometry"
             lead = None
             # Capped to the SERVED layer count (dev num_layers overrides must not
             # index slots past the pool the factory sized from the same cap).
-            for lid, kind in enumerate(args.indexer_types[: config.num_layers]):
+            for lid, kind in enumerate(indexer_types[: config.num_layers]):
                 if kind == "full":
                     lead = lid
                     self._idx_slot[lid] = len(self._idx_slot)
@@ -113,7 +122,7 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         self._rows_buf: torch.Tensor | None = None
         self._kvlen_buf: torch.Tensor | None = None
         self.max_seq_len = 0
-        self.capture_bs: List[int] = []
+        self.capture_bs: list[int] = []
 
     def forward(self, q, k, v, layer_id, batch, attn_spec: AttentionSpec | None = None):
         raise NotImplementedError("MLA models use mla_forward(), not forward().")
@@ -128,7 +137,9 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         # active_table_idx (which the decode path's addressing requires) for
         # phase == "decode". The prefill path handles extend_len == 1 fine.
         is_decode = getattr(batch, "phase", None) == "decode"
-        qo_indptr = torch.tensor([0] + seqlens_q, **_CPU_PINNED).cumsum_(0).to(torch.int32)
+        qo_indptr = (
+            torch.tensor([0] + seqlens_q, **_CPU_PINNED).cumsum_(0).to(torch.int32)
+        )
         kv_len = torch.tensor(seqlens_k, **_CPU_PINNED)
         last = (qo_indptr[1:].to(torch.int32) - 1).to(self.device, non_blocking=True)
         md = DSAMetadata(
@@ -151,8 +162,12 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         from freetoken.kernel.triton.glm_dsa_sparse import glm_dsa_sparse_attn
 
         return glm_dsa_sparse_attn(
-            q_cat, self.kvcache.latent_rows(layer_id), sel, self.sm_scale,
-            counts=cnt, d_v=self.kv_lora_rank,
+            q_cat,
+            self.kvcache.latent_rows(layer_id),
+            sel,
+            self.sm_scale,
+            counts=cnt,
+            d_v=self.kv_lora_rank,
         )
 
     def mla_forward(
@@ -177,7 +192,9 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         if self.dsa_enabled and indexer_qkw is not None:
             # Scatter index keys unconditionally: short prefills serve through the
             # identity path TODAY, but their keys must exist once decode passes topk.
-            self.kvcache.store_index_k(indexer_qkw[1], batch.out_loc, self._idx_slot[layer_id])
+            self.kvcache.store_index_k(
+                indexer_qkw[1], batch.out_loc, self._idx_slot[layer_id]
+            )
 
         if md.is_decode:
             return self._decode(md, layer_id, q_nope, q_pe, indexer_qkw)
@@ -194,7 +211,9 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         else:
             if indexer_qkw is not None:
                 q_idx, _, w = indexer_qkw
-                s = self.dsa_decode_scores(q_idx, w, self._idx_slot[layer_id], rows, kvlen)
+                s = self.dsa_decode_scores(
+                    q_idx, w, self._idx_slot[layer_id], rows, kvlen
+                )
                 k_sel = min(self.index_topk, s.shape[-1])
                 picks = self.indexer_select_decode(
                     s.view(bs, 1, -1), valid=kvlen, topk=k_sel, offset=0
@@ -205,15 +224,21 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
                 md.sel.clear()
                 md.sel[layer_id] = (sel, cnt)
             sel, cnt = md.sel[self._leader[layer_id]]
-        q_cat = torch.cat([q_nope, q_pe], dim=-1).view(bs, 1, self.num_heads, self.latent_dim)
+        q_cat = torch.cat([q_nope, q_pe], dim=-1).view(
+            bs, 1, self.num_heads, self.latent_dim
+        )
         o = self._attend(q_cat, layer_id, sel, cnt)
         return o.view(bs, self.num_heads, self.kv_lora_rank)
 
     # ----- prefill / extend (eager) ------------------------------------------------------
     def _select_prefill(
-        self, slot: int, q_idx: torch.Tensor, w: torch.Tensor,
-        rows: torch.Tensor, positions: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self,
+        slot: int,
+        q_idx: torch.Tensor,
+        w: torch.Tensor,
+        rows: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Per-request causal top-k: ([1, m, K] physical rows, [1, m] counts)."""
         kv_len = rows.numel()
         k_all = self.kvcache.index_k_cache(slot).index_select(0, rows.long())
@@ -223,14 +248,20 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         start_pos = int(positions[0])
         # Bound the fp32 [chunk, kv_len] logits transient (worst case is capped by the
         # model's max_position: floor 16 x 1M x 4 B = 64 MB, see _PREFILL_SCORE_BYTES).
-        chunk = max(16, min(_PREFILL_SCORE_CHUNK, _PREFILL_SCORE_BYTES // max(kv_len * 4, 1)))
+        chunk = max(
+            16, min(_PREFILL_SCORE_CHUNK, _PREFILL_SCORE_BYTES // max(kv_len * 4, 1))
+        )
         for s0 in range(0, m, chunk):
             s1 = min(s0 + chunk, m)
             scores = self.dsa_prefill_logits(q_idx[s0:s1], k_all, w[s0:s1])
             # Shared selection semantics (dsv4_indexer): token-granular == ratio 1.
             picks = self.indexer_select_prefill(
-                scores.unsqueeze(0), start_pos=start_pos + s0, seqlen=s1 - s0,
-                ratio=1, topk=k_sel, offset=0,
+                scores.unsqueeze(0),
+                start_pos=start_pos + s0,
+                seqlen=s1 - s0,
+                ratio=1,
+                topk=k_sel,
+                offset=0,
             )[0]
             sel[s0:s1] = self.dsa_map_rows(picks, rows.view(1, -1).expand(s1 - s0, -1))
         cnt = torch.clamp(positions + 1, max=k_sel).to(torch.int32)
@@ -249,7 +280,8 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
             md.sel[layer_id] = [
                 self._select_prefill(
                     self._idx_slot[layer_id],
-                    q_idx[qo[i] : qo[i + 1]], w[qo[i] : qo[i + 1]],
+                    q_idx[qo[i] : qo[i + 1]],
+                    w[qo[i] : qo[i + 1]],
                     page_table[r.table_idx, : r.device_len],
                     batch.positions[qo[i] : qo[i + 1]],
                 )
@@ -267,34 +299,50 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
                 # token at kv <= index_topk, and the ablation attends everything).
                 # One shared row list broadcast across queries (stride 0), causality
                 # through per-query counts.
-                sel = page_table[r.table_idx, : r.device_len].view(1, 1, -1).to(torch.int32)
-                cnt = (batch.positions[qo[i] : qo[i + 1]] + 1).to(torch.int32).view(1, m)
+                sel = (
+                    page_table[r.table_idx, : r.device_len]
+                    .view(1, 1, -1)
+                    .to(torch.int32)
+                )
+                cnt = (
+                    (batch.positions[qo[i] : qo[i + 1]] + 1).to(torch.int32).view(1, m)
+                )
             o[qo[i] : qo[i + 1]] = self._attend(
                 q_cat[qo[i] : qo[i + 1]].view(1, m, self.num_heads, self.latent_dim),
-                layer_id, sel, cnt,
+                layer_id,
+                sel,
+                cnt,
             ).view(m, self.num_heads, self.kv_lora_rank)
         return o
 
     # ----- CUDA graph (decode) ----------------------------------------------------------
-    def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
+    def init_capture_graph(self, max_seq_len: int, bs_list: list[int]) -> None:
         self.max_seq_len = max_seq_len
         self.capture_bs = sorted(bs_list)
         max_bs = max(bs_list)
         width = get_global_ctx().page_table.shape[1]
-        self._rows_buf = torch.full((max_bs, width), -1, dtype=torch.int32, device=self.device)
+        self._rows_buf = torch.full(
+            (max_bs, width), -1, dtype=torch.int32, device=self.device
+        )
         self._kvlen_buf = torch.zeros(max_bs, dtype=torch.int32, device=self.device)
 
     def _decode_rows(self, batch: Batch) -> torch.Tensor:
         """This decode step's per-request page-table rows [bs, W], gathered off the
         scheduler-staged ``active_table_idx`` (a device tensor -- no host loop)."""
-        assert batch.active_table_idx is not None, "decode batch is missing its page-table rows"
-        return get_global_ctx().page_table.index_select(0, batch.active_table_idx.to(torch.int64))
+        assert batch.active_table_idx is not None, (
+            "decode batch is missing its page-table rows"
+        )
+        return get_global_ctx().page_table.index_select(
+            0, batch.active_table_idx.to(torch.int64)
+        )
 
     def _stage_decode(self, batch: Batch, bs: int, table_idx: torch.Tensor) -> None:
         """Copy this step's addressing into the static graph buffers and point the
         metadata at them (restage-per-replay, same shape as the generic backends)."""
         md = batch.attn_metadata
-        self._rows_buf[:bs].copy_(get_global_ctx().page_table.index_select(0, table_idx))
+        self._rows_buf[:bs].copy_(
+            get_global_ctx().page_table.index_select(0, table_idx)
+        )
         self._kvlen_buf[:bs].copy_(md.kv_len_cpu.to(self.device, non_blocking=True))
         md.rows = self._rows_buf[:bs]
         md.kvlen = self._kvlen_buf[:bs]
@@ -311,7 +359,9 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         self._stage_decode(batch, bs, dummy)
 
     def prepare_for_replay(self, batch: Batch) -> None:
-        assert batch.active_table_idx is not None, "decode batch is missing its page-table rows"
+        assert batch.active_table_idx is not None, (
+            "decode batch is missing its page-table rows"
+        )
         self._stage_decode(
             batch, batch.padded_size, batch.active_table_idx.to(torch.int64)
         )

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -420,6 +420,7 @@ class Engine:
             vocab_size=config.model_config.vocab_size,
             dummy_req=self.dummy_req,
             moe_offload_cache=self.moe_offload_cache,
+            moe_top_k=config.model_config.num_experts_per_tok,
         )
         if config.attention_backend.split(",")[0] == "triton":
             # Prefill runs on the first comma part; warm its autotune cache.
@@ -913,6 +914,7 @@ class Engine:
             vocab_size=config.model_config.vocab_size,
             dummy_req=self.dummy_req,
             moe_offload_cache=self.moe_offload_cache,
+            moe_top_k=config.model_config.num_experts_per_tok,
         )
 
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
@@ -1287,10 +1289,18 @@ def _adjust_config(config: EngineConfig):
             override("cache_type", "swa_radix")
 
     if has_linear_attention:
-        override(
-            "cache_type",
-            _resolve_cache_type(True, getattr(config, "cache_type", "radix")),
-        )
+        if not getattr(model_config, "supports_hybrid_radix", True):
+            if getattr(config, "cache_type", "radix") != "naive":
+                logger.warning_rank0(
+                    f"{getattr(model_config, 'model_type', 'model')} does not support "
+                    "linear-state radix snapshots yet; using cache_type='naive'."
+                )
+            override("cache_type", "naive")
+        else:
+            override(
+                "cache_type",
+                _resolve_cache_type(True, getattr(config, "cache_type", "radix")),
+            )
 
     # Type x backend capability matrix: resolve auto from the per-type priority
     # lists, then validate whatever is now selected (explicit or auto) -- every

--- a/python/freetoken/engine/graph.py
+++ b/python/freetoken/engine/graph.py
@@ -69,22 +69,33 @@ def _determine_cuda_graph_bs(
     cuda_graph_bs: List[int] | None,
     cuda_graph_max_bs: int | None,
     free_memory: int,
+    moe_cache_size: int | None = None,
+    moe_top_k: int = 0,
 ) -> List[int]:
     if cuda_graph_bs is not None:
-        return cuda_graph_bs
+        candidates = cuda_graph_bs
+    else:
+        free_memory_gb = free_memory / (1 << 30)
+        if cuda_graph_max_bs is None:
+            if free_memory_gb > 80:  # H200
+                cuda_graph_max_bs = 256
+            else:
+                cuda_graph_max_bs = 160
 
-    free_memory_gb = free_memory / (1 << 30)
-    if cuda_graph_max_bs is None:
-        if free_memory_gb > 80:  # H200
-            cuda_graph_max_bs = 256
-        else:
-            cuda_graph_max_bs = 160
+        if cuda_graph_max_bs < 1:
+            return []
 
-    if cuda_graph_max_bs < 1:
-        return []
+        candidates = [1, 2, 4] + list(range(8, cuda_graph_max_bs + 1, 8))
+        candidates = [bs for bs in candidates if bs <= cuda_graph_max_bs]
 
-    candidates = [1, 2, 4] + list(range(8, cuda_graph_max_bs + 1, 8))
-    return [bs for bs in candidates if bs <= cuda_graph_max_bs]
+    if moe_cache_size is not None and moe_top_k > 0:
+        # flashlib validates K>cache by calling torch.unique. That debug guard is
+        # correct in eager mode but is not CUDA-graph capturable. Every individual
+        # MoE layer owns at most num_experts distinct ids and the offload cache has
+        # at least that many slots, so larger batches remain valid eager forwards;
+        # omit only graph shapes whose padded routing rows cross the cache size.
+        candidates = [bs for bs in candidates if bs * moe_top_k <= moe_cache_size]
+    return candidates
 
 
 def get_free_memory(device: torch.device) -> int:
@@ -105,11 +116,16 @@ class GraphRunner:
         vocab_size: int,
         dummy_req: Req,
         moe_offload_cache: OffloadMoeCache | None = None,
+        moe_top_k: int = 0,
     ) -> None:
         cuda_graph_bs = _determine_cuda_graph_bs(
             cuda_graph_bs=cuda_graph_bs,
             cuda_graph_max_bs=cuda_graph_max_bs,
             free_memory=free_memory,
+            moe_cache_size=(
+                moe_offload_cache.cache_size if moe_offload_cache is not None else None
+            ),
+            moe_top_k=moe_top_k,
         )
         self.attn_backend = attn_backend
         self.max_graph_bs = max(cuda_graph_bs) if cuda_graph_bs else 0

--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -70,8 +70,14 @@ inline bf16_t f32_to_bf16(float f) {
 // ACT_SWIGLUOAI is the clamped (up + 1) swiglu (gpt-oss "swigluoai" /
 // MiniMax-M3): gate/up are combined jointly with the runtime alpha/limit
 // scalars, so it is handled in the do_pass1 epilogue (act_apply never sees it;
-// the mxfp4 kernel additionally fuses its own copy of the same math).
-enum ActKind { ACT_SILU = 0, ACT_GELU = 1, ACT_GELU_TANH = 2, ACT_SWIGLUOAI = 3 };
+// the mxfp4 kernel additionally fuses activation-specific math).
+enum ActKind {
+  ACT_SILU = 0,
+  ACT_GELU = 1,
+  ACT_GELU_TANH = 2,
+  ACT_SWIGLUOAI = 3,
+  ACT_SITU = 4,
+};
 
 inline float act_apply(int act, float x) {
   if (act == ACT_SILU) return x / (1.0f + std::exp(-x));
@@ -1605,6 +1611,7 @@ struct CpuMoeExecutor {
     const int i0 = static_cast<int>(ib) * IBLK;
     const int i1 = std::min(I, i0 + IBLK);
     const bool swigluoai = act == ACT_SWIGLUOAI;
+    const bool situ = act == ACT_SITU;
     const float lim = swiglu_limit, alpha = swiglu_alpha;
     for (int i = i0; i < i1; ++i) {
       // gate = row i, up = row I+i
@@ -1620,6 +1627,13 @@ struct CpuMoeExecutor {
         else if (up < -lim) up = -lim;
         const float glu = gate / (1.0f + std::exp(-gate * alpha));
         g_row[i] = f32_to_bf16(glu * (up + 1.0f));
+      } else if (situ) {
+        // Kimi-K3 SiTU. The executor's two activation scalars carry beta and
+        // linear_beta for this activation (4 and 25 in the public checkpoint).
+        const float gate_situ = alpha * std::tanh(gate / alpha) /
+                                (1.0f + std::exp(-gate));
+        const float up_situ = lim * std::tanh(up / lim);
+        g_row[i] = f32_to_bf16(gate_situ * up_situ);
       } else {
         g_row[i] = f32_to_bf16(act_apply(act, gate) * up);
       }
@@ -1667,7 +1681,7 @@ struct CpuMoeExecutor {
     }
   }
 
-  // ----------------------------- mxfp4 (gpt-oss) -----------------------------
+  // ----------------------------- mxfp4 ---------------------------------------
   // Transposed split-K layout (N innermost), so the GEMV streams K and accumulates
   // a contiguous block of N output columns -> cache-line-efficient, no repack, no
   // extra host memory. Pass 1 fuses gate_up + clamped-swiglu(+bias); pass 2 fuses
@@ -1705,11 +1719,18 @@ struct CpuMoeExecutor {
     for (int j = 0; j < nunit; ++j) {
       float gate = gu[2 * j] + bf16_to_f32(bias_e[2 * j]);
       float up = gu[2 * j + 1] + bf16_to_f32(bias_e[2 * j + 1]);
-      if (gate > lim) gate = lim;
-      if (up > lim) up = lim;
-      else if (up < -lim) up = -lim;
-      const float glu = gate / (1.0f + std::exp(-gate * alpha));  // gate * sigmoid(alpha*gate)
-      g_row[i0 + j] = f32_to_bf16(glu * (up + 1.0f));
+      if (act == ACT_SITU) {
+        const float gate_situ = alpha * std::tanh(gate / alpha) /
+                                (1.0f + std::exp(-gate));
+        const float up_situ = lim * std::tanh(up / lim);
+        g_row[i0 + j] = f32_to_bf16(gate_situ * up_situ);
+      } else {
+        if (gate > lim) gate = lim;
+        if (up > lim) up = lim;
+        else if (up < -lim) up = -lim;
+        const float glu = gate / (1.0f + std::exp(-gate * alpha));
+        g_row[i0 + j] = f32_to_bf16(glu * (up + 1.0f));
+      }
     }
   }
 
@@ -2143,8 +2164,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // ABI capability marker: the highest ActKind this build implements in the
   // GENERIC epilogue. CpuMoeExecutor.__init__ probes it before requesting an act
   // id the epilogue must handle -- a prebuilt .so from before ACT_SWIGLUOAI
-  // accepts id 3 without error and silently computes the wrong activation
+  // accepts newer ids without error and silently computes the wrong activation
   // (act_apply falls through to gelu_tanh); the probe turns a stale extension
   // into a loud rebuild instruction instead of wrong model outputs.
-  m.def("max_generic_act_id", []() { return static_cast<int>(ACT_SWIGLUOAI); });
+  m.def("max_generic_act_id", []() { return static_cast<int>(ACT_SITU); });
 }

--- a/python/freetoken/kernel/triton/activation.py
+++ b/python/freetoken/kernel/triton/activation.py
@@ -18,10 +18,9 @@ import functools
 import torch
 import triton
 import triton.language as tl
-from triton.language.extra import libdevice
-from triton.language.extra.cuda import gdc_wait, gdc_launch_dependents
-
 from freetoken.utils.arch import is_sm90_supported
+from triton.language.extra import libdevice
+from triton.language.extra.cuda import gdc_launch_dependents, gdc_wait
 
 SILU = 0
 GELU = 1
@@ -31,6 +30,12 @@ GELU_TANH = 2
 # variant lives in triton/mxfp4_moe.py):
 #   y = clamp(gate, max=limit) * sigmoid(alpha * gate) * (clamp(up, +-limit) + 1)
 SWIGLUOAI = 3
+# Kimi-K3 SiTU over un-interleaved gate/up halves:
+#   beta*tanh(gate/beta)*sigmoid(gate) * linear_beta*tanh(up/linear_beta)
+# The public checkpoint fixes beta=4 and linear_beta=25. They are runtime scalars
+# here so the model adapter can validate the checkpoint and the kernel can remain
+# independently testable.
+SITU = 4
 
 _SQRT_2_OVER_PI = 0.7978845608028654  # sqrt(2/pi)
 _GELU_C = 0.044715
@@ -50,8 +55,12 @@ def _pdl_supported() -> bool:
 def _fast_tanh(x):
     # PTX tanh.approx.f32 — single HW op, matches flashinfer math::tanh.
     return tl.inline_asm_elementwise(
-        "tanh.approx.f32 $0, $1;", "=f,f", [x],
-        dtype=tl.float32, is_pure=True, pack=1,
+        "tanh.approx.f32 $0, $1;",
+        "=f,f",
+        [x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
     )
 
 
@@ -59,8 +68,12 @@ def _fast_tanh(x):
 def _fast_ex2(x):
     # PTX ex2.approx.f32 — matches __expf fast path used by flashinfer silu.
     return tl.inline_asm_elementwise(
-        "ex2.approx.f32 $0, $1;", "=f,f", [x],
-        dtype=tl.float32, is_pure=True, pack=1,
+        "ex2.approx.f32 $0, $1;",
+        "=f,f",
+        [x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
     )
 
 
@@ -105,6 +118,11 @@ def _act_and_mul_kernel(
         up = tl.minimum(tl.maximum(up, -limit), limit)
         act = gate / (1.0 + _fast_ex2(-gate * alpha * _LOG2E))
         y = act * (up + 1.0)
+    elif ACT == 4:  # SiTU (Kimi-K3)
+        gate_situ = alpha * _fast_tanh(gate / alpha)
+        gate_situ *= 1.0 / (1.0 + _fast_ex2(-gate * _LOG2E))
+        up_situ = limit * _fast_tanh(up / limit)
+        y = gate_situ * up_situ
     else:  # GELU (erf)
         act = 0.5 * gate * (1.0 + libdevice.erf(gate * 0.7071067811865476))
         y = act * up
@@ -134,8 +152,17 @@ def _act_and_mul(
     block_d = min(triton.next_power_of_2(d), 1024 if M >= 4096 else 512)
     num_stages = 2 if block_d == 1024 else 3
     _act_and_mul_kernel[grid](
-        o2, x2, d, alpha, limit, ACT=kind, ENABLE_PDL=pdl, launch_pdl=pdl,
-        BLOCK_D=block_d, num_warps=4, num_stages=num_stages,
+        o2,
+        x2,
+        d,
+        alpha,
+        limit,
+        ACT=kind,
+        ENABLE_PDL=pdl,
+        launch_pdl=pdl,
+        BLOCK_D=block_d,
+        num_warps=4,
+        num_stages=num_stages,
     )
     return out
 
@@ -166,4 +193,23 @@ def swigluoai_and_mul(
     return _act_and_mul(SWIGLUOAI, x, out, alpha=alpha, limit=limit)
 
 
-__all__ = ["silu_and_mul", "gelu_and_mul", "gelu_tanh_and_mul", "swigluoai_and_mul"]
+def situ_and_mul(
+    x: torch.Tensor,
+    out: torch.Tensor | None = None,
+    *,
+    beta: float = 4.0,
+    linear_beta: float = 25.0,
+) -> torch.Tensor:
+    """Kimi-K3 SiTU over un-interleaved ``gate | up`` halves."""
+    if beta <= 0 or linear_beta <= 0:
+        raise ValueError("SiTU beta values must be positive")
+    return _act_and_mul(SITU, x, out, alpha=beta, limit=linear_beta)
+
+
+__all__ = [
+    "gelu_and_mul",
+    "gelu_tanh_and_mul",
+    "silu_and_mul",
+    "situ_and_mul",
+    "swigluoai_and_mul",
+]

--- a/python/freetoken/kernel/triton/mxfp4_moe.py
+++ b/python/freetoken/kernel/triton/mxfp4_moe.py
@@ -1,7 +1,6 @@
 import triton
 import triton.language as tl
 
-
 # ── Split-K expert GEMV (transposed weight layout [E, K_bytes, N]) ──────────
 # The MXFP4 MoE decode/prefill at small token counts is a memory-bound GEMV per
 # (route, expert); splitting the K
@@ -105,7 +104,9 @@ def mxfp4_splitk_reduce_kernel(
     acc = tl.zeros([BLOCK_N], dtype=tl.float32)
     for k in range(NUM_K_SPLITS):
         acc += tl.load(
-            partial_ptr + (pid_e * NUM_K_SPLITS + k) * N + offs_n, mask=mask_n, other=0.0
+            partial_ptr + (pid_e * NUM_K_SPLITS + k) * N + offs_n,
+            mask=mask_n,
+            other=0.0,
         )
     if HAS_EXPERT_WTS:
         acc *= ewt
@@ -218,6 +219,9 @@ def mxfp4_fused_moe_kernel(
             mask=(offs_n[None, :] < N) & (k_offsets[:, None] < K),
             other=127,
         )
+        # 0xff is reserved by E8M0. Keep this grouped path bit-contract aligned
+        # with split-K and the CPU executor, both of which clamp to 254.
+        scale_u8 = tl.minimum(scale_u8.to(tl.int32), 254)
         scale = tl.exp2(scale_u8.to(tl.float32) - 127.0)
         b = (_dequant_fp4_lut(nibble) * scale).to(compute_type)
 
@@ -232,7 +236,9 @@ def mxfp4_fused_moe_kernel(
     accumulator += bias[None, :]
 
     if MUL_ROUTED_WEIGHT:
-        route_weight = tl.load(topk_weights_ptr + offs_route, mask=route_mask, other=0.0)
+        route_weight = tl.load(
+            topk_weights_ptr + offs_route, mask=route_mask, other=0.0
+        )
         accumulator *= route_weight[:, None]
 
     c_ptrs = c_ptr + stride_cm * offs_route[:, None] + stride_cn * offs_n[None, :]
@@ -329,4 +335,3 @@ def gpt_oss_routing_kernel(
     out_off = token_id * K + offs_e
     tl.store(topk_weights_ptr + out_off, weights, mask=top_mask)
     tl.store(topk_ids_ptr + out_off, all_ids, mask=top_mask)
-

--- a/python/freetoken/kvcache/__init__.py
+++ b/python/freetoken/kvcache/__init__.py
@@ -219,6 +219,7 @@ def create_kvcache_pool(
                 device=device,
                 index_head_dim=spec.index_head_dim,
                 num_index_layers=spec.num_index_layers,
+                layer_ids=spec.layer_ids,
             )
         return MLAKVCache(
             latent_dim=spec.head_dim,
@@ -227,6 +228,7 @@ def create_kvcache_pool(
             page_size=page_size,
             dtype=dtype,
             device=device,
+            layer_ids=spec.layer_ids,
         )
 
     return MHAKVCache(

--- a/python/freetoken/kvcache/dsa_pool.py
+++ b/python/freetoken/kvcache/dsa_pool.py
@@ -17,6 +17,8 @@ bytes off the attention-group spec) stay correct by construction.
 
 from __future__ import annotations
 
+from typing import Sequence
+
 import torch
 
 from .base import BaseKVCachePool
@@ -37,9 +39,23 @@ class MLAKVCache(BaseKVCachePool):
         page_size: int,
         dtype: torch.dtype,
         device: torch.device,
+        layer_ids: Sequence[int] | None = None,
     ) -> None:
         self._latent_dim = latent_dim
         self._num_layers = num_layers
+        if layer_ids is None:
+            self._num_storage_layers = num_layers
+            self._layer_map: list[int] | None = None
+        else:
+            self._num_storage_layers = len(layer_ids)
+            layer_map = [-1] * num_layers
+            for dense, global_id in enumerate(layer_ids):
+                if global_id < 0 or global_id >= num_layers:
+                    raise ValueError(
+                        f"KV layer id {global_id} outside [0, {num_layers})"
+                    )
+                layer_map[global_id] = dense
+            self._layer_map = layer_map
         self._page_size = page_size
         self._dtype = dtype
         self._device = device
@@ -48,15 +64,32 @@ class MLAKVCache(BaseKVCachePool):
     def _alloc(self, num_pages: int) -> None:
         self._num_pages = num_pages
         self._kv_buffer = torch.empty(
-            (1, self._num_layers, num_pages, self._page_size, 1, self._latent_dim),
+            (
+                1,
+                self._num_storage_layers,
+                num_pages,
+                self._page_size,
+                1,
+                self._latent_dim,
+            ),
             device=self._device,
             dtype=self._dtype,
         )
 
     # -- views ------------------------------------------------------------------
+    def _dense(self, layer_id: int) -> int:
+        if self._layer_map is None:
+            return layer_id
+        dense = self._layer_map[layer_id]
+        if dense < 0:
+            raise KeyError(f"layer {layer_id} has no paged KV storage")
+        return dense
+
     def k_cache(self, layer_id: int) -> torch.Tensor:
         """Paged latent view ``[num_pages, page_size, latent_dim]``."""
-        return self._kv_buffer[0, layer_id].view(self._num_pages, self._page_size, -1)
+        return self._kv_buffer[0, self._dense(layer_id)].view(
+            self._num_pages, self._page_size, -1
+        )
 
     def v_cache(self, layer_id: int) -> torch.Tensor:
         # MLA: K == V (single latent); same buffer, dsv4_paged_pool precedent.
@@ -64,7 +97,7 @@ class MLAKVCache(BaseKVCachePool):
 
     def latent_rows(self, layer_id: int) -> torch.Tensor:
         """Row-flat latent view ``[num_pages * page_size, latent_dim]``."""
-        return self._kv_buffer[0, layer_id].view(-1, self._latent_dim)
+        return self._kv_buffer[0, self._dense(layer_id)].view(-1, self._latent_dim)
 
     # -- writes -----------------------------------------------------------------
     def store_kv(
@@ -141,10 +174,19 @@ class DSAKVCache(MLAKVCache):
         device: torch.device,
         index_head_dim: int,
         num_index_layers: int,
+        layer_ids: Sequence[int] | None = None,
     ) -> None:
         self._index_head_dim = index_head_dim
         self._num_index_layers = num_index_layers
-        super().__init__(latent_dim, num_layers, num_pages, page_size, dtype, device)
+        super().__init__(
+            latent_dim,
+            num_layers,
+            num_pages,
+            page_size,
+            dtype,
+            device,
+            layer_ids,
+        )
 
     def _alloc(self, num_pages: int) -> None:
         # Both slabs in one allocation step: rebuild can never leave the pool with a

--- a/python/freetoken/models/config.py
+++ b/python/freetoken/models/config.py
@@ -316,9 +316,18 @@ class ModelConfig:
     # n-gram embedding geometry and the QSA indexer scoring geometry the model module
     # needs. Opaque to model-agnostic engine code; None for every other model.
     qwen4_args: Any | None = None
+    # Kimi-K3 (kimi_linear) payload. This records the mixed KDA/MLA layer map,
+    # latent-routed-expert geometry, SiTU constants, and attention residual block
+    # size. Keeping it explicit prevents a superficially similar Qwen/GLM config
+    # from being accepted and producing plausible-looking but invalid output.
+    kimi_k3_args: Any | None = None
     # Generic execution-path capability flags (set by a model's parse_config) so the engine and
     # factories stay model-agnostic instead of branching on dsv4_args:
     single_stream_only: bool = False  # model runs one sequence at a time -> force bs=1
+    # Linear-attention implementations opt out until they can snapshot recurrent
+    # state at radix chunk boundaries. The engine then selects the correct naive
+    # cache instead of failing on the first real prompt.
+    supports_hybrid_radix: bool = True
     # Extra per-request tensors riding the LinearStatePool slots (see SlotStateSpec);
     # () for models without any. Requires a linear-attention group to ride on.
     slot_states: Tuple[SlotStateSpec, ...] = ()

--- a/python/freetoken/models/kimi_k3/__init__.py
+++ b/python/freetoken/models/kimi_k3/__init__.py
@@ -1,0 +1,15 @@
+from .args import KimiK3Args, load_args
+from .config import detect_kimi_mxfp4, parse_config
+from .model import KimiK3ForCausalLM, KimiK3Model
+from .weight import iter_weights, setup_offload_expert_banks
+
+__all__ = [
+    "KimiK3Args",
+    "KimiK3ForCausalLM",
+    "KimiK3Model",
+    "detect_kimi_mxfp4",
+    "iter_weights",
+    "load_args",
+    "parse_config",
+    "setup_offload_expert_banks",
+]

--- a/python/freetoken/models/kimi_k3/__init__.py
+++ b/python/freetoken/models/kimi_k3/__init__.py
@@ -1,7 +1,11 @@
 from .args import KimiK3Args, load_args
 from .config import detect_kimi_mxfp4, parse_config
 from .model import KimiK3ForCausalLM, KimiK3Model
-from .weight import iter_weights, setup_offload_expert_banks
+from .weight import (
+    iter_weights,
+    load_mxfp4_expert_banks_parallel,
+    setup_offload_expert_banks,
+)
 
 __all__ = [
     "KimiK3Args",
@@ -9,6 +13,7 @@ __all__ = [
     "KimiK3Model",
     "detect_kimi_mxfp4",
     "iter_weights",
+    "load_mxfp4_expert_banks_parallel",
     "load_args",
     "parse_config",
     "setup_offload_expert_banks",

--- a/python/freetoken/models/kimi_k3/args.py
+++ b/python/freetoken/models/kimi_k3/args.py
@@ -1,0 +1,151 @@
+"""Validated Kimi-K3 text-tower geometry.
+
+The public checkpoint numbers its ``linear_attn_config`` layer lists from one.
+FreeToken numbers decoder layers from zero, so conversion happens once here and
+the normalized tuples are shared by config, model, cache, and weight loading.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+def _value(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+@dataclass(frozen=True)
+class KimiK3Args:
+    hidden_size: int
+    num_heads: int
+    num_kv_heads: int
+    num_layers: int
+    q_lora_rank: int
+    kv_lora_rank: int
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    kda_num_heads: int
+    kda_head_dim: int
+    kda_conv_kernel: int
+    kda_gate_lower_bound: float | None
+    kda_full_rank_gate: bool
+    kda_layer_ids: tuple[int, ...]
+    mla_layer_ids: tuple[int, ...]
+    routed_expert_hidden_size: int
+    latent_moe_use_norm: bool
+    situ_beta: float
+    situ_linear_beta: float
+    attn_res_block_size: int
+    mla_use_nope: bool
+    mla_use_output_gate: bool
+
+    @property
+    def qk_head_dim(self) -> int:
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+    @property
+    def mla_latent_dim(self) -> int:
+        return self.kv_lora_rank + self.qk_rope_head_dim
+
+
+def _zero_based_layers(raw: Any, *, key: str, num_layers: int) -> tuple[int, ...]:
+    values = tuple(int(x) for x in (raw or ()))
+    if not values:
+        raise ValueError(f"Kimi-K3 linear_attn_config.{key} is empty")
+    if min(values) < 1 or max(values) > num_layers:
+        raise ValueError(
+            f"Kimi-K3 {key} must use one-based layer ids in [1, {num_layers}], "
+            f"got [{min(values)}, {max(values)}]"
+        )
+    if len(values) != len(set(values)):
+        raise ValueError(f"Kimi-K3 {key} contains duplicate layer ids")
+    return tuple(x - 1 for x in values)
+
+
+def load_args(text: Any) -> KimiK3Args:
+    num_layers = int(_value(text, "num_hidden_layers"))
+    linear = _value(text, "linear_attn_config") or {}
+    kda_ids = _zero_based_layers(
+        _value(linear, "kda_layers"), key="kda_layers", num_layers=num_layers
+    )
+    mla_ids = _zero_based_layers(
+        _value(linear, "full_attn_layers"),
+        key="full_attn_layers",
+        num_layers=num_layers,
+    )
+    if set(kda_ids) & set(mla_ids):
+        raise ValueError("Kimi-K3 KDA and MLA layer sets overlap")
+    if set(kda_ids) | set(mla_ids) != set(range(num_layers)):
+        missing = sorted(set(range(num_layers)) - set(kda_ids) - set(mla_ids))
+        raise ValueError(
+            f"Kimi-K3 attention layer map is incomplete; missing {missing}"
+        )
+
+    args = KimiK3Args(
+        hidden_size=int(_value(text, "hidden_size")),
+        num_heads=int(_value(text, "num_attention_heads")),
+        num_kv_heads=int(_value(text, "num_key_value_heads")),
+        num_layers=num_layers,
+        q_lora_rank=int(_value(text, "q_lora_rank")),
+        kv_lora_rank=int(_value(text, "kv_lora_rank")),
+        qk_nope_head_dim=int(_value(text, "qk_nope_head_dim")),
+        qk_rope_head_dim=int(_value(text, "qk_rope_head_dim")),
+        v_head_dim=int(_value(text, "v_head_dim")),
+        kda_num_heads=int(_value(linear, "num_heads")),
+        kda_head_dim=int(_value(linear, "head_dim")),
+        kda_conv_kernel=int(_value(linear, "short_conv_kernel_size")),
+        kda_gate_lower_bound=(
+            None
+            if _value(linear, "gate_lower_bound") is None
+            else float(_value(linear, "gate_lower_bound"))
+        ),
+        kda_full_rank_gate=bool(_value(linear, "use_full_rank_gate")),
+        kda_layer_ids=kda_ids,
+        mla_layer_ids=mla_ids,
+        routed_expert_hidden_size=int(_value(text, "routed_expert_hidden_size")),
+        latent_moe_use_norm=bool(_value(text, "latent_moe_use_norm")),
+        situ_beta=float(_value(text, "activation_situ_beta")),
+        situ_linear_beta=float(_value(text, "activation_situ_linear_beta")),
+        attn_res_block_size=int(_value(text, "attn_res_block_size")),
+        mla_use_nope=bool(_value(text, "mla_use_nope")),
+        mla_use_output_gate=bool(_value(text, "mla_use_output_gate")),
+    )
+
+    # These are kernel contracts, not merely model-card metadata. Fail a future
+    # checkpoint variant before allocating its weights.  The second geometry is
+    # the small Kimi-K3 development checkpoint published by
+    # inference-optimization; it exercises the same KDA/MLA and latent-MoE paths
+    # without requiring the full model's multi-terabyte host.
+    if args.kda_num_heads != args.num_heads or args.num_kv_heads != args.num_heads:
+        raise ValueError("Kimi-K3 support requires independent KDA/attention heads")
+    supported_geometries = {
+        (93, 7168, 96, 128, 12, 3584),
+        (8, 1024, 8, 32, 4, 512),
+    }
+    geometry = (
+        args.num_layers,
+        args.hidden_size,
+        args.num_heads,
+        args.kda_head_dim,
+        args.attn_res_block_size,
+        args.routed_expert_hidden_size,
+    )
+    if geometry not in supported_geometries:
+        raise ValueError(f"unsupported Kimi-K3 kernel geometry: {geometry}")
+    if args.kda_conv_kernel != 4:
+        raise ValueError("Kimi-K3 KDA kernels require conv kernel=4")
+    if not args.kda_full_rank_gate:
+        raise ValueError("Kimi-K3 support requires the full-rank KDA gate")
+    if not args.mla_use_nope or not args.mla_use_output_gate:
+        raise ValueError("Kimi-K3 support requires NoPE MLA with its output gate")
+    if (args.situ_beta, args.situ_linear_beta) != (4.0, 25.0):
+        raise ValueError("Kimi-K3 SiTU kernels require beta=4 and linear_beta=25")
+    return args
+
+
+__all__ = ["KimiK3Args", "load_args"]

--- a/python/freetoken/models/kimi_k3/attention.py
+++ b/python/freetoken/models/kimi_k3/attention.py
@@ -1,0 +1,309 @@
+"""Kimi-K3 text-tower mixers: NoPE MLA and Kimi Delta Attention (KDA)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from freetoken.core import get_global_ctx
+from freetoken.kernel.causal_conv1d import causal_conv1d_decode, causal_conv1d_varlen
+from freetoken.layers import BaseOP, LinearReplicated, RMSNorm
+from freetoken.utils import nvtx_annotate
+
+if TYPE_CHECKING:
+    from freetoken.models.config import ModelConfig
+
+
+class _DepthwiseConv1d(BaseOP):
+    """Checkpoint-compatible FLA ShortConvolution weight holder."""
+
+    def __init__(self, channels: int, kernel_size: int):
+        # The public checkpoint deliberately stores convolution kernels in FP32,
+        # even when the surrounding projections are BF16. Model construction runs
+        # under a BF16 default-dtype context, so make this exception explicit.
+        self.weight = torch.empty(channels, 1, kernel_size, dtype=torch.float32)
+
+
+class _SigmoidRMSNormGated(BaseOP):
+    """RMSNorm(x) * sigmoid(gate), matching FLA's FusedRMSNormGated."""
+
+    def __init__(self, size: int, eps: float):
+        # KDA's gated output norm is FP32 in the released checkpoint.
+        self.weight = torch.empty(size, dtype=torch.float32)
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        from freetoken.kernel.fla import rms_norm_gated
+
+        return rms_norm_gated(
+            x=x,
+            weight=self.weight,
+            bias=None,
+            z=gate,
+            eps=self.eps,
+            is_rms_norm=True,
+            norm_before_gate=True,
+            activation="sigmoid",
+        )
+
+
+class KimiMLAAttention(BaseOP):
+    """NoPE MLA with low-rank Q/KV projections and an output gate.
+
+    ``kv_b_proj`` is absorbed into Q and the output, so the paged cache stores only
+    ``compressed_kv | k_rope``.  Kimi calls the latter field ``rope`` for checkpoint
+    compatibility, but ``mla_use_nope`` means neither it nor Q's matching dimensions
+    receive a positional rotation.
+    """
+
+    def __init__(self, config: ModelConfig, layer_id: int):
+        args = config.kimi_k3_args
+        if args is None:
+            raise ValueError("KimiMLAAttention requires ModelConfig.kimi_k3_args")
+        self.layer_id = layer_id
+        self.num_heads = args.num_heads
+        self.q_lora_rank = args.q_lora_rank
+        self.kv_lora_rank = args.kv_lora_rank
+        self.qk_nope_head_dim = args.qk_nope_head_dim
+        self.qk_rope_head_dim = args.qk_rope_head_dim
+        self.q_head_dim = args.qk_head_dim
+        self.v_head_dim = args.v_head_dim
+
+        self.q_a_proj = LinearReplicated(
+            args.hidden_size, args.q_lora_rank, has_bias=False
+        )
+        self.q_a_layernorm = RMSNorm(args.q_lora_rank, eps=1e-6)
+        self.q_b_proj = LinearReplicated(
+            args.q_lora_rank, args.num_heads * args.qk_head_dim, has_bias=False
+        )
+        self.kv_a_proj_with_mqa = LinearReplicated(
+            args.hidden_size, args.kv_lora_rank + args.qk_rope_head_dim, has_bias=False
+        )
+        self.kv_a_layernorm = RMSNorm(args.kv_lora_rank, eps=1e-6)
+        self.kv_b_proj = LinearReplicated(
+            args.kv_lora_rank,
+            args.num_heads * (args.qk_nope_head_dim + args.v_head_dim),
+            has_bias=False,
+        )
+        self.g_proj = LinearReplicated(
+            args.hidden_size, args.num_heads * args.v_head_dim, has_bias=False
+        )
+        self.o_proj = LinearReplicated(
+            args.num_heads * args.v_head_dim, args.hidden_size, has_bias=False
+        )
+        self._w_uk: torch.Tensor | None = None
+        self._w_uv: torch.Tensor | None = None
+
+    def _kv_b(self) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._w_uk is None:
+            if self.kv_b_proj.weight is None:
+                raise RuntimeError(
+                    "Kimi MLA kv_b projection was freed before repacking"
+                )
+            w = self.kv_b_proj.weight.view(
+                self.num_heads,
+                self.qk_nope_head_dim + self.v_head_dim,
+                self.kv_lora_rank,
+            )
+            self._w_uk = w[:, : self.qk_nope_head_dim].contiguous()
+            self._w_uv = w[:, self.qk_nope_head_dim :].transpose(1, 2).contiguous()
+        assert self._w_uv is not None
+        return self._w_uk, self._w_uv
+
+    def prepare_for_runtime(self) -> None:
+        self._kv_b()
+        self.kv_b_proj.weight = None
+
+    @nvtx_annotate("MLA")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        ctx = get_global_ctx()
+        n = x.shape[0]
+        w_uk, w_uv = self._kv_b()
+
+        q = self.q_b_proj.forward(self.q_a_layernorm.forward(self.q_a_proj.forward(x)))
+        q = q.view(n, self.num_heads, self.q_head_dim)
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        kv = self.kv_a_proj_with_mqa.forward(x)
+        c_kv, k_pe = kv.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        c_kv = self.kv_a_layernorm.forward(c_kv)
+
+        q_absorbed = torch.bmm(q_nope.transpose(0, 1).contiguous(), w_uk).transpose(
+            0, 1
+        )
+        o_latent = ctx.attn_backend.mla_forward(
+            q_absorbed.contiguous(),
+            q_pe.contiguous(),
+            c_kv.contiguous(),
+            k_pe.contiguous(),
+            self.layer_id,
+            ctx.batch,
+        )
+        o = torch.bmm(o_latent.transpose(0, 1).contiguous(), w_uv).transpose(0, 1)
+        o = o.reshape(n, self.num_heads * self.v_head_dim)
+        o = o * torch.sigmoid(self.g_proj.forward(x))
+        return self.o_proj.forward(o)
+
+
+class KimiDeltaAttention(BaseOP):
+    """KDA over FreeToken's per-request convolution and recurrent state pools."""
+
+    def __init__(self, config: ModelConfig, layer_id: int):
+        args = config.kimi_k3_args
+        if args is None:
+            raise ValueError("KimiDeltaAttention requires ModelConfig.kimi_k3_args")
+        self.layer_id = layer_id
+        self.hidden_size = args.hidden_size
+        self.num_heads = args.kda_num_heads
+        self.head_dim = args.kda_head_dim
+        self.projection_size = self.num_heads * self.head_dim
+        self.conv_size = args.kda_conv_kernel
+        self.gate_lower_bound = args.kda_gate_lower_bound
+
+        self.q_proj = LinearReplicated(
+            args.hidden_size, self.projection_size, has_bias=False
+        )
+        self.k_proj = LinearReplicated(
+            args.hidden_size, self.projection_size, has_bias=False
+        )
+        self.v_proj = LinearReplicated(
+            args.hidden_size, self.projection_size, has_bias=False
+        )
+        self.q_conv1d = _DepthwiseConv1d(self.projection_size, self.conv_size)
+        self.k_conv1d = _DepthwiseConv1d(self.projection_size, self.conv_size)
+        self.v_conv1d = _DepthwiseConv1d(self.projection_size, self.conv_size)
+
+        # The production checkpoint's bounded gate stores one decay per key
+        # dimension.  The small development checkpoint uses the original
+        # unbounded, per-head KDA parameterization.
+        a_log_size = (
+            self.head_dim if self.gate_lower_bound is not None else self.num_heads
+        )
+        self.A_log = torch.empty(a_log_size, dtype=torch.float32)
+        self.f_a_proj = LinearReplicated(
+            args.hidden_size, self.head_dim, has_bias=False
+        )
+        self.f_b_proj = LinearReplicated(
+            self.head_dim, self.projection_size, has_bias=False
+        )
+        self.dt_bias = torch.empty(self.projection_size, dtype=torch.float32)
+        self.b_proj = LinearReplicated(args.hidden_size, self.num_heads, has_bias=False)
+        self.g_proj = LinearReplicated(
+            args.hidden_size, self.projection_size, has_bias=False
+        )
+        self.o_norm = _SigmoidRMSNormGated(self.head_dim, config.rms_norm_eps)
+        self.o_proj = LinearReplicated(
+            self.projection_size, args.hidden_size, has_bias=False
+        )
+
+    def _conv_weight(self) -> torch.Tensor:
+        return torch.cat(
+            [self.q_conv1d.weight, self.k_conv1d.weight, self.v_conv1d.weight], dim=0
+        ).squeeze(1)
+
+    def _safe_a(self, a: torch.Tensor) -> torch.Tensor:
+        """Fold per-key A into ``a`` and apply Kimi's lower bound exactly.
+
+        The vendored recurrent decode kernel accepts one ``A_log`` scalar per
+        head, whereas the K3 checkpoint has one per key dimension.  Passing a
+        zero head decay and folding ``exp(A_log)`` through inverse-softplus is
+        algebraically equivalent and avoids silently misinterpreting weights.
+        """
+        if self.gate_lower_bound is None:
+            raise RuntimeError("safe KDA gate requested without a lower bound")
+        x = a.float() + self.dt_bias
+        decay = self.A_log.exp().repeat(self.num_heads)
+        # Official safe KDA gate:
+        #   g = lower_bound * sigmoid(exp(A_log) * (a + dt_bias))
+        # The vendored recurrent kernel implements
+        #   g = -exp(A_head) * softplus(a' + dt_bias).
+        # Feed it A_head=0 below and inverse-softplus the positive magnitude
+        # here.  This preserves the checkpoint's per-key A_log and its bounded
+        # [-5, 0) decay exactly instead of approximating it with a clamp.
+        magnitude = -self.gate_lower_bound * torch.sigmoid(decay * x)
+        # Stable inverse softplus; values above 20 are already indistinguishable from x.
+        inverse = torch.where(
+            magnitude > 20.0, magnitude, torch.log(torch.expm1(magnitude))
+        )
+        return inverse - self.dt_bias
+
+    def _recurrent(self, q, k, v, a, beta, pool, fla) -> torch.Tensor:
+        from freetoken.kernel.fla import fused_sigmoid_gating_delta_rule_update
+
+        if fla.track_dst is not None:
+            raise NotImplementedError(
+                "Kimi-K3 KDA does not yet support hybrid-radix mid-chunk state snapshots"
+            )
+        li = pool.local_index(self.layer_id)
+        if fla.fresh_state_indices is not None:
+            pool.recurrent_states[li].index_fill_(0, fla.fresh_state_indices, 0.0)
+        safe_gate = self.gate_lower_bound is not None
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=(self.A_log.new_zeros(self.num_heads) if safe_gate else self.A_log),
+            a=(self._safe_a(a) if safe_gate else a),
+            dt_bias=self.dt_bias,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            q=q,
+            k=k,
+            v=v,
+            b=beta,
+            initial_state_source=pool.recurrent_states[li],
+            initial_state_indices=fla.cache_indices,
+            scale=self.head_dim**-0.5,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=fla.cu_seqlens,
+            is_kda=True,
+        )
+
+    @nvtx_annotate("KDA")
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        ctx = get_global_ctx()
+        batch = ctx.batch
+        pool = ctx.linear_state_pool
+        if pool is None:
+            raise RuntimeError("Kimi KDA requires a LinearStatePool")
+        fla = batch.fla_metadata
+        if fla is None:
+            from freetoken.attention.linear import build_fla_metadata
+
+            fla = build_fla_metadata(batch, hidden_states.device)
+            batch.fla_metadata = fla
+
+        qkv_in = torch.cat(
+            [
+                self.q_proj.forward(hidden_states),
+                self.k_proj.forward(hidden_states),
+                self.v_proj.forward(hidden_states),
+            ],
+            dim=-1,
+        )
+        li = pool.local_index(self.layer_id)
+        if batch.is_decode:
+            mixed = causal_conv1d_decode(
+                qkv_in, pool.conv_states[li], self._conv_weight(), fla.cache_indices
+            )
+        else:
+            mixed = causal_conv1d_varlen(
+                qkv_in.transpose(0, 1).contiguous(),
+                self._conv_weight(),
+                pool.conv_states[li],
+                fla.cu_seqlens,
+                fla.cache_indices,
+                fla.has_initial_state,
+            ).transpose(0, 1)
+
+        q, k, v = mixed.split([self.projection_size] * 3, dim=-1)
+        n = hidden_states.shape[0]
+        q = q.view(1, n, self.num_heads, self.head_dim)
+        k = k.view(1, n, self.num_heads, self.head_dim)
+        v = v.view(1, n, self.num_heads, self.head_dim)
+        a = self.f_b_proj.forward(self.f_a_proj.forward(hidden_states))
+        beta = self.b_proj.forward(hidden_states).float()
+        out = self._recurrent(q, k, v, a, beta, pool, fla)
+        gate = self.g_proj.forward(hidden_states).view(n, self.num_heads, self.head_dim)
+        out = self.o_norm.forward(out.view(n, self.num_heads, self.head_dim), gate)
+        return self.o_proj.forward(out.reshape(n, self.projection_size))
+
+
+__all__ = ["KimiDeltaAttention", "KimiMLAAttention"]

--- a/python/freetoken/models/kimi_k3/attention.py
+++ b/python/freetoken/models/kimi_k3/attention.py
@@ -196,10 +196,16 @@ class KimiDeltaAttention(BaseOP):
             self.projection_size, args.hidden_size, has_bias=False
         )
 
-    def _conv_weight(self) -> torch.Tensor:
+    def _conv_weight(self, dtype: torch.dtype) -> torch.Tensor:
+        """Return KDA's checkpoint FP32 convolution weights in the activation dtype.
+
+        The public checkpoint intentionally stores these weights in FP32, but the
+        fused ``sgl_kernel`` causal-convolution op requires its input and weight
+        dtypes to match.  Kimi-K3 activations are BF16 in production.
+        """
         return torch.cat(
             [self.q_conv1d.weight, self.k_conv1d.weight, self.v_conv1d.weight], dim=0
-        ).squeeze(1)
+        ).squeeze(1).to(dtype=dtype)
 
     def _safe_a(self, a: torch.Tensor) -> torch.Tensor:
         """Fold per-key A into ``a`` and apply Kimi's lower bound exactly.
@@ -281,12 +287,15 @@ class KimiDeltaAttention(BaseOP):
         li = pool.local_index(self.layer_id)
         if batch.is_decode:
             mixed = causal_conv1d_decode(
-                qkv_in, pool.conv_states[li], self._conv_weight(), fla.cache_indices
+                qkv_in,
+                pool.conv_states[li],
+                self._conv_weight(qkv_in.dtype),
+                fla.cache_indices,
             )
         else:
             mixed = causal_conv1d_varlen(
                 qkv_in.transpose(0, 1).contiguous(),
-                self._conv_weight(),
+                self._conv_weight(qkv_in.dtype),
                 pool.conv_states[li],
                 fla.cu_seqlens,
                 fla.cache_indices,

--- a/python/freetoken/models/kimi_k3/config.py
+++ b/python/freetoken/models/kimi_k3/config.py
@@ -1,0 +1,251 @@
+"""Engine-facing, fail-closed config for the Kimi-K3 text tower."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from freetoken.models.config import (
+    FullAttentionGroupConfig,
+    LinearGatedDeltaGroupConfig,
+    ModelConfig,
+    RotaryConfig,
+)
+
+from .args import load_args
+
+
+def _value(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _text_config(hf_config: Any) -> Any:
+    return _value(hf_config, "text_config") or hf_config
+
+
+def _quant_contract(value: Any) -> tuple[int, str, int, str, str]:
+    return (
+        int(_value(value, "num_bits", 0) or 0),
+        str(_value(value, "type", "")).lower(),
+        int(_value(value, "group_size", 0) or 0),
+        str(_value(value, "strategy", "")).lower(),
+        str(_value(value, "scale_dtype", "")).lower(),
+    )
+
+
+def _development_ignores(text: Any) -> set[str]:
+    linear = _value(text, "linear_attn_config") or {}
+    kda_layers = {int(x) - 1 for x in (_value(linear, "kda_layers", ()) or ())}
+    full_layers = {int(x) - 1 for x in (_value(linear, "full_attn_layers", ()) or ())}
+    num_layers = int(_value(text, "num_hidden_layers", 0) or 0)
+    ignores = {
+        *(
+            f"vision_tower.encoder.blocks.{layer}.{suffix}"
+            for layer in range(2)
+            for suffix in ("mlp.fc0", "mlp.fc1", "wqkv", "wo")
+        ),
+        "mm_projector.proj.0",
+        "mm_projector.proj.2",
+        "language_model.model.output_attn_res_proj",
+        "language_model.lm_head",
+    }
+    kda_suffixes = (
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "f_a_proj",
+        "f_b_proj",
+        "b_proj",
+        "g_proj",
+        "o_norm",
+        "o_proj",
+    )
+    mla_suffixes = (
+        "q_a_proj",
+        "q_b_proj",
+        "kv_a_proj_with_mqa",
+        "kv_b_proj",
+        "o_proj",
+        "g_proj",
+    )
+    for layer in range(num_layers):
+        prefix = f"language_model.model.layers.{layer}"
+        suffixes = kda_suffixes if layer in kda_layers else mla_suffixes
+        if layer not in kda_layers | full_layers:
+            raise ValueError("Kimi-K3 development attention map is incomplete")
+        ignores.update(f"{prefix}.self_attn.{suffix}" for suffix in suffixes)
+        ignores.update((f"{prefix}.self_attention_res_proj", f"{prefix}.mlp_res_proj"))
+        if layer == 0:
+            ignores.update(
+                f"{prefix}.mlp.{part}_proj" for part in ("gate", "up", "down")
+            )
+        else:
+            ignores.add(f"{prefix}.block_sparse_moe.gate")
+    return ignores
+
+
+def detect_kimi_mxfp4(config: Any) -> str:
+    """Accept only the two audited compressed-tensors Kimi MXFP4 layouts."""
+    text = _text_config(config)
+    quant = _value(config, "quantization_config") or _value(text, "quantization_config")
+    if not quant:
+        return "none"
+    method = str(_value(quant, "quant_method", "")).lower()
+    fmt = str(_value(quant, "format", "")).lower()
+    groups = _value(quant, "config_groups", {}) or {}
+    if method != "compressed-tensors" or fmt != "mxfp4-pack-quantized":
+        raise ValueError(
+            f"unsupported Kimi-K3 quantization: method={method!r}, format={fmt!r}"
+        )
+    if not isinstance(groups, Mapping) or len(groups) != 1:
+        raise ValueError("Kimi-K3 support requires exactly one MXFP4 config group")
+    group = next(iter(groups.values()))
+    if str(_value(group, "format", "")).lower() != "mxfp4-pack-quantized":
+        raise ValueError(
+            "Kimi-K3 MXFP4 group format does not match the public checkpoint"
+        )
+    targets = list(_value(group, "targets", ()) or ())
+    weights = _value(group, "weights", {}) or {}
+    contract = _quant_contract(weights)
+    if contract != (4, "float", 32, "group", "torch.uint8"):
+        raise ValueError(f"unsupported Kimi-K3 MXFP4 geometry: {contract!r}")
+    if _value(group, "output_activations") is not None:
+        raise ValueError("Kimi-K3 W4A16 support requires unquantized outputs")
+
+    # The public checkpoint is deliberately mixed precision: only the routed
+    # experts are MXFP4.  Accepting a future export that quantizes attention,
+    # shared experts, the dense prefix, or the vocabulary head would construct
+    # BF16 modules for packed tensors and fail only after a multi-terabyte
+    # download.  Verify the exact exclusion contract up front instead.
+    production_ignores = {
+        r"re:.*self_attn.*",
+        r"re:.*shared_experts.*",
+        r"re:.*mlp\.(gate|up|gate_up|down)_proj.*",
+        r"re:.*lm_head.*",
+        r"re:.*vision_tower.*",
+        r"re:.*mm_projector.*",
+    }
+    ignores = set(_value(quant, "ignore", ()) or ())
+    input_activations = _value(group, "input_activations")
+    if targets == ["Linear"]:
+        if input_activations is not None:
+            raise ValueError("Kimi-K3 W4A16 support requires unquantized activations")
+        if ignores != production_ignores:
+            raise ValueError(
+                "Kimi-K3 MXFP4 ignore contract differs from the public routed-expert-only checkpoint"
+            )
+        return "mxfp4"
+
+    # The 0.40B development checkpoint stores every non-router MoE projection
+    # in MXFP4 and records dynamic group-32 activation quantization. FreeToken's
+    # W4A16 kernels consume the same packed weights with BF16 activations.
+    if targets != [r"re:.*block_sparse_moe.*"]:
+        raise ValueError(f"unsupported Kimi-K3 MXFP4 targets: {targets!r}")
+    activation_contract = _quant_contract(input_activations or {})
+    if activation_contract != (4, "float", 32, "group", "torch.uint8") or not bool(
+        _value(input_activations, "dynamic", False)
+    ):
+        raise ValueError(
+            f"unsupported Kimi-K3 activation quantization: {activation_contract!r}"
+        )
+    if ignores != _development_ignores(text):
+        raise ValueError(
+            "Kimi-K3 MXFP4 ignore contract differs from the audited development checkpoint"
+        )
+    return "mxfp4"
+
+
+def parse_config(hf_config: Any) -> ModelConfig:
+    text = _text_config(hf_config)
+    args = load_args(text)
+    expert_quant = detect_kimi_mxfp4(hf_config)
+    first_dense = int(_value(text, "first_k_dense_replace", 0))
+    if first_dense != 1:
+        raise ValueError(
+            f"Kimi-K3 support requires one dense prefix layer, got {first_dense}"
+        )
+    if str(_value(text, "hidden_act")) != "situ":
+        raise ValueError("Kimi-K3 support implements SiTU activation only")
+    if str(_value(text, "moe_router_activation_func")) != "sigmoid":
+        raise ValueError("Kimi-K3 support implements sigmoid expert routing only")
+    if str(_value(text, "topk_method")) != "noaux_tc":
+        raise ValueError("Kimi-K3 support implements noaux_tc expert selection only")
+
+    # Kimi's MLA is explicitly NoPE. The dimensions still describe the raw q/k
+    # split and latent cache; rotary_dim=0 prevents accidental position transforms.
+    no_rope = RotaryConfig(
+        head_dim=args.qk_head_dim,
+        rotary_dim=0,
+        max_position=int(_value(text, "max_position_embeddings")),
+        base=10000.0,
+        scaling=None,
+    )
+    groups = tuple(
+        sorted(
+            (
+                LinearGatedDeltaGroupConfig(
+                    name="kda",
+                    layer_ids=args.kda_layer_ids,
+                    num_key_heads=args.kda_num_heads,
+                    num_value_heads=args.kda_num_heads,
+                    key_head_dim=args.kda_head_dim,
+                    value_head_dim=args.kda_head_dim,
+                    conv_kernel_dim=args.kda_conv_kernel,
+                    output_gate=True,
+                ),
+                FullAttentionGroupConfig(
+                    name="mla",
+                    layer_ids=args.mla_layer_ids,
+                    num_kv_heads=1,
+                    head_dim=args.mla_latent_dim,
+                    rotary_config=no_rope,
+                    mla=True,
+                ),
+            ),
+            key=lambda group: group.layer_ids[0],
+        )
+    )
+    return ModelConfig(
+        num_layers=args.num_layers,
+        num_qo_heads=args.num_heads,
+        num_kv_heads=1,
+        head_dim=args.mla_latent_dim,
+        hidden_size=args.hidden_size,
+        vocab_size=int(_value(text, "vocab_size")),
+        intermediate_size=int(_value(text, "intermediate_size")),
+        hidden_act="situ",
+        rms_norm_eps=float(_value(text, "rms_norm_eps")),
+        tie_word_embeddings=bool(_value(text, "tie_word_embeddings", False)),
+        rotary_config=no_rope,
+        attention_groups=groups,
+        num_experts=int(_value(text, "num_experts")),
+        num_experts_per_tok=int(_value(text, "num_experts_per_token")),
+        moe_intermediate_size=int(_value(text, "moe_intermediate_size")),
+        norm_topk_prob=bool(_value(text, "moe_renormalize")),
+        model_type=str(_value(hf_config, "model_type", "kimi_k3")),
+        architectures=list(
+            _value(hf_config, "architectures", ["KimiK3ForConditionalGeneration"])
+        ),
+        supports_hybrid_radix=False,
+        moe_enabled=True,
+        expert_quant=expert_quant,
+        moe_weight_format="mxfp4" if expert_quant == "mxfp4" else None,
+        first_k_dense_replace=first_dense,
+        n_shared_experts=int(_value(text, "num_shared_experts", 0)),
+        shared_expert_intermediate_size=(
+            int(_value(text, "num_shared_experts", 0))
+            * int(_value(text, "moe_intermediate_size"))
+        ),
+        routed_scaling_factor=float(_value(text, "routed_scaling_factor", 1.0)),
+        n_group=int(_value(text, "num_expert_group", 1)),
+        topk_group=int(_value(text, "topk_group", 1)),
+        has_router_bias=True,
+        attn_sm_scale=args.qk_head_dim**-0.5,
+        vision_config=None,
+        kimi_k3_args=args,
+    )
+
+
+__all__ = ["detect_kimi_mxfp4", "parse_config"]

--- a/python/freetoken/models/kimi_k3/layers.py
+++ b/python/freetoken/models/kimi_k3/layers.py
@@ -1,0 +1,102 @@
+"""Kimi-K3 decoder layer and attention-residual aggregation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from freetoken.layers import BaseOP, LinearReplicated, RMSNorm
+from freetoken.utils import nvtx_annotate
+
+from .attention import KimiDeltaAttention, KimiMLAAttention
+from .mlp import KimiMLP
+from .moe import KimiSparseMoeBlock
+
+if TYPE_CHECKING:
+    from freetoken.models.config import ModelConfig
+
+
+def apply_attention_residual(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: LinearReplicated,
+    norm: RMSNorm,
+) -> torch.Tensor:
+    """Softmax-weighted aggregation from the official Kimi attention residual."""
+    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
+    vf = values.float()
+    normalized = vf * torch.rsqrt(vf.square().mean(-1, keepdim=True) + norm.eps)
+    score_weight = norm.weight.float() * proj.weight.squeeze(0).float()
+    probs = (normalized * score_weight).sum(-1).softmax(-1).unsqueeze(1)
+    return torch.matmul(probs, vf).squeeze(1).to(values.dtype)
+
+
+class KimiDecoderLayer(BaseOP):
+    def __init__(self, config: ModelConfig, layer_id: int):
+        args = config.kimi_k3_args
+        if args is None:
+            raise ValueError("KimiDecoderLayer requires ModelConfig.kimi_k3_args")
+        self._layer_id = layer_id
+        self.layer_id = layer_id
+        self.is_linear_attn = config.is_linear_layer(layer_id)
+        self.self_attn: BaseOP = (
+            KimiDeltaAttention(config, layer_id)
+            if self.is_linear_attn
+            else KimiMLAAttention(config, layer_id)
+        )
+        if layer_id >= config.first_k_dense_replace:
+            self.block_sparse_moe = KimiSparseMoeBlock(config, layer_id)
+        else:
+            self.mlp = KimiMLP(
+                config.hidden_size,
+                config.intermediate_size,
+                beta=args.situ_beta,
+                linear_beta=args.situ_linear_beta,
+            )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.self_attention_res_norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.mlp_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attention_res_proj = LinearReplicated(
+            config.hidden_size, 1, has_bias=False
+        )
+        self.mlp_res_proj = LinearReplicated(config.hidden_size, 1, has_bias=False)
+        self.attn_res_block_size = args.attn_res_block_size
+
+    @nvtx_annotate("Layer_{}", layer_id_field="_layer_id")
+    def forward(
+        self, hidden_states: torch.Tensor, block_residual: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prefix_sum = hidden_states
+        if block_residual.shape[1] > 0:
+            hidden_states = apply_attention_residual(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+            )
+        if self.layer_id % self.attn_res_block_size == 0:
+            block_residual = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
+            prefix_sum = None
+
+        hidden_states = self.input_layernorm.forward(hidden_states)
+        mixed = self.self_attn.forward(hidden_states)
+        prefix_sum = mixed if prefix_sum is None else prefix_sum + mixed
+
+        hidden_states = apply_attention_residual(
+            prefix_sum, block_residual, self.mlp_res_proj, self.mlp_res_norm
+        )
+        hidden_states = self.post_attention_layernorm.forward(hidden_states)
+        if hasattr(self, "block_sparse_moe"):
+            hidden_states = self.block_sparse_moe.forward(hidden_states)
+        else:
+            hidden_states = self.mlp.forward(hidden_states)
+        return prefix_sum + hidden_states, block_residual
+
+
+__all__ = ["KimiDecoderLayer", "apply_attention_residual"]

--- a/python/freetoken/models/kimi_k3/mlp.py
+++ b/python/freetoken/models/kimi_k3/mlp.py
@@ -1,0 +1,38 @@
+"""Dense and shared SiTU MLPs for Kimi-K3."""
+
+from __future__ import annotations
+
+import torch
+
+from freetoken.kernel.triton.activation import situ_and_mul
+from freetoken.layers import BaseOP, LinearColParallelMerged, LinearRowParallel
+from freetoken.utils import nvtx_annotate
+
+
+class KimiMLP(BaseOP):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        *,
+        beta: float = 4.0,
+        linear_beta: float = 25.0,
+    ):
+        self.gate_up_proj = LinearColParallelMerged(
+            hidden_size, [intermediate_size, intermediate_size], has_bias=False
+        )
+        self.down_proj = LinearRowParallel(
+            intermediate_size, hidden_size, has_bias=False
+        )
+        self.beta = beta
+        self.linear_beta = linear_beta
+
+    @nvtx_annotate("MLP")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up = self.gate_up_proj.forward(x)
+        return self.down_proj.forward(
+            situ_and_mul(gate_up, beta=self.beta, linear_beta=self.linear_beta)
+        )
+
+
+__all__ = ["KimiMLP"]

--- a/python/freetoken/models/kimi_k3/model.py
+++ b/python/freetoken/models/kimi_k3/model.py
@@ -1,0 +1,91 @@
+"""FreeToken inference model for the Kimi-K3 text tower."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from freetoken.core import get_global_ctx
+from freetoken.distributed import get_tp_info
+from freetoken.layers import (
+    BaseOP,
+    LinearReplicated,
+    OPList,
+    ParallelLMHead,
+    RMSNorm,
+    VocabParallelEmbedding,
+)
+from freetoken.models.blocks import BaseLLMModel
+
+from .layers import KimiDecoderLayer, apply_attention_residual
+
+if TYPE_CHECKING:
+    from freetoken.models.config import ModelConfig
+
+
+class KimiK3Model(BaseOP):
+    def __init__(self, config: ModelConfig):
+        args = config.kimi_k3_args
+        if args is None:
+            raise ValueError("KimiK3Model requires ModelConfig.kimi_k3_args")
+        if get_tp_info().size != 1:
+            raise NotImplementedError(
+                "Kimi-K3 text inference currently supports tensor parallel size 1"
+            )
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size, config.hidden_size
+        )
+        self.layers = OPList(
+            [
+                KimiDecoderLayer(config, layer_id)
+                for layer_id in range(config.num_layers)
+            ]
+        )
+        self.output_attn_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.output_attn_res_proj = LinearReplicated(
+            config.hidden_size, 1, has_bias=False
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.embed_tokens.forward(input_ids)
+        block_residual = hidden_states.new_empty(
+            hidden_states.shape[0], 0, hidden_states.shape[1]
+        )
+        for layer in self.layers.op_list:
+            hidden_states, block_residual = layer.forward(hidden_states, block_residual)
+        hidden_states = apply_attention_residual(
+            hidden_states,
+            block_residual,
+            self.output_attn_res_proj,
+            self.output_attn_res_norm,
+        )
+        return self.norm.forward(hidden_states)
+
+
+class KimiK3ForCausalLM(BaseLLMModel):
+    def __init__(self, config: ModelConfig):
+        self.model = KimiK3Model(config)
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            tie_word_embeddings=config.tie_word_embeddings,
+            tied_embedding=self.model.embed_tokens
+            if config.tie_word_embeddings
+            else None,
+        )
+        super().__init__()
+
+    def prepare_for_runtime(self) -> None:
+        for layer in self.model.layers.op_list:
+            if not layer.is_linear_attn:
+                layer.self_attn.prepare_for_runtime()
+        torch.cuda.empty_cache()
+
+    def forward(self) -> torch.Tensor:
+        output = self.model.forward(get_global_ctx().batch.input_ids)
+        return self.lm_head.forward(output)
+
+
+__all__ = ["KimiK3ForCausalLM", "KimiK3Model"]

--- a/python/freetoken/models/kimi_k3/moe.py
+++ b/python/freetoken/models/kimi_k3/moe.py
@@ -1,0 +1,111 @@
+"""Latent routed Kimi-K3 MoE with noaux_tc sigmoid routing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn.functional as F
+
+from freetoken.layers import BaseOP, LinearReplicated, RMSNorm, make_moe_layer
+from freetoken.moe import is_offload_moe_backend
+
+from .mlp import KimiMLP
+
+if TYPE_CHECKING:
+    from freetoken.models.config import ModelConfig
+
+TopK = tuple[torch.Tensor, torch.Tensor]
+
+
+class KimiSparseMoeBlock(BaseOP):
+    def __init__(self, config: ModelConfig, layer_id: int):
+        args = config.kimi_k3_args
+        if args is None:
+            raise ValueError("KimiSparseMoeBlock requires ModelConfig.kimi_k3_args")
+        if config.expert_quant == "mxfp4" and not is_offload_moe_backend(
+            config.moe_backend
+        ):
+            raise ValueError(
+                "Kimi-K3 MXFP4 experts require an offload-family MoE backend"
+            )
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.renormalize = config.norm_topk_prob
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.gate = LinearReplicated(
+            config.hidden_size, config.num_experts, has_bias=False
+        )
+        # This routing-only correction stays FP32 in the official checkpoint.
+        self.e_score_correction_bias = torch.empty(
+            config.num_experts, dtype=torch.float32
+        )
+
+        self.routed_expert_down_proj = LinearReplicated(
+            config.hidden_size, args.routed_expert_hidden_size, has_bias=False
+        )
+        self.experts = make_moe_layer(
+            config,
+            layer_id=layer_id - config.first_k_dense_replace,
+            activation="situ",
+            hidden_size=args.routed_expert_hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            renormalize=config.norm_topk_prob,
+            extra_attrs={
+                "hidden_act_alpha": args.situ_beta,
+                "swiglu_limit": args.situ_linear_beta,
+            },
+        )
+        self.routed_expert_norm = RMSNorm(
+            args.routed_expert_hidden_size, eps=config.rms_norm_eps
+        )
+        self.routed_expert_up_proj = LinearReplicated(
+            args.routed_expert_hidden_size, config.hidden_size, has_bias=False
+        )
+        self.shared_experts = KimiMLP(
+            config.hidden_size,
+            config.shared_expert_intermediate_size,
+            beta=args.situ_beta,
+            linear_beta=args.situ_linear_beta,
+        )
+
+    def _route(self, hidden_states: torch.Tensor) -> TopK:
+        logits = F.linear(hidden_states.float(), self.gate.weight.float())
+        scores = logits.sigmoid()
+        choice = scores + self.e_score_correction_bias.float()
+        if self.n_group > 1 and self.n_group > self.topk_group:
+            n, e = choice.shape
+            group_scores = (
+                choice.view(n, self.n_group, e // self.n_group)
+                .topk(2, dim=-1)[0]
+                .sum(dim=-1)
+            )
+            group_ids = group_scores.topk(self.topk_group, dim=-1, sorted=False)[1]
+            group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+            group_mask.scatter_(1, group_ids, True)
+            choice = choice.masked_fill(
+                ~group_mask.unsqueeze(-1)
+                .expand(n, self.n_group, e // self.n_group)
+                .reshape(n, e),
+                float("-inf"),
+            )
+        topk_ids = choice.topk(self.top_k, dim=-1, sorted=False)[1]
+        topk_weights = scores.gather(1, topk_ids)
+        if self.top_k > 1 and self.renormalize:
+            topk_weights = topk_weights / (topk_weights.sum(-1, keepdim=True) + 1e-20)
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return topk_weights.float().contiguous(), topk_ids.to(torch.int32).contiguous()
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        identity = hidden_states
+        topk_weights, topk_ids = self._route(hidden_states)
+        latent = self.routed_expert_down_proj.forward(hidden_states)
+        routed = self.experts.routed_forward(latent, topk_weights, topk_ids)
+        routed = self.routed_expert_norm.forward(routed)
+        routed = self.routed_expert_up_proj.forward(routed)
+        return routed + self.shared_experts.forward(identity)
+
+
+__all__ = ["KimiSparseMoeBlock"]

--- a/python/freetoken/models/kimi_k3/weight.py
+++ b/python/freetoken/models/kimi_k3/weight.py
@@ -263,13 +263,8 @@ def _copy_expert_tensor(
     banks[bank][layer][expert, :, parity::2].copy_(value.t())
 
 
-def load_mxfp4_expert_banks(
-    model_path: str,
-    model_config,
-    *,
-    dtype: torch.dtype,
-) -> dict[str, list[torch.Tensor]]:
-    """Load official per-expert MXFP4 tensors into transposed group-32 banks."""
+def _expert_bank_geometry(model_config) -> tuple[int, int, int, int, int]:
+    """Validate the Kimi expert-bank ABI and return its dimensions."""
     if model_config.moe_weight_format != "mxfp4":
         raise ValueError("Kimi-K3 expert offload requires MXFP4 weights")
     args = model_config.kimi_k3_args
@@ -288,8 +283,85 @@ def load_mxfp4_expert_banks(
         raise NotImplementedError(
             "Kimi-K3 MXFP4 expert banks currently support TP=1 only"
         )
+    return (
+        first_moe_layer,
+        num_moe_layers,
+        model_config.num_experts,
+        hidden,
+        intermediate,
+    )
 
-    num_experts = model_config.num_experts
+
+def _expert_key(
+    name: str,
+    *,
+    first_moe_layer: int,
+    num_layers: int,
+    num_experts: int,
+) -> tuple[int, int, str, str]:
+    """Parse and range-check an official routed-expert tensor name."""
+    match = _EXPERT_KEY_RE.fullmatch(name)
+    if match is None:
+        raise ValueError(f"unexpected Kimi-K3 expert tensor: {name}")
+    checkpoint_layer = int(match.group("layer"))
+    expert = int(match.group("expert"))
+    if (
+        not first_moe_layer <= checkpoint_layer < num_layers
+        or not 0 <= expert < num_experts
+    ):
+        raise ValueError(f"out-of-range Kimi-K3 expert tensor: {name}")
+    return (
+        checkpoint_layer - first_moe_layer,
+        expert,
+        match.group("proj"),
+        match.group("kind"),
+    )
+
+
+def _check_complete_expert_banks(
+    seen: set[tuple[int, int, str, str]],
+    *,
+    num_moe_layers: int,
+    num_experts: int,
+) -> None:
+    expected = {
+        (layer, expert, proj, kind)
+        for layer in range(num_moe_layers)
+        for expert in range(num_experts)
+        for proj in ("w1", "w2", "w3")
+        for kind in ("weight_packed", "weight_scale")
+    }
+    missing = expected - seen
+    if missing:
+        raise ValueError(f"missing Kimi-K3 expert tensors: {sorted(missing)[:8]}")
+
+
+def _pin_expert_banks(
+    banks: dict[str, list[torch.Tensor]],
+    host_banks: dict,
+    num_moe_layers: int,
+) -> None:
+    if not host_banks:
+        return
+    from freetoken.moe.host_banks import pin_banks
+
+    pin_banks(host_banks)
+    # Bias banks are small relative to weights and shared across layers. Pin one
+    # copy of each so all repeated source pointers are DMA-safe.
+    banks["gate_up_bias"] = [banks["gate_up_bias"][0].pin_memory()] * num_moe_layers
+    banks["down_bias"] = [banks["down_bias"][0].pin_memory()] * num_moe_layers
+
+
+def load_mxfp4_expert_banks(
+    model_path: str,
+    model_config,
+    *,
+    dtype: torch.dtype,
+) -> dict[str, list[torch.Tensor]]:
+    """Load official per-expert MXFP4 tensors into transposed group-32 banks."""
+    first_moe_layer, num_moe_layers, num_experts, hidden, intermediate = (
+        _expert_bank_geometry(model_config)
+    )
     banks, host_banks = _allocate_banks(
         num_moe_layers, num_experts, hidden, intermediate, dtype
     )
@@ -302,21 +374,11 @@ def load_mxfp4_expert_banks(
             for name in f.keys():  # noqa: SIM118
                 if _EXPERT_FRAGMENT not in name:
                     continue
-                match = _EXPERT_KEY_RE.fullmatch(name)
-                if match is None:
-                    raise ValueError(f"unexpected Kimi-K3 expert tensor: {name}")
-                checkpoint_layer = int(match.group("layer"))
-                expert = int(match.group("expert"))
-                if (
-                    not first_moe_layer <= checkpoint_layer < model_config.num_layers
-                    or not 0 <= expert < num_experts
-                ):
-                    raise ValueError(f"out-of-range Kimi-K3 expert tensor: {name}")
-                key = (
-                    checkpoint_layer - first_moe_layer,
-                    expert,
-                    match.group("proj"),
-                    match.group("kind"),
+                key = _expert_key(
+                    name,
+                    first_moe_layer=first_moe_layer,
+                    num_layers=model_config.num_layers,
+                    num_experts=num_experts,
                 )
                 if key in seen:
                     raise ValueError(f"duplicate Kimi-K3 expert tensor: {name}")
@@ -324,7 +386,7 @@ def load_mxfp4_expert_banks(
                 _copy_expert_tensor(
                     banks,
                     layer=key[0],
-                    expert=expert,
+                    expert=key[1],
                     proj=key[2],
                     kind=key[3],
                     value=f.get_tensor(name),
@@ -332,23 +394,79 @@ def load_mxfp4_expert_banks(
                     intermediate=intermediate,
                 )
 
-    expected = {
-        (layer, expert, proj, kind)
-        for layer in range(num_moe_layers)
-        for expert in range(num_experts)
-        for proj in ("w1", "w2", "w3")
-        for kind in ("weight_packed", "weight_scale")
-    }
-    missing = expected - seen
-    if missing:
-        raise ValueError(f"missing Kimi-K3 expert tensors: {sorted(missing)[:8]}")
+    _check_complete_expert_banks(
+        seen, num_moe_layers=num_moe_layers, num_experts=num_experts
+    )
+    _pin_expert_banks(banks, host_banks, num_moe_layers)
+    return banks
+
+
+def load_mxfp4_expert_banks_parallel(
+    model_path: str,
+    model_config,
+    *,
+    dtype: torch.dtype,
+    workers: int = 8,
+    chunk: int = 8 << 20,
+) -> dict[str, list[torch.Tensor]]:
+    """Load Kimi MXFP4 experts with shard prefetch and parallel O_DIRECT reads."""
+    from freetoken.models.weight import iter_expert_tensors_parallel
+    from freetoken.moe.host_banks import LayerCompletionTracker, PinPipeline
+
+    first_moe_layer, num_moe_layers, num_experts, hidden, intermediate = (
+        _expert_bank_geometry(model_config)
+    )
+    banks, host_banks = _allocate_banks(
+        num_moe_layers, num_experts, hidden, intermediate, dtype
+    )
+    seen: set[tuple[int, int, str, str]] = set()
+
+    def _load(sink) -> None:
+        tracker = (
+            LayerCompletionTracker(num_experts * 6, host_banks, sink)
+            if host_banks
+            else None
+        )
+        for name, value in iter_expert_tensors_parallel(
+            model_path,
+            lambda candidate: _EXPERT_FRAGMENT in candidate,
+            workers=workers,
+            chunk=chunk,
+        ):
+            key = _expert_key(
+                name,
+                first_moe_layer=first_moe_layer,
+                num_layers=model_config.num_layers,
+                num_experts=num_experts,
+            )
+            if key in seen:
+                raise ValueError(f"duplicate Kimi-K3 expert tensor: {name}")
+            seen.add(key)
+            _copy_expert_tensor(
+                banks,
+                layer=key[0],
+                expert=key[1],
+                proj=key[2],
+                kind=key[3],
+                value=value,
+                hidden=hidden,
+                intermediate=intermediate,
+            )
+            if tracker is not None:
+                tracker.note(key[0])
 
     if host_banks:
-        from freetoken.moe.host_banks import pin_banks
+        with PinPipeline() as pins:
+            _load(pins)
+    else:
+        _load(None)
 
-        pin_banks(host_banks)
-        # Bias banks are small relative to weights and shared across layers. Pin
-        # one copy of each so all repeated source pointers are DMA-safe.
+    _check_complete_expert_banks(
+        seen, num_moe_layers=num_moe_layers, num_experts=num_experts
+    )
+    # Layer banks were pinned by PinPipeline as each layer completed. Only the
+    # small shared zero-bias banks remain.
+    if host_banks:
         banks["gate_up_bias"] = [banks["gate_up_bias"][0].pin_memory()] * num_moe_layers
         banks["down_bias"] = [banks["down_bias"][0].pin_memory()] * num_moe_layers
     return banks
@@ -386,6 +504,9 @@ def setup_offload_expert_banks(
     device: torch.device,
     dtype: torch.dtype,
     dummy: bool = False,
+    parallel: bool = False,
+    workers: int = 8,
+    chunk: int = 8 << 20,
 ):
     """Model-specific ExpertBanks provider used by the offload engine."""
     del device  # host banks are CPU-resident by contract
@@ -393,12 +514,24 @@ def setup_offload_expert_banks(
 
     if model_config.moe_weight_format != "mxfp4":
         raise ValueError("Kimi-K3 offload requires MXFP4 expert weights")
-    sources = (
-        _dummy_banks(model_config, dtype)
-        if dummy
-        else load_mxfp4_expert_banks(model_path, model_config, dtype=dtype)
-    )
+    if dummy:
+        sources = _dummy_banks(model_config, dtype)
+    elif parallel:
+        sources = load_mxfp4_expert_banks_parallel(
+            model_path,
+            model_config,
+            dtype=dtype,
+            workers=workers,
+            chunk=chunk,
+        )
+    else:
+        sources = load_mxfp4_expert_banks(model_path, model_config, dtype=dtype)
     return ExpertBanks("mxfp4_triton", sources)
 
 
-__all__ = ["iter_weights", "load_mxfp4_expert_banks", "setup_offload_expert_banks"]
+__all__ = [
+    "iter_weights",
+    "load_mxfp4_expert_banks",
+    "load_mxfp4_expert_banks_parallel",
+    "setup_offload_expert_banks",
+]

--- a/python/freetoken/models/kimi_k3/weight.py
+++ b/python/freetoken/models/kimi_k3/weight.py
@@ -1,0 +1,404 @@
+"""Kimi-K3 checkpoint and routed-expert weight loading.
+
+The public checkpoint wraps the text tower in ``language_model`` and stores each
+routed expert as compressed-tensors MXFP4 rows.  The offload kernels consume the
+same values transposed into their split-K layout.  Kimi's expert input is the
+3584-wide latent MoE representation, not the decoder's 7168-wide residual.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import safetensors
+import torch
+from tqdm import tqdm
+
+from freetoken.distributed import get_tp_info
+from freetoken.models.loader import ShardReader, iter_weight_files
+from freetoken.moe.fused_mxfp4 import dequant_mxfp4_blocks
+from freetoken.utils import cached_load_hf_config
+
+from .config import parse_config
+
+_EXPERT_FRAGMENT = ".block_sparse_moe.experts."
+_EXPERT_KEY_RE = re.compile(
+    r"^language_model\.model\.layers\.(?P<layer>\d+)\.block_sparse_moe\."
+    r"experts\.(?P<expert>\d+)\.(?P<proj>w1|w2|w3)\."
+    r"(?P<kind>weight_packed|weight_scale)$"
+)
+_LAYER_RE = re.compile(r"^model\.layers\.(?P<layer>\d+)\.")
+_DENSE_MLP_PART_RE = re.compile(
+    r"^(?P<prefix>model\.layers\.0\.mlp)\.(?P<part>gate|up)_proj\.weight$"
+)
+_SHARED_MLP_PART_RE = re.compile(
+    r"^(?P<prefix>model\.layers\.(?P<layer>\d+)\.block_sparse_moe\.shared_experts)\."
+    r"(?P<part>gate|up)_proj\.weight$"
+)
+
+
+def _resident_name(raw_name: str, num_layers: int) -> str | None:
+    """Return the text-tower state key, dropping vision, MTP and routed experts."""
+    lower_parts = raw_name.lower().split(".")
+    if any(part.startswith(("vision", "mtp", "mm_projector")) for part in lower_parts):
+        return None
+    if _EXPERT_FRAGMENT in raw_name:
+        return None
+    name = raw_name.removeprefix("language_model.")
+    match = _LAYER_RE.match(name)
+    if match is not None and int(match.group("layer")) >= num_layers:
+        return None  # appended multi-token-prediction layer
+    correction = ".block_sparse_moe.gate.e_score_correction_bias"
+    if name.endswith(correction):
+        return name[: -len(correction)] + ".block_sparse_moe.e_score_correction_bias"
+    return name
+
+
+def _fuse_resident_mlp(
+    name: str,
+    tensor: torch.Tensor,
+    fuse_buf: dict[str, dict[str, torch.Tensor]],
+    num_layers: int,
+) -> tuple[str, torch.Tensor] | None:
+    """Buffer one BF16 gate/up part and emit a gate-then-up fusion."""
+    match = _DENSE_MLP_PART_RE.fullmatch(name) or _SHARED_MLP_PART_RE.fullmatch(name)
+    if match is None:
+        return name, tensor
+    layer = match.groupdict().get("layer")
+    if layer is not None and not 1 <= int(layer) < num_layers:
+        raise ValueError(f"unexpected Kimi-K3 shared-expert MLP layer: {name}")
+    target = f"{match.group('prefix')}.gate_up_proj.weight"
+    part = match.group("part")
+    slots = fuse_buf.setdefault(target, {})
+    if part in slots:
+        raise ValueError(f"duplicate Kimi-K3 resident MLP tensor: {name}")
+    slots[part] = tensor
+    if len(slots) != 2:
+        return None
+    gate, up = slots["gate"], slots["up"]
+    if gate.ndim != 2 or gate.shape != up.shape:
+        raise ValueError(
+            f"incompatible Kimi-K3 gate/up fusion for {target}: "
+            f"{tuple(gate.shape)} and {tuple(up.shape)}"
+        )
+    if gate.dtype != up.dtype or gate.device != up.device:
+        raise ValueError(
+            f"dtype/device mismatch in Kimi-K3 gate/up fusion for {target}"
+        )
+    del fuse_buf[target]
+    return target, torch.cat((gate, up), dim=0)
+
+
+def _dequant_resident_mxfp4(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    name: str,
+) -> torch.Tensor:
+    if packed.dtype != torch.uint8 or scales.dtype != torch.uint8:
+        raise ValueError(f"invalid Kimi-K3 resident MXFP4 dtypes for {name}")
+    if packed.ndim != 2 or scales.ndim != 2:
+        raise ValueError(f"invalid Kimi-K3 resident MXFP4 ranks for {name}")
+    if packed.shape[0] != scales.shape[0] or packed.shape[1] != scales.shape[1] * 16:
+        raise ValueError(
+            f"invalid Kimi-K3 resident MXFP4 shapes for {name}: "
+            f"{tuple(packed.shape)} and {tuple(scales.shape)}"
+        )
+    blocks = packed.reshape(packed.shape[0], scales.shape[1], 16)
+    return dequant_mxfp4_blocks(blocks, scales, out_dtype=torch.bfloat16)
+
+
+def iter_weights(
+    model_path: str,
+    device: torch.device,
+    *,
+    include_moe_experts: bool,
+    include_non_moe: bool,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield resident text weights, preserving official projection names.
+
+    Routed experts are only valid in the host offload banks and are never yielded
+    into ``load_state_dict``.  Kimi TP loading is deliberately rejected until the
+    model's latent-MoE projections and expert banks have a single agreed TP ABI.
+    """
+    if include_moe_experts:
+        raise ValueError("Kimi-K3 routed experts must be loaded into MXFP4 host banks")
+    if not include_non_moe:
+        return
+    tp_info = get_tp_info()
+    if tp_info.size != 1:
+        raise NotImplementedError("Kimi-K3 weight loading currently supports TP=1 only")
+    config = parse_config(cached_load_hf_config(model_path))
+    fuse_buf: dict[str, dict[str, torch.Tensor]] = {}
+    reader = ShardReader(model_path, device)
+    try:
+        for file in tqdm(
+            reader.files(),
+            desc="Loading Kimi-K3 resident weights",
+            disable=not tp_info.is_primary(),
+        ):
+            for raw_name in reader.names_in(file):
+                if raw_name.endswith(".weight_scale"):
+                    continue  # consumed with its packed sibling, potentially cross-shard
+                name = _resident_name(raw_name, config.num_layers)
+                if name is None:
+                    continue
+                if raw_name.endswith(".weight_packed"):
+                    raw_base = raw_name[: -len(".weight_packed")]
+                    name = name[: -len(".weight_packed")] + ".weight"
+                    tensor = _dequant_resident_mxfp4(
+                        reader.get_tensor(raw_name),
+                        reader.get_tensor(raw_base + ".weight_scale"),
+                        name=name,
+                    )
+                else:
+                    tensor = reader.get_tensor(raw_name)
+                fused = _fuse_resident_mlp(name, tensor, fuse_buf, config.num_layers)
+                if fused is not None:
+                    yield fused
+    finally:
+        reader.close()
+    if fuse_buf:
+        raise ValueError(f"incomplete Kimi-K3 resident MLP fusions: {sorted(fuse_buf)}")
+
+
+def _bank_shapes(
+    num_experts: int,
+    hidden: int,
+    intermediate: int,
+) -> dict[str, tuple[tuple[int, ...], torch.dtype]]:
+    return {
+        "gate_up_blocks": (
+            (num_experts, hidden // 2, 2 * intermediate),
+            torch.uint8,
+        ),
+        "gate_up_scales": (
+            (num_experts, hidden // 32, 2 * intermediate),
+            torch.uint8,
+        ),
+        "down_blocks": (
+            (num_experts, intermediate // 2, hidden),
+            torch.uint8,
+        ),
+        "down_scales": (
+            (num_experts, intermediate // 32, hidden),
+            torch.uint8,
+        ),
+    }
+
+
+def _allocate_banks(
+    num_layers: int,
+    num_experts: int,
+    hidden: int,
+    intermediate: int,
+    dtype: torch.dtype,
+):
+    """Allocate bulk banks per layer and one shared immutable zero bias per role."""
+    specs = _bank_shapes(num_experts, hidden, intermediate)
+    host_banks = {}
+    if torch.cuda.is_available():
+        from freetoken.moe.host_banks import alloc_layer_banks
+
+        host_banks = alloc_layer_banks(specs, num_layers)
+        banks = {
+            name: [bank.tensor for bank in values]
+            for name, values in host_banks.items()
+        }
+    else:
+        banks = {
+            name: [torch.empty(shape, dtype=dt) for _ in range(num_layers)]
+            for name, (shape, dt) in specs.items()
+        }
+
+    # The checkpoint is bias-free. A single full, contiguous expert bank can be
+    # shared safely by every layer; this retains ExpertBanks' [E, N] contract
+    # without allocating roughly a gigabyte of identical zeros.
+    gate_bias = torch.zeros((num_experts, 2 * intermediate), dtype=dtype)
+    down_bias = torch.zeros((num_experts, hidden), dtype=dtype)
+    banks["gate_up_bias"] = [gate_bias] * num_layers
+    banks["down_bias"] = [down_bias] * num_layers
+    return banks, host_banks
+
+
+def _expected_source_shape(
+    proj: str,
+    kind: str,
+    hidden: int,
+    intermediate: int,
+) -> tuple[int, int]:
+    out_features, in_features = (
+        (intermediate, hidden) if proj in {"w1", "w3"} else (hidden, intermediate)
+    )
+    divisor = 2 if kind == "weight_packed" else 32
+    return out_features, in_features // divisor
+
+
+def _copy_expert_tensor(
+    banks: dict[str, list[torch.Tensor]],
+    *,
+    layer: int,
+    expert: int,
+    proj: str,
+    kind: str,
+    value: torch.Tensor,
+    hidden: int,
+    intermediate: int,
+) -> None:
+    expected = _expected_source_shape(proj, kind, hidden, intermediate)
+    if value.dtype != torch.uint8 or tuple(value.shape) != expected:
+        raise ValueError(
+            f"invalid Kimi-K3 {proj}.{kind}: expected uint8 {expected}, "
+            f"got {value.dtype} {tuple(value.shape)}"
+        )
+    if proj == "w2":
+        bank = "down_blocks" if kind == "weight_packed" else "down_scales"
+        banks[bank][layer][expert].copy_(value.t())
+        return
+
+    bank = "gate_up_blocks" if kind == "weight_packed" else "gate_up_scales"
+    # SiTU consumes gate/up pairs: w1 (gate) is even, w3 (up) is odd.
+    parity = 0 if proj == "w1" else 1
+    banks[bank][layer][expert, :, parity::2].copy_(value.t())
+
+
+def load_mxfp4_expert_banks(
+    model_path: str,
+    model_config,
+    *,
+    dtype: torch.dtype,
+) -> dict[str, list[torch.Tensor]]:
+    """Load official per-expert MXFP4 tensors into transposed group-32 banks."""
+    if model_config.moe_weight_format != "mxfp4":
+        raise ValueError("Kimi-K3 expert offload requires MXFP4 weights")
+    args = model_config.kimi_k3_args
+    hidden = args.routed_expert_hidden_size
+    intermediate = model_config.moe_intermediate_size
+    if hidden % 32 or intermediate % 32:
+        raise ValueError(
+            f"Kimi-K3 MXFP4 expert dimensions must be divisible by 32: "
+            f"{(hidden, intermediate)}"
+        )
+    first_moe_layer = model_config.first_k_dense_replace
+    num_moe_layers = model_config.num_layers - first_moe_layer
+    if first_moe_layer != 1 or num_moe_layers <= 0:
+        raise ValueError("Kimi-K3 expert loader requires one dense prefix layer")
+    if get_tp_info().size != 1:
+        raise NotImplementedError(
+            "Kimi-K3 MXFP4 expert banks currently support TP=1 only"
+        )
+
+    num_experts = model_config.num_experts
+    banks, host_banks = _allocate_banks(
+        num_moe_layers, num_experts, hidden, intermediate, dtype
+    )
+    seen: set[tuple[int, int, str, str]] = set()
+
+    for file in iter_weight_files(model_path):
+        with safetensors.safe_open(file, framework="pt", device="cpu") as f:
+            # SafeOpen is intentionally not treated as a mapping: explicit
+            # ``keys()`` works across the supported safetensors releases.
+            for name in f.keys():  # noqa: SIM118
+                if _EXPERT_FRAGMENT not in name:
+                    continue
+                match = _EXPERT_KEY_RE.fullmatch(name)
+                if match is None:
+                    raise ValueError(f"unexpected Kimi-K3 expert tensor: {name}")
+                checkpoint_layer = int(match.group("layer"))
+                expert = int(match.group("expert"))
+                if (
+                    not first_moe_layer <= checkpoint_layer < model_config.num_layers
+                    or not 0 <= expert < num_experts
+                ):
+                    raise ValueError(f"out-of-range Kimi-K3 expert tensor: {name}")
+                key = (
+                    checkpoint_layer - first_moe_layer,
+                    expert,
+                    match.group("proj"),
+                    match.group("kind"),
+                )
+                if key in seen:
+                    raise ValueError(f"duplicate Kimi-K3 expert tensor: {name}")
+                seen.add(key)
+                _copy_expert_tensor(
+                    banks,
+                    layer=key[0],
+                    expert=expert,
+                    proj=key[2],
+                    kind=key[3],
+                    value=f.get_tensor(name),
+                    hidden=hidden,
+                    intermediate=intermediate,
+                )
+
+    expected = {
+        (layer, expert, proj, kind)
+        for layer in range(num_moe_layers)
+        for expert in range(num_experts)
+        for proj in ("w1", "w2", "w3")
+        for kind in ("weight_packed", "weight_scale")
+    }
+    missing = expected - seen
+    if missing:
+        raise ValueError(f"missing Kimi-K3 expert tensors: {sorted(missing)[:8]}")
+
+    if host_banks:
+        from freetoken.moe.host_banks import pin_banks
+
+        pin_banks(host_banks)
+        # Bias banks are small relative to weights and shared across layers. Pin
+        # one copy of each so all repeated source pointers are DMA-safe.
+        banks["gate_up_bias"] = [banks["gate_up_bias"][0].pin_memory()] * num_moe_layers
+        banks["down_bias"] = [banks["down_bias"][0].pin_memory()] * num_moe_layers
+    return banks
+
+
+def _dummy_banks(model_config, dtype: torch.dtype) -> dict[str, list[torch.Tensor]]:
+    args = model_config.kimi_k3_args
+    num_moe_layers = model_config.num_layers - model_config.first_k_dense_replace
+    banks, host_banks = _allocate_banks(
+        num_moe_layers,
+        model_config.num_experts,
+        args.routed_expert_hidden_size,
+        model_config.moe_intermediate_size,
+        dtype,
+    )
+    for name in ("gate_up_blocks", "down_blocks"):
+        for tensor in banks[name]:
+            tensor.random_(0, 256)
+    for name in ("gate_up_scales", "down_scales"):
+        for tensor in banks[name]:
+            tensor.fill_(127)
+    if host_banks:
+        from freetoken.moe.host_banks import pin_banks
+
+        pin_banks(host_banks)
+        banks["gate_up_bias"] = [banks["gate_up_bias"][0].pin_memory()] * num_moe_layers
+        banks["down_bias"] = [banks["down_bias"][0].pin_memory()] * num_moe_layers
+    return banks
+
+
+def setup_offload_expert_banks(
+    model_path: str,
+    model_config,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    dummy: bool = False,
+):
+    """Model-specific ExpertBanks provider used by the offload engine."""
+    del device  # host banks are CPU-resident by contract
+    from freetoken.moe.expert_banks import ExpertBanks
+
+    if model_config.moe_weight_format != "mxfp4":
+        raise ValueError("Kimi-K3 offload requires MXFP4 expert weights")
+    sources = (
+        _dummy_banks(model_config, dtype)
+        if dummy
+        else load_mxfp4_expert_banks(model_path, model_config, dtype=dtype)
+    )
+    return ExpertBanks("mxfp4_triton", sources)
+
+
+__all__ = ["iter_weights", "load_mxfp4_expert_banks", "setup_offload_expert_banks"]

--- a/python/freetoken/models/register.py
+++ b/python/freetoken/models/register.py
@@ -119,6 +119,14 @@ _MODEL_REGISTRY: dict[str, ModelSpec] = {
         "freetoken.models.gpt_oss",
         "GptOssForCausalLM",
     ),
+    "KimiK3ForConditionalGeneration": ModelSpec(
+        "freetoken.models.kimi_k3",
+        "KimiK3ForCausalLM",
+    ),
+    "KimiLinearForCausalLM": ModelSpec(
+        "freetoken.models.kimi_k3",
+        "KimiK3ForCausalLM",
+    ),
     "Glm4MoeForCausalLM": ModelSpec(
         "freetoken.models.glm4_moe",
         "Glm4MoeForCausalLM",

--- a/python/freetoken/moe/benchbw.py
+++ b/python/freetoken/moe/benchbw.py
@@ -123,6 +123,16 @@ WORKLOADS: dict[str, Workload] = {
     "dsv4": Workload("dsv4", 4096, 2048, 256, 6, ("ds_fp4",), swiglu_limit=7.0),
     "glm4.7-nvfp4": Workload("glm4.7-nvfp4", 5120, 1536, 160, 8, ("nvfp4",)),
     "minimax-m2.5": Workload("minimax-m2.5", 3072, 1536, 256, 8, ("nvfp4",)),
+    # Public Kimi-K3 checkpoint: 896 routed experts, top-16, 3584 latent expert
+    # hidden, 3072 expert intermediate, compressed-tensors MXFP4,
+    # SiTU(beta=4, linear_beta=25). The surrounding resident BF16 projections
+    # perform the 7168 <-> 3584 conversion.
+    # The synthetic-bank cap keeps this calibration below 2 GiB while preserving
+    # the real per-expert geometry and the expert-miss memory path.
+    "kimi-k3": Workload(
+        "kimi-k3", 3584, 3072, 896, 16, ("mxfp4_triton",),
+        activation="situ", swiglu_alpha=4.0, swiglu_limit=25.0,
+    ),
 }
 
 # Per-dtype canonical geometries for the TUNING bench (`--dtype`). The hybrid-vs-offload choice is

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -56,7 +56,8 @@ _FLAG_SLOTS_PER_LAYER = 16
 
 # Activation ids must match ActKind in csrc/cpu_moe/cpu_moe_ext.cpp. Id 3 is the
 # clamped (up + 1) swiglu: "swigluoai" runs it in the generic GEMV epilogue,
-# "gpt_oss_swiglu" is the same math fused inside the mxfp4 kernel.
+# "gpt_oss_swiglu" is the same math fused inside the mxfp4 kernel. Id 4 is
+# Kimi-K3 SiTU and is likewise supported by generic and MXFP4 paths.
 _ACT_IDS = {
     "silu": 0,
     "swish": 0,
@@ -65,6 +66,7 @@ _ACT_IDS = {
     "gelu_pytorch_tanh": 2,
     "gpt_oss_swiglu": 3,
     "swigluoai": 3,
+    "situ": 4,
 }
 
 # Weight-format ids must match WFmt in csrc/cpu_moe/cpu_moe_ext.cpp.
@@ -104,7 +106,9 @@ def physical_core_cpus() -> list[int]:
     seen: set[str] = set()
     for cpu in allowed:
         try:
-            with open(f"/sys/devices/system/cpu/cpu{cpu}/topology/thread_siblings_list") as f:
+            with open(
+                f"/sys/devices/system/cpu/cpu{cpu}/topology/thread_siblings_list"
+            ) as f:
                 key = f.read().strip()
         except OSError:
             reps.append(cpu)
@@ -167,12 +171,14 @@ class CpuMoeExecutor:
                 f"{fmt!r}; use --moe-backend offload (GPU-side dequant) instead."
             )
         if activation not in _ACT_IDS:
-            raise NotImplementedError(f"CPU MoE backend: unsupported activation {activation!r}")
+            raise NotImplementedError(
+                f"CPU MoE backend: unsupported activation {activation!r}"
+            )
         # ABI probe: a stale prebuilt _cpu_moe.so accepts newer act ids without
         # error and silently computes the wrong activation in the generic
-        # epilogue -- fail loudly with the rebuild instruction instead. (mxfp4
-        # handles its act inside the kernel and predates the marker.)
-        if _ACT_IDS[activation] >= 3 and fmt != "mxfp4_triton":
+        # epilogue -- fail loudly with the rebuild instruction instead. MXFP4
+        # also dispatches activation ids, so it must obey the same ABI marker.
+        if _ACT_IDS[activation] >= 3:
             supported = getattr(_cpu_moe, "max_generic_act_id", lambda: 2)()
             if _ACT_IDS[activation] > supported:
                 raise RuntimeError(
@@ -234,7 +240,9 @@ class CpuMoeExecutor:
             apply_router_weight_on_input=1 if apply_router_weight_on_input else 0,
             weight_format=_WFMT_IDS[fmt],
             swiglu_alpha=float(swiglu_alpha),
-            swiglu_limit=float(swiglu_limit) if swiglu_limit is not None else float("inf"),
+            swiglu_limit=float(swiglu_limit)
+            if swiglu_limit is not None
+            else float("inf"),
             core_ids=core_ids,
             **ptrs,
         )
@@ -276,7 +284,9 @@ class CpuMoeExecutor:
             self._done.zero_()
             self._err.zero_()
             self._ext.start_flag_coordinator(
-                self._ready.data_ptr(), self._done.data_ptr(), self._flag_capacity,
+                self._ready.data_ptr(),
+                self._done.data_ptr(),
+                self._flag_capacity,
                 self._coord_core,
             )
             self._watchdog_stop = False
@@ -352,16 +362,16 @@ class CpuMoeExecutor:
             I = int(gate_up[0].shape[1] // 2)
             assert gate_up[0].shape[1] == 2 * I
             assert tuple(down[0].shape[1:]) == (H, I), (down[0].shape, H, I)
-            ptrs = dict(
-                gate_up_ptr=self._make_table(gate_up).data_ptr(),
-                down_ptr=self._make_table(down).data_ptr(),
-                gate_up_scale_ptr=0,
-                gate_up_global_ptr=0,
-                down_scale_ptr=0,
-                down_global_ptr=0,
-                gate_up_bias_ptr=0,
-                down_bias_ptr=0,
-            )
+            ptrs = {
+                "gate_up_ptr": self._make_table(gate_up).data_ptr(),
+                "down_ptr": self._make_table(down).data_ptr(),
+                "gate_up_scale_ptr": 0,
+                "gate_up_global_ptr": 0,
+                "down_scale_ptr": 0,
+                "down_global_ptr": 0,
+                "gate_up_bias_ptr": 0,
+                "down_bias_ptr": 0,
+            }
             return ptrs, (H, I)
 
         if fmt == "q4_0":
@@ -374,11 +384,23 @@ class CpuMoeExecutor:
             return self._resolve_dsfp4_banks(banks)
 
         # nvfp4: packed e2m1 (2/byte) + fp8-e4m3 per-16 block scales + fp16 row globals.
-        gup, gus, gug = banks["gate_up_packed"], banks["gate_up_scale"], banks["gate_up_global"]
+        gup, gus, gug = (
+            banks["gate_up_packed"],
+            banks["gate_up_scale"],
+            banks["gate_up_global"],
+        )
         dnp, dns, dng = banks["down_packed"], banks["down_scale"], banks["down_global"]
-        assert gup[0].dtype == torch.uint8 and dnp[0].dtype == torch.uint8, (gup[0].dtype, dnp[0].dtype)
-        assert gus[0].element_size() == 1 and dns[0].element_size() == 1, "block scales must be 1 byte"
-        assert gug[0].dtype == torch.float16 and dng[0].dtype == torch.float16, (gug[0].dtype, dng[0].dtype)
+        assert gup[0].dtype == torch.uint8 and dnp[0].dtype == torch.uint8, (
+            gup[0].dtype,
+            dnp[0].dtype,
+        )
+        assert gus[0].element_size() == 1 and dns[0].element_size() == 1, (
+            "block scales must be 1 byte"
+        )
+        assert gug[0].dtype == torch.float16 and dng[0].dtype == torch.float16, (
+            gug[0].dtype,
+            dng[0].dtype,
+        )
         I = int(gup[0].shape[1] // 2)
         H = int(gup[0].shape[2] * 2)
         assert gup[0].shape[1] == 2 * I
@@ -387,16 +409,16 @@ class CpuMoeExecutor:
         assert tuple(gus[0].shape[1:]) == (2 * I, H // 16), (gus[0].shape, I, H)
         assert tuple(dns[0].shape[1:]) == (H, I // 16), (dns[0].shape, H, I)
         assert tuple(gug[0].shape[1:]) == (2 * I,) and tuple(dng[0].shape[1:]) == (H,)
-        ptrs = dict(
-            gate_up_ptr=self._make_table(gup).data_ptr(),
-            down_ptr=self._make_table(dnp).data_ptr(),
-            gate_up_scale_ptr=self._make_table(gus).data_ptr(),
-            gate_up_global_ptr=self._make_table(gug).data_ptr(),
-            down_scale_ptr=self._make_table(dns).data_ptr(),
-            down_global_ptr=self._make_table(dng).data_ptr(),
-            gate_up_bias_ptr=0,
-            down_bias_ptr=0,
-        )
+        ptrs = {
+            "gate_up_ptr": self._make_table(gup).data_ptr(),
+            "down_ptr": self._make_table(dnp).data_ptr(),
+            "gate_up_scale_ptr": self._make_table(gus).data_ptr(),
+            "gate_up_global_ptr": self._make_table(gug).data_ptr(),
+            "down_scale_ptr": self._make_table(dns).data_ptr(),
+            "down_global_ptr": self._make_table(dng).data_ptr(),
+            "gate_up_bias_ptr": 0,
+            "down_bias_ptr": 0,
+        }
         return ptrs, (H, I)
 
     def _resolve_q4_0_banks(self, banks: dict) -> tuple[dict, tuple[int, int]]:
@@ -406,7 +428,8 @@ class CpuMoeExecutor:
         row in place (18 bytes / 32 K) and dequantizes weights inside the K-loop."""
         gate_up, down = banks["gate_up"], banks["down"]
         assert gate_up[0].dtype == torch.uint8 and down[0].dtype == torch.uint8, (
-            gate_up[0].dtype, down[0].dtype,
+            gate_up[0].dtype,
+            down[0].dtype,
         )
         I = int(gate_up[0].shape[1] // 2)
         H = int(down[0].shape[1])
@@ -414,16 +437,16 @@ class CpuMoeExecutor:
         assert H % 32 == 0 and I % 32 == 0, (H, I)
         assert int(gate_up[0].shape[2]) == (H // 32) * 18, (gate_up[0].shape, H)
         assert int(down[0].shape[2]) == (I // 32) * 18, (down[0].shape, I)
-        ptrs = dict(
-            gate_up_ptr=self._make_table(gate_up).data_ptr(),
-            down_ptr=self._make_table(down).data_ptr(),
-            gate_up_scale_ptr=0,
-            gate_up_global_ptr=0,
-            down_scale_ptr=0,
-            down_global_ptr=0,
-            gate_up_bias_ptr=0,
-            down_bias_ptr=0,
-        )
+        ptrs = {
+            "gate_up_ptr": self._make_table(gate_up).data_ptr(),
+            "down_ptr": self._make_table(down).data_ptr(),
+            "gate_up_scale_ptr": 0,
+            "gate_up_global_ptr": 0,
+            "down_scale_ptr": 0,
+            "down_global_ptr": 0,
+            "gate_up_bias_ptr": 0,
+            "down_bias_ptr": 0,
+        }
         return ptrs, (H, I)
 
     def _resolve_mxfp4_banks(self, banks: dict) -> tuple[dict, tuple[int, int]]:
@@ -431,11 +454,24 @@ class CpuMoeExecutor:
         (N innermost) + per-output-row biases. The C++ kernel streams K and
         accumulates a contiguous N-block, so the GPU-tiled layout is read in place
         (no repack, no extra host memory). Block scales are e8m0 (1 byte / 32 K)."""
-        gub, gus, gob = banks["gate_up_blocks"], banks["gate_up_scales"], banks["gate_up_bias"]
+        gub, gus, gob = (
+            banks["gate_up_blocks"],
+            banks["gate_up_scales"],
+            banks["gate_up_bias"],
+        )
         dnb, dns, dob = banks["down_blocks"], banks["down_scales"], banks["down_bias"]
-        assert gub[0].dtype == torch.uint8 and dnb[0].dtype == torch.uint8, (gub[0].dtype, dnb[0].dtype)
-        assert gus[0].dtype == torch.uint8 and dns[0].dtype == torch.uint8, (gus[0].dtype, dns[0].dtype)
-        assert gob[0].dtype == torch.bfloat16 and dob[0].dtype == torch.bfloat16, (gob[0].dtype, dob[0].dtype)
+        assert gub[0].dtype == torch.uint8 and dnb[0].dtype == torch.uint8, (
+            gub[0].dtype,
+            dnb[0].dtype,
+        )
+        assert gus[0].dtype == torch.uint8 and dns[0].dtype == torch.uint8, (
+            gus[0].dtype,
+            dns[0].dtype,
+        )
+        assert gob[0].dtype == torch.bfloat16 and dob[0].dtype == torch.bfloat16, (
+            gob[0].dtype,
+            dob[0].dtype,
+        )
         # gate_up_blocks [E, H//2, 2I]; down_blocks [E, I//2, H]
         H = int(gub[0].shape[1] * 2)
         I = int(gub[0].shape[2] // 2)
@@ -445,16 +481,16 @@ class CpuMoeExecutor:
         assert tuple(gus[0].shape[1:]) == (H // 32, 2 * I), (gus[0].shape, H, I)
         assert tuple(dns[0].shape[1:]) == (I // 32, H), (dns[0].shape, H, I)
         assert tuple(gob[0].shape[1:]) == (2 * I,) and tuple(dob[0].shape[1:]) == (H,)
-        ptrs = dict(
-            gate_up_ptr=self._make_table(gub).data_ptr(),
-            down_ptr=self._make_table(dnb).data_ptr(),
-            gate_up_scale_ptr=self._make_table(gus).data_ptr(),
-            gate_up_global_ptr=0,
-            down_scale_ptr=self._make_table(dns).data_ptr(),
-            down_global_ptr=0,
-            gate_up_bias_ptr=self._make_table(gob).data_ptr(),
-            down_bias_ptr=self._make_table(dob).data_ptr(),
-        )
+        ptrs = {
+            "gate_up_ptr": self._make_table(gub).data_ptr(),
+            "down_ptr": self._make_table(dnb).data_ptr(),
+            "gate_up_scale_ptr": self._make_table(gus).data_ptr(),
+            "gate_up_global_ptr": 0,
+            "down_scale_ptr": self._make_table(dns).data_ptr(),
+            "down_global_ptr": 0,
+            "gate_up_bias_ptr": self._make_table(gob).data_ptr(),
+            "down_bias_ptr": self._make_table(dob).data_ptr(),
+        }
         return ptrs, (H, I)
 
     def _resolve_dsfp4_banks(self, banks: dict) -> tuple[dict, tuple[int, int]]:
@@ -464,25 +500,33 @@ class CpuMoeExecutor:
         activations (block 128) to match DSV4's W4A8 reference, hence the %128 dims."""
         gup, gus = banks["gate_up_packed"], banks["gate_up_scale"]
         dnp, dns = banks["down_packed"], banks["down_scale"]
-        assert gup[0].dtype == torch.uint8 and dnp[0].dtype == torch.uint8, (gup[0].dtype, dnp[0].dtype)
-        assert gus[0].element_size() == 1 and dns[0].element_size() == 1, "block scales must be 1 byte"
+        assert gup[0].dtype == torch.uint8 and dnp[0].dtype == torch.uint8, (
+            gup[0].dtype,
+            dnp[0].dtype,
+        )
+        assert gus[0].element_size() == 1 and dns[0].element_size() == 1, (
+            "block scales must be 1 byte"
+        )
         I = int(gup[0].shape[1] // 2)
         H = int(gup[0].shape[2] * 2)
         assert gup[0].shape[1] == 2 * I
-        assert H % 128 == 0 and I % 128 == 0, (H, I)  # FP8 activation round-trip block=128
+        assert H % 128 == 0 and I % 128 == 0, (
+            H,
+            I,
+        )  # FP8 activation round-trip block=128
         assert tuple(dnp[0].shape[1:]) == (H, I // 2), (dnp[0].shape, H, I)
         assert tuple(gus[0].shape[1:]) == (2 * I, H // 32), (gus[0].shape, I, H)
         assert tuple(dns[0].shape[1:]) == (H, I // 32), (dns[0].shape, H, I)
-        ptrs = dict(
-            gate_up_ptr=self._make_table(gup).data_ptr(),
-            down_ptr=self._make_table(dnp).data_ptr(),
-            gate_up_scale_ptr=self._make_table(gus).data_ptr(),
-            gate_up_global_ptr=0,
-            down_scale_ptr=self._make_table(dns).data_ptr(),
-            down_global_ptr=0,
-            gate_up_bias_ptr=0,
-            down_bias_ptr=0,
-        )
+        ptrs = {
+            "gate_up_ptr": self._make_table(gup).data_ptr(),
+            "down_ptr": self._make_table(dnp).data_ptr(),
+            "gate_up_scale_ptr": self._make_table(gus).data_ptr(),
+            "gate_up_global_ptr": 0,
+            "down_scale_ptr": self._make_table(dns).data_ptr(),
+            "down_global_ptr": 0,
+            "gate_up_bias_ptr": 0,
+            "down_bias_ptr": 0,
+        }
         return ptrs, (H, I)
 
     def _io_for(self, bs: int) -> dict[str, torch.Tensor]:
@@ -574,7 +618,9 @@ class CpuMoeExecutor:
             # doorbell). No kernel launched; no host-func round trip.
             self._cpu_moe.memop_submit(
                 torch.cuda.current_stream().cuda_stream,
-                self._done.data_ptr(), self._ready.data_ptr(), slot,
+                self._done.data_ptr(),
+                self._ready.data_ptr(),
+                slot,
             )
         else:
             stream = torch.cuda.current_stream().cuda_stream
@@ -590,7 +636,9 @@ class CpuMoeExecutor:
             # Front-end WAIT(done[slot] >= 1): blocks this stream's later nodes without
             # occupying an SM, so GPU utilization stays truthful during the CPU window.
             self._cpu_moe.memop_sync(
-                torch.cuda.current_stream().cuda_stream, self._done.data_ptr(), slot,
+                torch.cuda.current_stream().cuda_stream,
+                self._done.data_ptr(),
+                slot,
             )
         else:
             stream = torch.cuda.current_stream().cuda_stream
@@ -624,7 +672,10 @@ class CpuMoeExecutor:
             served = self._ext.flag_served_count(slot)
             first_seen, served_then = suspects.get(slot, (None, None))
             if first_seen is None or served != served_then:
-                suspects[slot] = (now, served)  # new suspect, or alive-but-loaded: rearm
+                suspects[slot] = (
+                    now,
+                    served,
+                )  # new suspect, or alive-but-loaded: rearm
                 continue
             if now - first_seen >= 10.0:
                 dead.append(slot)

--- a/python/freetoken/moe/fused_mxfp4.py
+++ b/python/freetoken/moe/fused_mxfp4.py
@@ -1,4 +1,4 @@
-"""GPT-OSS MXFP4 fused-MoE kernels: transposed split-K GEMV decode + grouped
+"""MXFP4 fused-MoE kernels: transposed split-K GEMV decode + grouped
 ``_t`` prefill over ``[E, K//2, N]``-layout blocks/scales (N innermost, shared
 between the resident and offload paths).
 """
@@ -16,13 +16,48 @@ from freetoken.moe.fused import moe_align_block_size, try_get_optimal_moe_config
 MXFP4_DECODE_MAX_TOKENS = 16
 
 
-def gpt_oss_swiglu(gate_up: torch.Tensor, *, alpha: float, limit: float | None) -> torch.Tensor:
+def gpt_oss_swiglu(
+    gate_up: torch.Tensor, *, alpha: float, limit: float | None
+) -> torch.Tensor:
     gate = gate_up[..., ::2]
     up = gate_up[..., 1::2]
     if limit is not None:
         gate = gate.clamp(max=limit)
         up = up.clamp(min=-limit, max=limit)
     return gate * torch.sigmoid(gate * alpha) * (up + 1.0)
+
+
+def kimi_situ(
+    gate_up: torch.Tensor, *, beta: float = 4.0, linear_beta: float = 25.0
+) -> torch.Tensor:
+    """Kimi-K3 SiTU over the interleaved MXFP4 expert output ``gate, up`` pairs."""
+    if beta <= 0 or linear_beta <= 0:
+        raise ValueError("SiTU beta values must be positive")
+    gate = gate_up[..., ::2]
+    up = gate_up[..., 1::2]
+    return (
+        beta
+        * torch.tanh(gate / beta)
+        * torch.sigmoid(gate)
+        * linear_beta
+        * torch.tanh(up / linear_beta)
+    )
+
+
+def _activate_interleaved(
+    gate_up: torch.Tensor,
+    *,
+    activation: str,
+    act_alpha: float,
+    act_limit: float | None,
+) -> torch.Tensor:
+    if activation in {"gpt_oss_swiglu", "swigluoai"}:
+        return gpt_oss_swiglu(gate_up, alpha=act_alpha, limit=act_limit)
+    if activation == "situ":
+        if act_limit is None:
+            raise ValueError("SiTU requires linear_beta")
+        return kimi_situ(gate_up, beta=act_alpha, linear_beta=act_limit)
+    raise NotImplementedError(f"MXFP4 expert activation {activation!r} is unsupported")
 
 
 def dequant_mxfp4_blocks(
@@ -67,7 +102,10 @@ def dequant_mxfp4_blocks(
         dtype=torch.float32,
     )
     unpacked = values[nibbles.long()]
-    scale = torch.exp2(scales.float() - 127).unsqueeze(-1)
+    # E8M0 reserves 0xff.  Match the split-K and CPU production kernels by
+    # clamping that byte to the largest finite exponent instead of producing a
+    # path-dependent infinity in the Python/grouped reference.
+    scale = torch.exp2(scales.float().clamp_(max=254) - 127).unsqueeze(-1)
     dequantized = unpacked * scale
     return dequantized.reshape(*blocks.shape[:-2], blocks.shape[-2] * 32).to(out_dtype)
 
@@ -76,22 +114,22 @@ def run_mxfp4_prefill_experts_t(
     hidden_states: torch.Tensor,
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
-    gate_up_blocks_t: torch.Tensor,   # [E, H//2, 2*I]
-    gate_up_scales_t: torch.Tensor,   # [E, H//32, 2*I]
-    gate_up_bias: torch.Tensor,       # [E, 2*I]
-    down_blocks_t: torch.Tensor,      # [E, I//2, H]
-    down_scales_t: torch.Tensor,      # [E, I//32, H]
-    down_bias: torch.Tensor,          # [E, H]
+    gate_up_blocks_t: torch.Tensor,  # [E, H//2, 2*I]
+    gate_up_scales_t: torch.Tensor,  # [E, H//32, 2*I]
+    gate_up_bias: torch.Tensor,  # [E, 2*I]
+    down_blocks_t: torch.Tensor,  # [E, I//2, H]
+    down_scales_t: torch.Tensor,  # [E, I//32, H]
+    down_bias: torch.Tensor,  # [E, H]
     *,
     top_k: int,
     hidden_act_alpha: float,
     swiglu_limit: float | None,
+    activation: str = "gpt_oss_swiglu",
 ) -> torch.Tensor:
     """Prefill experts using the transposed weight layout shared with split-K decode
     ([E, K//2, N] blocks, [E, K//32, N] scales, N innermost). Uses
     mxfp4_fused_moe_kernel_t_triton for the grouped GEMM."""
     from freetoken.kernel import (
-        gpt_oss_swiglu_triton,
         moe_sum_reduce_triton,
         mxfp4_fused_moe_kernel_t_triton,
     )
@@ -146,18 +184,12 @@ def run_mxfp4_prefill_experts_t(
         compute_type=hidden_states.dtype,
     )
 
-    activated = torch.empty(
-        (num_tokens * top_k, local_intermediate_size),
-        device=hidden_states.device,
-        dtype=hidden_states.dtype,
-    )
-    gpt_oss_swiglu_triton(
+    activated = _activate_interleaved(
         gate_up.view(num_tokens * top_k, 2 * local_intermediate_size),
-        activated,
-        alpha=hidden_act_alpha,
-        limit=swiglu_limit if swiglu_limit is not None else float("inf"),
-        compute_type=hidden_states.dtype,
-    )
+        activation=activation,
+        act_alpha=hidden_act_alpha,
+        act_limit=swiglu_limit,
+    ).contiguous()
 
     down = torch.empty(
         (num_tokens, top_k, hidden_size),
@@ -192,7 +224,9 @@ def _transpose_mxfp4_for_decode(
     """HF MXFP4 [E, N, K//32, 16] blocks / [E, N, K//32] scales -> split-K GEMV
     layout: blocks_t [E, K//2, N], scales_t [E, K//32, N] (N innermost/contiguous)."""
     num_experts, n, k_blocks, _ = blocks.shape
-    blocks_t = blocks.reshape(num_experts, n, k_blocks * 16).permute(0, 2, 1).contiguous()
+    blocks_t = (
+        blocks.reshape(num_experts, n, k_blocks * 16).permute(0, 2, 1).contiguous()
+    )
     scales_t = scales.permute(0, 2, 1).contiguous()
     return blocks_t, scales_t
 
@@ -218,12 +252,13 @@ def run_mxfp4_splitk_decode_experts(
     top_k: int,
     hidden_act_alpha: float,
     swiglu_limit: float | None,
+    activation: str = "gpt_oss_swiglu",
 ) -> torch.Tensor:
     """Split-K GEMV MoE decode over TRANSPOSED MXFP4 weights:
     gate_up_blocks_t [E, H//2, 2I], gate_up_scales_t [E, H//32, 2I], bias [E, 2I];
     down_blocks_t [E, I//2, H], down_scales_t [E, I//32, H], bias [E, H].
     Targets small token counts (M <= MXFP4_DECODE_MAX_TOKENS)."""
-    from freetoken.kernel import gpt_oss_swiglu_triton, mxfp4_splitk_gemv_triton
+    from freetoken.kernel import mxfp4_splitk_gemv_triton
 
     if not hidden_states.is_cuda:
         raise RuntimeError("GPT-OSS MXFP4 MoE requires the Triton CUDA kernel")
@@ -251,23 +286,42 @@ def run_mxfp4_splitk_decode_experts(
 
     gu_splits = _decode_split_count(routes, H // 32, target_programs=180)
     gate_up_out = mxfp4_splitk_gemv_triton(
-        routed_x, gate_up_blocks_t, gate_up_scales_t, gate_up_bias,
-        route_experts, N=two_I, K=H, stride_xe=gu_stride_xe, num_splits=gu_splits,
+        routed_x,
+        gate_up_blocks_t,
+        gate_up_scales_t,
+        gate_up_bias,
+        route_experts,
+        N=two_I,
+        K=H,
+        stride_xe=gu_stride_xe,
+        num_splits=gu_splits,
     )
 
-    hidden_out = torch.empty((routes, local_intermediate_size), device=device, dtype=compute_type)
-    gpt_oss_swiglu_triton(
-        gate_up_out, hidden_out,
-        alpha=hidden_act_alpha,
-        limit=swiglu_limit if swiglu_limit is not None else float("inf"),
-        compute_type=compute_type,
+    hidden_out = (
+        _activate_interleaved(
+            gate_up_out,
+            activation=activation,
+            act_alpha=hidden_act_alpha,
+            act_limit=swiglu_limit,
+        )
+        .to(compute_type)
+        .contiguous()
     )
 
-    dp_splits = _decode_split_count(routes, local_intermediate_size // 32, target_programs=72)
+    dp_splits = _decode_split_count(
+        routes, local_intermediate_size // 32, target_programs=72
+    )
     down_out = mxfp4_splitk_gemv_triton(
-        hidden_out, down_blocks_t, down_scales_t, down_bias,
-        route_experts, N=H, K=local_intermediate_size,
-        stride_xe=hidden_out.stride(0), num_splits=dp_splits, expert_wts=route_weights,
+        hidden_out,
+        down_blocks_t,
+        down_scales_t,
+        down_bias,
+        route_experts,
+        N=H,
+        K=local_intermediate_size,
+        stride_xe=hidden_out.stride(0),
+        num_splits=dp_splits,
+        expert_wts=route_weights,
     )
 
     return down_out.view(M, top_k, H).sum(dim=1).to(compute_type)
@@ -277,6 +331,7 @@ __all__ = [
     "MXFP4_DECODE_MAX_TOKENS",
     "dequant_mxfp4_blocks",
     "gpt_oss_swiglu",
+    "kimi_situ",
     "run_mxfp4_prefill_experts_t",
     "run_mxfp4_splitk_decode_experts",
 ]

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -180,10 +180,12 @@ class OffloadMoeCache:
         self.usage = torch.zeros((self.cache_size,), dtype=torch.int64, device=self.device)
         self.step = torch.zeros((), dtype=torch.int64, device=self.device)
         self.active_mask = torch.zeros((self.num_experts,), dtype=torch.int32, device=self.device)
-        # lru_ensure validates these against plan = min(batch * top_k, cache_size), so num_experts elements would under-size them
-        plan_slots = max(self.num_experts, self.cache_size)
-        self.evict_slots = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
-        self.src_indices = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
+        # A batched decode can route more rows than one layer has experts (for
+        # example bs=32, top-k=2 -> 64 queries for an 8-expert layer). flashlib's
+        # copy plan requires min(query rows, cache slots), so size the plan by the
+        # cache rather than by one expert layer.
+        self.evict_slots = torch.empty((self.cache_size,), dtype=torch.int32, device=self.device)
+        self.src_indices = torch.empty((self.cache_size,), dtype=torch.int32, device=self.device)
         self.num_indices = torch.zeros((1,), dtype=torch.int64, device=self.device)
         # hybrid only: full missing count BEFORE the per-step fetch cap (num_indices holds
         # the capped count that copy_missing actually fetches). The difference is what the
@@ -478,9 +480,8 @@ class OffloadMoeCache:
         self.slot_for_id.fill_(-1)
         self.id_of_slot = torch.full((cache_size,), -1, dtype=torch.int32, device=self.device)
         self.usage = torch.zeros((cache_size,), dtype=torch.int64, device=self.device)
-        plan_slots = max(self.num_experts, cache_size)
-        self.evict_slots = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
-        self.src_indices = torch.empty((plan_slots,), dtype=torch.int32, device=self.device)
+        self.evict_slots = torch.empty((cache_size,), dtype=torch.int32, device=self.device)
+        self.src_indices = torch.empty((cache_size,), dtype=torch.int32, device=self.device)
         self.step.zero_()
         self.active_mask.zero_()
         self.num_indices.zero_()

--- a/python/freetoken/utils/hf.py
+++ b/python/freetoken/utils/hf.py
@@ -29,7 +29,10 @@ def load_tokenizer(model_path: str) -> PreTrainedTokenizerBase:
         from freetoken.models.gguf.tokenizer import load_gguf_tokenizer
 
         return load_gguf_tokenizer(gguf_src)
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    # Keep this aligned with ``_load_hf_config`` below.  Checkpoints with a custom
+    # tokenizer (Kimi-K3's tiktoken wrapper is one) cannot be loaded otherwise;
+    # model loading already opts into the checkpoint's custom config code.
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     # Some Mistral models store chat_template in a separate JSON file
     if not getattr(tokenizer, "chat_template", None):
         try:

--- a/tests/engine/test_graph_batch_sizes.py
+++ b/tests/engine/test_graph_batch_sizes.py
@@ -1,0 +1,25 @@
+from freetoken.engine.graph import _determine_cuda_graph_bs
+
+
+def test_offload_graph_shapes_do_not_exceed_flashlib_copy_plan():
+    sizes = _determine_cuda_graph_bs(
+        cuda_graph_bs=None,
+        cuda_graph_max_bs=32,
+        free_memory=24 << 30,
+        moe_cache_size=56,
+        moe_top_k=2,
+    )
+
+    assert sizes == [1, 2, 4, 8, 16, 24]
+
+
+def test_explicit_graph_shapes_are_filtered_too():
+    sizes = _determine_cuda_graph_bs(
+        cuda_graph_bs=[1, 8, 32],
+        cuda_graph_max_bs=None,
+        free_memory=24 << 30,
+        moe_cache_size=56,
+        moe_top_k=2,
+    )
+
+    assert sizes == [1, 8]

--- a/tests/kvcache/test_dsa_pool.py
+++ b/tests/kvcache/test_dsa_pool.py
@@ -125,6 +125,26 @@ def test_mla_pool_selected_by_group_spec():
     assert isinstance(mla, MLAKVCache) and not isinstance(mla, DSAKVCache)
 
 
+def test_mla_pool_backs_only_declared_global_layer_ids():
+    """Hybrid linear/MLA models must not allocate latent KV for linear layers."""
+    from freetoken.kvcache.dsa_pool import MLAKVCache
+
+    pool = MLAKVCache(
+        latent_dim=LATENT,
+        num_layers=8,
+        num_pages=4,
+        page_size=1,
+        dtype=torch.bfloat16,
+        device=torch.device("cuda"),
+        layer_ids=(3, 7),
+    )
+    assert pool._kv_buffer.shape == (1, 2, 4, 1, 1, LATENT)
+    assert pool.latent_rows(3).shape == (4, LATENT)
+    assert pool.latent_rows(7).shape == (4, LATENT)
+    with pytest.raises(KeyError, match="no paged KV storage"):
+        pool.latent_rows(0)
+
+
 def test_rebuild_shrink_and_engine_wiring():
     """Shrink-direction rebuild (both slabs) + the engine-facing rebuild_from_config
     (usable pages in, +1 dummy page added by the pool)."""

--- a/tests/models/test_kimi_k3.py
+++ b/tests/models/test_kimi_k3.py
@@ -150,6 +150,22 @@ def _development_config():
 
 
 class KimiK3ConfigTests(unittest.TestCase):
+    def test_kda_conv_weight_matches_activation_dtype(self):
+        import torch
+
+        # The released checkpoint holds KDA convolution weights in FP32, while
+        # the fused causal-convolution kernel requires same-typed activations
+        # and weights on the BF16 inference path.
+        attn = object.__new__(KimiDeltaAttention)
+        attn.q_conv1d = _ns(weight=torch.ones(2, 1, 3, dtype=torch.float32))
+        attn.k_conv1d = _ns(weight=torch.full((2, 1, 3), 2.0, dtype=torch.float32))
+        attn.v_conv1d = _ns(weight=torch.full((2, 1, 3), 3.0, dtype=torch.float32))
+
+        got = attn._conv_weight(torch.bfloat16)
+
+        self.assertEqual(got.dtype, torch.bfloat16)
+        torch.testing.assert_close(got.float(), torch.tensor([[1.0] * 3] * 2 + [[2.0] * 3] * 2 + [[3.0] * 3] * 2))
+
     def test_kda_decay_adapter_matches_official_bounded_gate(self):
         import torch
         import torch.nn.functional as F

--- a/tests/models/test_kimi_k3.py
+++ b/tests/models/test_kimi_k3.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import copy
+import unittest
+from types import SimpleNamespace
+
+from freetoken.models.config import (
+    FullAttentionGroupConfig,
+    LinearGatedDeltaGroupConfig,
+)
+from freetoken.models.kimi_k3.attention import KimiDeltaAttention
+from freetoken.models.kimi_k3.config import (
+    _development_ignores,
+    detect_kimi_mxfp4,
+    parse_config,
+)
+from freetoken.moe.benchbw import WORKLOADS
+from freetoken.moe.fused_mxfp4 import dequant_mxfp4_blocks, kimi_situ
+
+
+def _ns(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def _official_config():
+    full = list(range(4, 93, 4)) + [93]
+    kda = [layer for layer in range(1, 94) if layer not in full]
+    quant = {
+        "quant_method": "compressed-tensors",
+        "format": "mxfp4-pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "format": "mxfp4-pack-quantized",
+                "input_activations": None,
+                "output_activations": None,
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "float",
+                    "group_size": 32,
+                    "strategy": "group",
+                    "scale_dtype": "torch.uint8",
+                },
+            }
+        },
+        "ignore": [
+            r"re:.*self_attn.*",
+            r"re:.*shared_experts.*",
+            r"re:.*mlp\.(gate|up|gate_up|down)_proj.*",
+            r"re:.*lm_head.*",
+            r"re:.*vision_tower.*",
+            r"re:.*mm_projector.*",
+        ],
+    }
+    text = _ns(
+        num_hidden_layers=93,
+        hidden_size=7168,
+        num_attention_heads=96,
+        num_key_value_heads=96,
+        q_lora_rank=1536,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        v_head_dim=128,
+        linear_attn_config={
+            "full_attn_layers": full,
+            "kda_layers": kda,
+            "num_heads": 96,
+            "head_dim": 128,
+            "short_conv_kernel_size": 4,
+            "gate_lower_bound": -5.0,
+            "use_full_rank_gate": True,
+        },
+        routed_expert_hidden_size=3584,
+        latent_moe_use_norm=True,
+        activation_situ_beta=4.0,
+        activation_situ_linear_beta=25.0,
+        attn_res_block_size=12,
+        mla_use_nope=True,
+        mla_use_output_gate=True,
+        first_k_dense_replace=1,
+        hidden_act="situ",
+        moe_router_activation_func="sigmoid",
+        topk_method="noaux_tc",
+        max_position_embeddings=1048576,
+        vocab_size=163840,
+        intermediate_size=33792,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+        num_experts=896,
+        num_experts_per_token=16,
+        moe_intermediate_size=3072,
+        moe_renormalize=True,
+        num_shared_experts=2,
+        routed_scaling_factor=1.0,
+        num_expert_group=1,
+        topk_group=1,
+        quantization_config=quant,
+    )
+    return _ns(
+        model_type="kimi_k3",
+        architectures=["KimiK3ForConditionalGeneration"],
+        text_config=text,
+    )
+
+
+def _development_config():
+    config = _official_config()
+    text = config.text_config
+    text.num_hidden_layers = 8
+    text.hidden_size = 1024
+    text.num_attention_heads = 8
+    text.num_key_value_heads = 8
+    text.q_lora_rank = 256
+    text.kv_lora_rank = 128
+    text.qk_nope_head_dim = 64
+    text.qk_rope_head_dim = 32
+    text.v_head_dim = 64
+    text.linear_attn_config = {
+        "full_attn_layers": [4, 8],
+        "kda_layers": [1, 2, 3, 5, 6, 7],
+        "num_heads": 8,
+        "head_dim": 32,
+        "short_conv_kernel_size": 4,
+        "use_full_rank_gate": True,
+    }
+    text.routed_expert_hidden_size = 512
+    text.attn_res_block_size = 4
+    text.max_position_embeddings = 4096
+    text.intermediate_size = 2048
+    text.num_experts = 8
+    text.num_experts_per_token = 2
+    text.moe_intermediate_size = 256
+    text.num_shared_experts = 1
+    quant = copy.deepcopy(text.quantization_config)
+    group = quant["config_groups"]["group_0"]
+    group["targets"] = [r"re:.*block_sparse_moe.*"]
+    group["input_activations"] = {
+        "dynamic": True,
+        "num_bits": 4,
+        "type": "float",
+        "group_size": 32,
+        "strategy": "group",
+        "scale_dtype": "torch.uint8",
+    }
+    quant["ignore"] = sorted(_development_ignores(text))
+    del text.quantization_config
+    config.quantization_config = quant
+    return config
+
+
+class KimiK3ConfigTests(unittest.TestCase):
+    def test_kda_decay_adapter_matches_official_bounded_gate(self):
+        import torch
+        import torch.nn.functional as F
+
+        # Build only the scalar state needed by the adapter. Constructing the
+        # 753B model just to validate this algebra would obscure the contract.
+        attn = object.__new__(KimiDeltaAttention)
+        attn.num_heads = 2
+        attn.gate_lower_bound = -5.0
+        attn.A_log = torch.tensor([-0.7, 0.2, 0.9], dtype=torch.float32)
+        attn.dt_bias = torch.tensor(
+            [-0.4, 0.1, 0.5, -0.4, 0.1, 0.5], dtype=torch.float32
+        )
+        a = torch.tensor([[-2.0, -0.5, 0.0, 0.25, 1.0, 3.0]], dtype=torch.float32)
+
+        adapted = attn._safe_a(a)
+        actual = -F.softplus(adapted + attn.dt_bias)
+        decay = attn.A_log.exp().repeat(attn.num_heads)
+        expected = attn.gate_lower_bound * torch.sigmoid(decay * (a + attn.dt_bias))
+        torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+    def test_mxfp4_reserved_scale_byte_uses_largest_finite_exponent(self):
+        import torch
+
+        # Every nibble is +0.5. Scale 0xff must follow the production-kernel
+        # contract and clamp to exponent byte 254, not become an infinity.
+        blocks = torch.full((1, 1, 16), 0x11, dtype=torch.uint8)
+        scales = torch.full((1, 1), 255, dtype=torch.uint8)
+        got = dequant_mxfp4_blocks(blocks, scales, out_dtype=torch.float32)
+        expected = torch.full((1, 32), 0.5 * 2.0**127, dtype=torch.float32)
+        torch.testing.assert_close(got, expected)
+
+    def test_situ_interleaved_matches_checkpoint_formula(self):
+        import torch
+
+        gate_up = torch.tensor([[1.0, 2.0, -3.0, 4.0]], dtype=torch.float32)
+        gate = gate_up[..., ::2]
+        up = gate_up[..., 1::2]
+        expected = 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate)
+        expected *= 25.0 * torch.tanh(up / 25.0)
+        torch.testing.assert_close(kimi_situ(gate_up), expected)
+
+    def test_bandwidth_probe_uses_real_kimi_expert_geometry(self):
+        workload = WORKLOADS["kimi-k3"]
+        self.assertEqual(
+            (workload.hidden, workload.inter, workload.experts, workload.top_k),
+            (3584, 3072, 896, 16),
+        )
+        self.assertEqual(workload.formats, ("mxfp4_triton",))
+        self.assertEqual(workload.activation, "situ")
+        self.assertEqual((workload.swiglu_alpha, workload.swiglu_limit), (4.0, 25.0))
+
+    def test_public_checkpoint_geometry_is_normalized(self):
+        config = parse_config(_official_config())
+        self.assertEqual(config.num_layers, 93)
+        self.assertEqual(config.num_experts, 896)
+        self.assertEqual(config.num_experts_per_tok, 16)
+        self.assertEqual(config.expert_quant, "mxfp4")
+        self.assertEqual(config.moe_weight_format, "mxfp4")
+        self.assertEqual(config.num_moe_layers, 92)
+        self.assertEqual(config.kimi_k3_args.routed_expert_hidden_size, 3584)
+        self.assertEqual(config.kimi_k3_args.mla_latent_dim, 576)
+        linear = next(
+            g
+            for g in config.attention_groups
+            if isinstance(g, LinearGatedDeltaGroupConfig)
+        )
+        mla = next(
+            g
+            for g in config.attention_groups
+            if isinstance(g, FullAttentionGroupConfig)
+        )
+        self.assertEqual(len(linear.layer_ids), 69)
+        self.assertEqual(len(mla.layer_ids), 24)
+        self.assertEqual(mla.layer_ids[:2], (3, 7))
+        self.assertEqual(mla.layer_ids[-1], 92)
+        self.assertEqual(set(linear.layer_ids) | set(mla.layer_ids), set(range(93)))
+        self.assertFalse(config.supports_hybrid_radix)
+        self.assertTrue(mla.mla)
+        self.assertEqual(mla.head_dim, 576)
+        self.assertEqual(mla.rotary_config.rotary_dim, 0)
+
+    def test_development_checkpoint_geometry_and_top_level_quantization(self):
+        config = parse_config(_development_config())
+        self.assertEqual(config.num_layers, 8)
+        self.assertEqual(config.num_moe_layers, 7)
+        self.assertEqual(config.num_experts, 8)
+        self.assertEqual(config.num_experts_per_tok, 2)
+        self.assertEqual(config.kimi_k3_args.routed_expert_hidden_size, 512)
+        self.assertEqual(config.kimi_k3_args.kda_head_dim, 32)
+        self.assertIsNone(config.kimi_k3_args.kda_gate_lower_bound)
+        self.assertEqual(config.expert_quant, "mxfp4")
+
+    def test_mxfp4_detector_fails_closed_on_nvfp4_geometry(self):
+        config = _official_config()
+        quant = copy.deepcopy(config.text_config.quantization_config)
+        quant["config_groups"]["group_0"]["weights"].update(
+            group_size=16, strategy="tensor_group"
+        )
+        config.text_config.quantization_config = quant
+        with self.assertRaisesRegex(ValueError, "unsupported Kimi-K3 MXFP4 geometry"):
+            detect_kimi_mxfp4(config.text_config)
+
+    def test_mxfp4_detector_rejects_dense_quantization_contract(self):
+        config = _official_config()
+        config.text_config.quantization_config["ignore"].remove(r"re:.*self_attn.*")
+        with self.assertRaisesRegex(ValueError, "routed-expert-only"):
+            detect_kimi_mxfp4(config.text_config)
+
+    def test_incomplete_attention_map_is_rejected_before_allocation(self):
+        config = _official_config()
+        config.text_config.linear_attn_config["kda_layers"].pop()
+        with self.assertRaisesRegex(ValueError, "attention layer map is incomplete"):
+            parse_config(config)
+
+    def test_changed_situ_contract_is_rejected(self):
+        config = _official_config()
+        config.text_config.activation_situ_beta = 3.0
+        with self.assertRaisesRegex(ValueError, "SiTU kernels require"):
+            parse_config(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/models/test_kimi_k3_weight.py
+++ b/tests/models/test_kimi_k3_weight.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from freetoken.models.kimi_k3 import weight
+from safetensors.torch import save_file
+
+
+def _tp1():
+    return SimpleNamespace(size=1, rank=0, is_primary=lambda: True)
+
+
+def _config(
+    *,
+    experts: int = 1,
+    hidden: int = 64,
+    intermediate: int = 32,
+    num_layers: int = 93,
+):
+    return SimpleNamespace(
+        moe_weight_format="mxfp4",
+        kimi_k3_args=SimpleNamespace(routed_expert_hidden_size=hidden),
+        moe_intermediate_size=intermediate,
+        first_k_dense_replace=1,
+        num_layers=num_layers,
+        num_experts=experts,
+    )
+
+
+def test_resident_names_strip_wrapper_and_skip_vision_mtp_and_experts():
+    assert weight._resident_name("language_model.model.embed_tokens.weight", 93) == (
+        "model.embed_tokens.weight"
+    )
+    assert weight._resident_name(
+        "language_model.model.layers.92.self_attn.q_proj.weight", 93
+    ) == ("model.layers.92.self_attn.q_proj.weight")
+    assert (
+        weight._resident_name(
+            "language_model.model.layers.93.self_attn.q_proj.weight", 93
+        )
+        is None
+    )
+    assert weight._resident_name("vision_tower.blocks.0.weight", 93) is None
+    assert weight._resident_name("mm_projector.post_norm.weight", 93) is None
+    assert weight._resident_name("language_model.mtp.norm.weight", 93) is None
+    assert (
+        weight._resident_name(
+            "language_model.model.layers.7.block_sparse_moe.gate.e_score_correction_bias",
+            93,
+        )
+        == "model.layers.7.block_sparse_moe.e_score_correction_bias"
+    )
+    assert (
+        weight._resident_name(
+            "language_model.model.layers.1.block_sparse_moe.experts.0.w1.weight_packed",
+            93,
+        )
+        is None
+    )
+
+
+def test_resident_loader_fuses_dense_and_shared_mlp_across_shards(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    monkeypatch.setattr(weight, "cached_load_hf_config", lambda _: object())
+    monkeypatch.setattr(
+        weight, "parse_config", lambda _: SimpleNamespace(num_layers=93)
+    )
+    gate = torch.full((2, 3), 1.0)
+    up = torch.full((2, 3), 2.0)
+    shared_gate = torch.full((4, 3), 3.0)
+    shared_up = torch.full((4, 3), 4.0)
+    save_file(
+        {
+            "language_model.model.layers.0.mlp.gate_proj.weight": gate,
+            "language_model.model.layers.1.block_sparse_moe.shared_experts.up_proj.weight": shared_up,
+        },
+        tmp_path / "model-00001-of-00002.safetensors",
+    )
+    save_file(
+        {
+            "language_model.model.layers.0.mlp.up_proj.weight": up,
+            "language_model.model.layers.1.block_sparse_moe.shared_experts.gate_proj.weight": shared_gate,
+            "language_model.model.layers.1.block_sparse_moe.gate.e_score_correction_bias": torch.ones(
+                5
+            ),
+        },
+        tmp_path / "model-00002-of-00002.safetensors",
+    )
+    loaded = dict(
+        weight.iter_weights(
+            str(tmp_path),
+            torch.device("cpu"),
+            include_moe_experts=False,
+            include_non_moe=True,
+        )
+    )
+    torch.testing.assert_close(
+        loaded["model.layers.0.mlp.gate_up_proj.weight"], torch.cat((gate, up))
+    )
+    torch.testing.assert_close(
+        loaded["model.layers.1.block_sparse_moe.shared_experts.gate_up_proj.weight"],
+        torch.cat((shared_gate, shared_up)),
+    )
+    assert "model.layers.1.block_sparse_moe.e_score_correction_bias" in loaded
+
+
+def test_resident_loader_rejects_incomplete_mlp_pair(tmp_path, monkeypatch):
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    monkeypatch.setattr(weight, "cached_load_hf_config", lambda _: object())
+    monkeypatch.setattr(
+        weight, "parse_config", lambda _: SimpleNamespace(num_layers=93)
+    )
+    save_file(
+        {"language_model.model.layers.0.mlp.gate_proj.weight": torch.ones(2, 3)},
+        tmp_path / "model.safetensors",
+    )
+    with pytest.raises(ValueError, match="incomplete Kimi-K3 resident MLP fusions"):
+        list(
+            weight.iter_weights(
+                str(tmp_path),
+                torch.device("cpu"),
+                include_moe_experts=False,
+                include_non_moe=True,
+            )
+        )
+
+
+def test_resident_loader_dequantizes_mxfp4_pairs_across_shards(tmp_path, monkeypatch):
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    monkeypatch.setattr(weight, "cached_load_hf_config", lambda _: object())
+    monkeypatch.setattr(weight, "parse_config", lambda _: SimpleNamespace(num_layers=8))
+    prefix = "language_model.model.layers.1.block_sparse_moe.shared_experts"
+    packed = torch.full((2, 16), 0x11, dtype=torch.uint8)
+    scales = torch.full((2, 1), 127, dtype=torch.uint8)
+    save_file(
+        {
+            f"{prefix}.gate_proj.weight_packed": packed,
+            f"{prefix}.up_proj.weight_scale": scales,
+        },
+        tmp_path / "model-00001-of-00002.safetensors",
+    )
+    save_file(
+        {
+            f"{prefix}.gate_proj.weight_scale": scales,
+            f"{prefix}.up_proj.weight_packed": packed,
+        },
+        tmp_path / "model-00002-of-00002.safetensors",
+    )
+
+    loaded = dict(
+        weight.iter_weights(
+            str(tmp_path),
+            torch.device("cpu"),
+            include_moe_experts=False,
+            include_non_moe=True,
+        )
+    )
+    fused = loaded["model.layers.1.block_sparse_moe.shared_experts.gate_up_proj.weight"]
+    assert fused.dtype == torch.bfloat16
+    torch.testing.assert_close(fused, torch.full_like(fused, 0.5))
+
+
+def test_resident_fusion_rejects_incompatible_shapes():
+    buffer = {}
+    assert (
+        weight._fuse_resident_mlp(
+            "model.layers.0.mlp.gate_proj.weight", torch.ones(2, 3), buffer, 93
+        )
+        is None
+    )
+    with pytest.raises(ValueError, match="incompatible Kimi-K3 gate/up fusion"):
+        weight._fuse_resident_mlp(
+            "model.layers.0.mlp.up_proj.weight", torch.ones(3, 3), buffer, 93
+        )
+
+
+def test_copy_transposes_and_interleaves_gate_up():
+    h, i = 64, 32
+    banks = {
+        "gate_up_blocks": [torch.zeros(1, h // 2, 2 * i, dtype=torch.uint8)],
+        "gate_up_scales": [torch.zeros(1, h // 32, 2 * i, dtype=torch.uint8)],
+        "down_blocks": [torch.zeros(1, i // 2, h, dtype=torch.uint8)],
+        "down_scales": [torch.zeros(1, i // 32, h, dtype=torch.uint8)],
+    }
+    w1 = torch.randint(0, 256, (i, h // 2), dtype=torch.uint8)
+    w3 = (w1 + 19).to(torch.uint8)
+    w2 = torch.randint(0, 256, (h, i // 2), dtype=torch.uint8)
+    for proj, value in (("w1", w1), ("w3", w3), ("w2", w2)):
+        weight._copy_expert_tensor(
+            banks,
+            layer=0,
+            expert=0,
+            proj=proj,
+            kind="weight_packed",
+            value=value,
+            hidden=h,
+            intermediate=i,
+        )
+    torch.testing.assert_close(banks["gate_up_blocks"][0][0, :, ::2], w1.t())
+    torch.testing.assert_close(banks["gate_up_blocks"][0][0, :, 1::2], w3.t())
+    torch.testing.assert_close(banks["down_blocks"][0][0], w2.t())
+
+
+def test_copy_fails_closed_on_wrong_shape_or_dtype():
+    banks = {"gate_up_blocks": [torch.empty(1)]}
+    with pytest.raises(ValueError, match="expected uint8"):
+        weight._copy_expert_tensor(
+            banks,
+            layer=0,
+            expert=0,
+            proj="w1",
+            kind="weight_packed",
+            value=torch.empty(1, 1),
+            hidden=64,
+            intermediate=32,
+        )
+
+
+def test_official_keys_load_into_92_zero_based_moe_banks(tmp_path, monkeypatch):
+    # Shrink only the numerical geometry; retain the official 1..92 layer map and
+    # all six required tensors per expert so this exercises completeness checks.
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    tensors = {}
+    for checkpoint_layer in range(1, 93):
+        prefix = (
+            f"language_model.model.layers.{checkpoint_layer}.block_sparse_moe.experts.0"
+        )
+        for proj, shape in (
+            ("w1", (32, 32)),
+            ("w3", (32, 32)),
+            ("w2", (64, 16)),
+        ):
+            value = checkpoint_layer + {"w1": 1, "w2": 2, "w3": 3}[proj]
+            tensors[f"{prefix}.{proj}.weight_packed"] = torch.full(
+                shape, value % 256, dtype=torch.uint8
+            )
+        for proj, shape in (
+            ("w1", (32, 2)),
+            ("w3", (32, 2)),
+            ("w2", (64, 1)),
+        ):
+            value = checkpoint_layer + {"w1": 4, "w2": 5, "w3": 6}[proj]
+            tensors[f"{prefix}.{proj}.weight_scale"] = torch.full(
+                shape, value % 256, dtype=torch.uint8
+            )
+    save_file(tensors, tmp_path / "model.safetensors")
+
+    banks = weight.load_mxfp4_expert_banks(
+        str(tmp_path), _config(), dtype=torch.bfloat16
+    )
+    assert len(banks["gate_up_blocks"]) == 92
+    assert banks["gate_up_blocks"][0].shape == (1, 32, 64)
+    assert banks["gate_up_blocks"][91][0, 0, 0].item() == 93  # layer 1/92 + w1 marker
+    assert banks["gate_up_blocks"][91][0, 0, 1].item() == 95  # layer 92 + w3 marker
+    assert banks["down_blocks"][0][0, 0, 0].item() == 3
+    assert banks["gate_up_bias"][0] is banks["gate_up_bias"][91]
+    assert banks["down_bias"][0] is banks["down_bias"][91]
+    assert not torch.count_nonzero(banks["gate_up_bias"][0])
+
+
+def test_loader_rejects_missing_and_unexpected_expert_tensors(tmp_path, monkeypatch):
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    bad = {
+        "language_model.model.layers.1.block_sparse_moe.experts.0.w1.weight": torch.zeros(
+            1, dtype=torch.uint8
+        )
+    }
+    save_file(bad, tmp_path / "model.safetensors")
+    with pytest.raises(ValueError, match="unexpected Kimi-K3 expert tensor"):
+        weight.load_mxfp4_expert_banks(str(tmp_path), _config(), dtype=torch.bfloat16)
+
+    bad = {"language_model.model.norm.weight": torch.zeros(1)}
+    save_file(bad, tmp_path / "model.safetensors")
+    with pytest.raises(ValueError, match="missing Kimi-K3 expert tensors"):
+        weight.load_mxfp4_expert_banks(str(tmp_path), _config(), dtype=torch.bfloat16)

--- a/tests/models/test_kimi_k3_weight.py
+++ b/tests/models/test_kimi_k3_weight.py
@@ -29,6 +29,38 @@ def _config(
     )
 
 
+def _official_expert_tensors(config):
+    tensors = {}
+    hidden = config.kimi_k3_args.routed_expert_hidden_size
+    intermediate = config.moe_intermediate_size
+    for checkpoint_layer in range(config.first_k_dense_replace, config.num_layers):
+        for expert in range(config.num_experts):
+            prefix = (
+                f"language_model.model.layers.{checkpoint_layer}.block_sparse_moe."
+                f"experts.{expert}"
+            )
+            marker = checkpoint_layer * 31 + expert * 7
+            for proj, shape in (
+                ("w1", (intermediate, hidden // 2)),
+                ("w3", (intermediate, hidden // 2)),
+                ("w2", (hidden, intermediate // 2)),
+            ):
+                value = marker + {"w1": 1, "w2": 2, "w3": 3}[proj]
+                tensors[f"{prefix}.{proj}.weight_packed"] = torch.full(
+                    shape, value % 256, dtype=torch.uint8
+                )
+            for proj, shape in (
+                ("w1", (intermediate, hidden // 32)),
+                ("w3", (intermediate, hidden // 32)),
+                ("w2", (hidden, intermediate // 32)),
+            ):
+                value = marker + {"w1": 4, "w2": 5, "w3": 6}[proj]
+                tensors[f"{prefix}.{proj}.weight_scale"] = torch.full(
+                    shape, value % 256, dtype=torch.uint8
+                )
+    return tensors
+
+
 def test_resident_names_strip_wrapper_and_skip_vision_mtp_and_experts():
     assert weight._resident_name("language_model.model.embed_tokens.weight", 93) == (
         "model.embed_tokens.weight"
@@ -260,6 +292,71 @@ def test_official_keys_load_into_92_zero_based_moe_banks(tmp_path, monkeypatch):
     assert banks["gate_up_bias"][0] is banks["gate_up_bias"][91]
     assert banks["down_bias"][0] is banks["down_bias"][91]
     assert not torch.count_nonzero(banks["gate_up_bias"][0])
+
+
+def test_parallel_loader_matches_serial_banks(tmp_path, monkeypatch):
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    config = _config(experts=2, num_layers=3)
+    tensors = _official_expert_tensors(config)
+    save_file(tensors, tmp_path / "model.safetensors")
+
+    calls = []
+
+    def portable_parallel_reader(model_path, is_expert, *, workers, chunk):
+        calls.append((model_path, workers, chunk))
+        with weight.safetensors.safe_open(
+            tmp_path / "model.safetensors", framework="pt", device="cpu"
+        ) as checkpoint:
+            for name in checkpoint.keys():
+                if is_expert(name):
+                    yield name, checkpoint.get_tensor(name)
+
+    from freetoken.models import weight as common_weight
+
+    monkeypatch.setattr(
+        common_weight, "iter_expert_tensors_parallel", portable_parallel_reader
+    )
+    serial = weight.load_mxfp4_expert_banks(
+        str(tmp_path), config, dtype=torch.bfloat16
+    )
+    parallel = weight.load_mxfp4_expert_banks_parallel(
+        str(tmp_path), config, dtype=torch.bfloat16, workers=3, chunk=4096
+    )
+
+    assert calls == [(str(tmp_path), 3, 4096)]
+    assert serial.keys() == parallel.keys()
+    for bank_name in serial:
+        assert len(serial[bank_name]) == len(parallel[bank_name])
+        for serial_layer, parallel_layer in zip(
+            serial[bank_name], parallel[bank_name], strict=True
+        ):
+            torch.testing.assert_close(serial_layer, parallel_layer)
+
+
+def test_setup_dispatches_parallel_reader_options(monkeypatch):
+    monkeypatch.setattr(weight, "get_tp_info", _tp1)
+    config = _config(num_layers=2)
+    sources = {"sentinel": [torch.tensor(1)]}
+    calls = []
+
+    def fake_parallel(model_path, model_config, *, dtype, workers, chunk):
+        calls.append((model_path, model_config, dtype, workers, chunk))
+        return sources
+
+    monkeypatch.setattr(weight, "load_mxfp4_expert_banks_parallel", fake_parallel)
+    result = weight.setup_offload_expert_banks(
+        "/checkpoint",
+        config,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        parallel=True,
+        workers=5,
+        chunk=8192,
+    )
+
+    assert result.quant_format == "mxfp4_triton"
+    assert result.sources is sources
+    assert calls == [("/checkpoint", config, torch.bfloat16, 5, 8192)]
 
 
 def test_loader_rejects_missing_and_unexpected_expert_tensors(tmp_path, monkeypatch):

--- a/tests/moe/test_cpu_moe.py
+++ b/tests/moe/test_cpu_moe.py
@@ -339,6 +339,58 @@ def test_cpu_decode_mxfp4_matches_gpu_splitk(bs):
     assert rel < 4e-2, f"mxfp4 bs={bs} rel err {rel.item()}"
 
 
+@pytest.mark.parametrize("bs", [1, 4])
+def test_cpu_decode_mxfp4_kimi_situ_matches_gpu_splitk(bs):
+    """CPU and Triton MXFP4 paths implement the same Kimi-K3 SiTU epilogue."""
+    from freetoken.moe.cpu_executor import CpuMoeExecutor
+    from freetoken.moe.fused_mxfp4 import run_mxfp4_splitk_decode_experts
+
+    torch.manual_seed(400 + bs)
+    L, E, H, I, top_k = 2, 8, 256, 256, 2
+    layer = 1
+    beta, linear_beta = 4.0, 25.0
+    dev = torch.device("cuda")
+    cache = _make_mxfp4_cache(L, E, H, I, seed=29)
+
+    ex = CpuMoeExecutor(
+        cache,
+        top_k=top_k,
+        activation="situ",
+        apply_router_weight_on_input=False,
+        num_threads=0,
+        max_tokens=bs,
+        device=dev,
+        swiglu_alpha=beta,
+        swiglu_limit=linear_beta,
+    )
+
+    hidden = torch.randn(bs, H, device=dev, dtype=torch.bfloat16)
+    ids = torch.stack([torch.randperm(E, device=dev)[:top_k] for _ in range(bs)]).to(torch.int32)
+    weights = torch.rand(bs, top_k, device=dev, dtype=torch.float32)
+    cpu_out = ex.decode(layer, hidden, weights, ids).float()
+    torch.cuda.synchronize()
+
+    banks = cache.bank_sources
+    gpu_out = run_mxfp4_splitk_decode_experts(
+        hidden,
+        weights,
+        ids.clone(),
+        banks["gate_up_blocks"][layer].to(dev),
+        banks["gate_up_scales"][layer].to(dev),
+        banks["gate_up_bias"][layer].to(dev),
+        banks["down_blocks"][layer].to(dev),
+        banks["down_scales"][layer].to(dev),
+        banks["down_bias"][layer].to(dev),
+        top_k=top_k,
+        hidden_act_alpha=beta,
+        swiglu_limit=linear_beta,
+        activation="situ",
+    ).float()
+
+    rel = (cpu_out - gpu_out).abs().max() / (gpu_out.abs().max() + 1e-6)
+    assert rel < 4e-2, f"mxfp4 SiTU bs={bs} rel err {rel.item()}"
+
+
 def _make_dsfp4_cache(L, E, H, I, seed=0):
     """Random DeepSeek-V4 ``ds_fp4`` banks (row-major e2m1 + e8m0/32, no global)."""
     torch.manual_seed(seed)

--- a/tests/moe/test_gpt_oss.py
+++ b/tests/moe/test_gpt_oss.py
@@ -119,20 +119,22 @@ def test_gpt_oss_fused_routing_matches_softmax_topk_renorm(num_experts):
             assert abs(got[e] - want[e]) < 1e-3, f"token {t} expert {e}: {got[e]} vs {want[e]}"
 
 
-def _mxfp4_dequant_reference(run, M, seed):
+def _mxfp4_dequant_reference(
+    run, M, seed, *, activation="gpt_oss_swiglu", alpha=1.702, limit=7.0
+):
     """Run `run` (a split-K decode or _t prefill helper) on random mxfp4 experts and
     compare against a full dequant -> linear -> swiglu -> linear reference."""
     from freetoken.moe.fused_mxfp4 import (
         _transpose_mxfp4_for_decode,
         dequant_mxfp4_blocks,
         gpt_oss_swiglu,
+        kimi_situ,
     )
 
     device = torch.device("cuda")
     gen = torch.Generator(device=device).manual_seed(seed)
     E, H, I = 8, 128, 64
     top_k = 2
-    alpha, limit = 1.702, 7.0
     hb, ib = H // 32, I // 32
 
     gu_b = torch.randint(0, 256, (E, 2 * I, hb, 16), device=device, dtype=torch.uint8, generator=gen)
@@ -151,6 +153,7 @@ def _mxfp4_dequant_reference(run, M, seed):
     out = run(
         hidden, tw, tid, gbt, gst, gu_bias, dbt, dst, dn_bias,
         top_k=top_k, hidden_act_alpha=alpha, swiglu_limit=limit,
+        activation=activation,
     )
 
     expected = torch.zeros(M, H, device=device, dtype=torch.float32)
@@ -159,7 +162,10 @@ def _mxfp4_dequant_reference(run, M, seed):
             e = int(tid[t, r])
             gw = dequant_mxfp4_blocks(gu_b[e], gu_s[e], out_dtype=torch.float32)
             gate_up = torch.nn.functional.linear(hidden[t].float(), gw, gu_bias[e].float())
-            act = gpt_oss_swiglu(gate_up, alpha=alpha, limit=limit)
+            if activation == "situ":
+                act = kimi_situ(gate_up, beta=alpha, linear_beta=limit)
+            else:
+                act = gpt_oss_swiglu(gate_up, alpha=alpha, limit=limit)
             dw = dequant_mxfp4_blocks(dn_b[e], dn_s[e], out_dtype=torch.float32)
             expected[t] += torch.nn.functional.linear(act, dw, dn_bias[e].float()) * float(tw[t, r])
     torch.cuda.synchronize()
@@ -180,6 +186,36 @@ def test_run_mxfp4_prefill_experts_t_matches_reference(M):
     from freetoken.moe.fused_mxfp4 import run_mxfp4_prefill_experts_t
 
     _mxfp4_dequant_reference(run_mxfp4_prefill_experts_t, M, seed=31)
+
+
+@CUDA
+@pytest.mark.parametrize("M", [1, 3])
+def test_run_mxfp4_splitk_kimi_situ_matches_reference(M):
+    """Kimi's interleaved gate/up SiTU epilogue matches full MXFP4 dequantization."""
+    from freetoken.moe.fused_mxfp4 import run_mxfp4_splitk_decode_experts
+
+    _mxfp4_dequant_reference(
+        run_mxfp4_splitk_decode_experts,
+        M,
+        seed=41,
+        activation="situ",
+        alpha=4.0,
+        limit=25.0,
+    )
+
+
+@CUDA
+def test_run_mxfp4_prefill_kimi_situ_matches_reference():
+    from freetoken.moe.fused_mxfp4 import run_mxfp4_prefill_experts_t
+
+    _mxfp4_dequant_reference(
+        run_mxfp4_prefill_experts_t,
+        24,
+        seed=51,
+        activation="situ",
+        alpha=4.0,
+        limit=25.0,
+    )
 
 
 # ── offload movement (bit-identical vs the same kernel on the banks) ─────────

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -622,8 +622,26 @@ def test_offload_cache_rebuild_resizes_and_preserves_sources():
     # bookkeeping resized + reset
     assert cache.id_of_slot.shape == (10,)
     assert cache.usage.shape == (10,)
+    assert cache.evict_slots.shape == (10,)
+    assert cache.src_indices.shape == (10,)
     assert torch.all(cache.slot_for_id == -1)
     assert torch.all(cache.id_of_slot == -1)
+
+
+def test_offload_copy_plan_supports_batched_topk_larger_than_expert_count():
+    from freetoken.moe.offload_cache import OffloadMoeCache
+
+    _init_tp()
+    cache = OffloadMoeCache(
+        num_layers=7,
+        num_experts=8,
+        cache_size=56,
+        device=torch.device("cpu"),
+    )
+    # Kimi-K3's graph capture uses bs=32, top-k=2: flashlib needs a
+    # min(64 query rows, 56 slots) plan, not an 8-row expert-layer plan.
+    assert cache.src_indices.numel() >= min(32 * 2, cache.cache_size)
+    assert cache.evict_slots.numel() >= min(32 * 2, cache.cache_size)
 
 
 def test_offload_cache_rebuild_disables_prefill_overlap_when_too_small():

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -415,7 +415,7 @@ def test_adjust_config_converts_moe_cache_rate_to_cache_size():
         model_path="/tmp/freetoken-test-model",
         tp_info=DistributedInfo(rank=0, size=1),
         dtype=torch.float16,
-        attention_backend="fi",
+        attention_backend="triton",
         moe_cache_rate=0.3,
     )
     object.__setattr__(
@@ -475,6 +475,8 @@ def test_graph_capture_reuses_warm_offload_cache_before_capture(monkeypatch):
             return torch.zeros(batch.size, 3)
 
     class FakeOffloadCache:
+        cache_size = 1
+
         def reset(self):
             events.append("reset")
 

--- a/tests/tokenizer/test_hf_loading.py
+++ b/tests/tokenizer/test_hf_loading.py
@@ -1,0 +1,15 @@
+from unittest.mock import Mock
+
+
+def test_load_tokenizer_allows_checkpoint_custom_code(monkeypatch):
+    from freetoken.utils import hf
+
+    tokenizer = Mock(chat_template="template")
+    load = Mock(return_value=tokenizer)
+    monkeypatch.setattr(hf.AutoTokenizer, "from_pretrained", load)
+    monkeypatch.setattr(hf, "hf_hub_download", Mock())
+
+    assert hf.load_tokenizer("example/custom-tokenizer") is tokenizer
+    load.assert_called_once_with(
+        "example/custom-tokenizer", trust_remote_code=True
+    )


### PR DESCRIPTION
Closes #92.

## What changed

- adds native Kimi-K3 config parsing, model registration, KDA/MLA attention,
  latent-MoE routing, SiTU, and checkpoint weight mapping
- supports the official full configuration and the public eight-layer
  `inference-optimization/Kimi-K3-0.40B-MXFP4` development checkpoint
- supports TP=1 with MXFP4 routed experts through the offload-family backends
- makes hybrid KDA/MLA KV allocation layer-aware
- bounds CUDA graph batch sizes against the available MoE cache slots
- makes the offload copy plan size from cache capacity instead of expert count
- loads custom Hugging Face tokenizers with `trust_remote_code=True` and adds
  the required `tiktoken` dependency
- selects naive request caching for Kimi until linear-attention state snapshots
  can support radix reuse safely

## Validation

- 61 focused model, weight-loader, KV-pool, MoE, graph, and tokenizer tests
  passed while CUDA was healthy
- 22/22 config, loader, graph-batch, and tokenizer tests passed again after the
  benchmark host lost GPU access
- exact checkpoint audit loaded 204 resident tensors with matching shapes and
  all seven routed-expert banks from revision
  `ef3902c318fb8e13c3507e26055656e687fdfe38`
- OpenAI-compatible streaming generation ran end to end on an RTX 3090 through
  32 simultaneous requests

Raw metrics, methodology, host/checkpoint metadata, and the disclosed host
failure are preserved in the
[benchmark artifact](https://github.com/tekizai/tekizai/tree/bench/kimi-k3-freetoken-3090-20260823/artifacts/model-comparisons/kimi-k3-freetoken-3090-20260823).

The benchmark uses the 0.40B development checkpoint only as a functional test.
Its throughput is not presented as a proxy for the full 2.8T model. During a
sustained repetition, the live-swapped NVIDIA driver lost the passed-through
GPU; completed samples are retained, the interrupted sample is not reported,
and the failure is documented in the artifact.

## Scope

- text generation only
- tensor parallel size 1
- Kimi routed experts must be MXFP4
- hybrid radix reuse is intentionally disabled for Kimi pending KDA state
  snapshot support

This contribution was directed by the operator and implemented/tested with
Codex assistance. The implementation was manually checked against the official
configuration and checkpoint keys.

## Full-checkpoint qualification evidence

The full `moonshotai/Kimi-K3` checkpoint passed an end-to-end OpenAI-compatible qualification on 4× NVIDIA H200. The versioned record includes the exact server arguments, 21m30s cold start to first `/v1/models`, warmup and streaming measurements, and a 1/2/4/8/16-request concurrency sweep with 31/31 successful requests.

- [Human-readable H200 qualification record](https://github.com/earlvanze/FreeToken/blob/feat/kimi-k3-support/benchmarks/kimi_k3_vast_h200_20260824.md)
- [Machine-readable H200 measurements](https://github.com/earlvanze/FreeToken/blob/feat/kimi-k3-support/benchmarks/kimi_k3_vast_h200_20260824.json)
- [`docs/models.md` Supported Models entry](https://github.com/earlvanze/FreeToken/blob/feat/kimi-k3-support/docs/models.md)

The branch was rebased on upstream `main` (`bd372b6`). The Kimi, generic offload, GPT-OSS, and graph batch-size regression suite passes: 59 tests.
