### PR TITLE
perf(dsv4): compute the hyper-connection pre-norm in one kernel

### DIFF
--- a/python/freetoken/kernel/triton/dsv4/norm.py
+++ b/python/freetoken/kernel/triton/dsv4/norm.py
@@ -52,4 +52,48 @@ def rms_norm(x: torch.Tensor, weight: torch.Tensor | None, eps: float) -> torch.
     return out.reshape(x.shape)
 
 
-__all__ = ["rms_norm"]
+@triton.jit
+def _inv_rms_kernel(x_ptr, o_ptr, D, eps, stride_xm, BLOCK_D: tl.constexpr):
+    row = tl.program_id(0)
+    acc = tl.zeros((BLOCK_D,), dtype=tl.float32)
+    for off in range(0, D, BLOCK_D):
+        offs = off + tl.arange(0, BLOCK_D)
+        v = tl.load(x_ptr + row * stride_xm + offs, mask=offs < D, other=0.0).to(tl.float32)
+        acc += v * v
+    tl.store(o_ptr + row, tl.rsqrt(tl.sum(acc, axis=0) / D + eps))
+
+
+def inv_rms(x: torch.Tensor, eps: float) -> torch.Tensor:
+    """``rsqrt(mean(x^2, -1) + eps)`` -> ``[..., 1]`` fp32, one pass, no fp32 temp.
+
+    :func:`rms_norm` applies the scale and writes a full-size output; callers that need
+    the *scalar* (DSV4's hyper-connection pre-norm multiplies it into a [.., mix_hc]
+    tensor, not into x) were spelling it ``x.float().square().mean(-1)``, which
+    materialises a second full fp32 copy of the hidden state purely to reduce it away.
+    At hc_dim 16384, T=8192 that is a 537 MB write plus a 537 MB read for a [T, 1]
+    result. Reading the bf16 source instead of its fp32 upcast halves the bytes again;
+    the upcast is exact, so the sum of squares is unchanged.
+
+    RTX 6000 Ada, hc_dim 16384: 1.944 ms -> 0.304 ms at T=8192 (6.4x), 0.020 -> 0.013 ms
+    at T=64. The large end lands at ~880 GB/s against a 960 GB/s peak -- the memory roof.
+
+    NOT bit-identical to ``square().mean()``: the reduction order differs, and ATen's
+    order is not reproducible anyway (it varies with M -- a tree/2 fold matches at M=4
+    and nothing matches at M=64, because the block/grid split is chosen per shape). The
+    accuracy is equivalent, not merely close: against an fp64 reference the mean relative
+    error is 3.65e-08 here vs 3.60e-08 for ATen at M=8192, and 3.60e-08 vs 3.63e-08 at
+    M=4096 -- i.e. it wins at some shapes and loses at others, within 8% of ATen's own
+    distance from the truth. (``linalg.vector_norm`` is the same speed but consistently
+    ~23% worse, at 4.47e-08, because sqrt-then-square rounds twice.)
+    """
+    D = x.shape[-1]
+    x2d = x.reshape(-1, D)
+    out = torch.empty(x2d.shape[0], dtype=torch.float32, device=x.device)
+    _inv_rms_kernel[(x2d.shape[0],)](
+        x2d, out, D, eps, x2d.stride(0),
+        BLOCK_D=min(2048, triton.next_power_of_2(D)), num_warps=8,
+    )
+    return out.view(*x.shape[:-1], 1)
+
+
+__all__ = ["rms_norm", "inv_rms"]

--- a/python/freetoken/models/deepseek_v4/model.py
+++ b/python/freetoken/models/deepseek_v4/model.py
@@ -27,6 +27,7 @@ from torch import nn
 
 from freetoken.core import get_global_ctx
 from freetoken.kernel.triton.dsv4.hc import hc_post_combine, hc_pre_combine
+from freetoken.kernel.triton.dsv4.norm import inv_rms
 from freetoken.kernel.triton.dsv4.sinkhorn import hc_split_sinkhorn
 from freetoken.models.blocks import BaseLLMModel
 
@@ -73,8 +74,9 @@ class Block(nn.Module):
 
     def hc_pre(self, x, hc_fn, hc_scale, hc_base):
         shape, dtype = x.size(), x.dtype
-        xf = x.flatten(2).float()
-        rsqrt = torch.rsqrt(xf.square().mean(-1, keepdim=True) + self.norm_eps)
+        x2d = x.flatten(2)
+        xf = x2d.float()
+        rsqrt = inv_rms(x2d, self.norm_eps)
         mixes = F.linear(xf, hc_fn) * rsqrt
         pre, post, comb = hc_split_sinkhorn(
             mixes.view(-1, mixes.size(-1)), hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.hc_eps
@@ -151,8 +153,9 @@ class Transformer(nn.Module):
     def hc_head(self, x):
         shape, dtype = x.size(), x.dtype
         dim = self.args.dim
-        xf = x.flatten(2).float()
-        rsqrt = torch.rsqrt(xf.square().mean(-1, keepdim=True) + self.norm_eps)
+        x2d = x.flatten(2)
+        xf = x2d.float()
+        rsqrt = inv_rms(x2d, self.norm_eps)
         mixes = F.linear(xf, self.hc_head_fn) * rsqrt
         pre = torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base) + self.hc_eps
         M = shape[0] * shape[1]

--- a/tests/dsv4/test_hc_inv_rms.py
+++ b/tests/dsv4/test_hc_inv_rms.py
@@ -1,0 +1,67 @@
+"""``inv_rms`` must agree with the expression it replaced, and be no less accurate.
+
+The old form was ``torch.rsqrt(xf.square().mean(-1, keepdim=True) + eps)`` over the
+fp32 upcast. ``inv_rms`` reduces the bf16 source directly: the upcast is exact, so the
+per-element squares are identical and only the reduction order differs. Bit-equality is
+not asserted -- ATen's order varies with M and is not reproducible -- so the contract
+is (a) agreement to fp32 rounding and (b) accuracy no worse than ATen's against fp64.
+"""
+import pytest
+import torch
+
+from freetoken.kernel.triton.dsv4.norm import inv_rms
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="triton kernel")
+
+HC_DIM = 4 * 4096  # hc_mult * dim at DSV4-Flash
+EPS = 1e-6
+
+
+def _old(xf, eps):
+    return torch.rsqrt(xf.square().mean(-1, keepdim=True) + eps)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("rows", [1, 7, 512])
+def test_matches_square_mean(dtype, rows):
+    dev = "cuda"
+    x = torch.randn(rows, HC_DIM, device=dev, dtype=dtype)
+    got = inv_rms(x, EPS)
+    ref = _old(x.float(), EPS)
+    assert got.shape == ref.shape == (rows, 1)
+    assert got.dtype == torch.float32
+    torch.testing.assert_close(got, ref, rtol=1e-5, atol=0)
+
+
+def test_keeps_leading_dims():
+    """hc_pre feeds a [B, T, hc_dim] view and broadcasts the result against [B, T, mix]."""
+    dev = "cuda"
+    x = torch.randn(2, 3, HC_DIM, device=dev, dtype=torch.bfloat16)
+    got = inv_rms(x, EPS)
+    assert got.shape == (2, 3, 1)
+    torch.testing.assert_close(got, _old(x.float(), EPS), rtol=1e-5, atol=0)
+
+
+def test_tiny_and_large_magnitudes():
+    """Check the scale range a hidden state can reach."""
+    dev = "cuda"
+    for scale in (1e-3, 1.0, 1e3):
+        x = torch.randn(4, HC_DIM, device=dev, dtype=torch.bfloat16) * scale
+        torch.testing.assert_close(inv_rms(x, EPS), _old(x.float(), EPS),
+                                   rtol=1e-5, atol=0)
+
+
+def test_accuracy_not_worse_than_aten():
+    """The point of the Triton reduce over ``linalg.vector_norm``: no sqrt round-trip,
+    so it stays level with ATen against an fp64 reference instead of ~23% behind."""
+    torch.manual_seed(0)
+    for rows in (64, 1024):
+        x = torch.randn(rows, HC_DIM, device="cuda", dtype=torch.bfloat16)
+        xf = x.float()
+        xd = xf.double()
+        truth = torch.rsqrt((xd * xd).mean(-1, keepdim=True) + EPS)
+        err_new = ((inv_rms(x, EPS).double() - truth).abs() / truth.abs()).mean()
+        err_aten = ((_old(xf, EPS).double() - truth).abs() / truth.abs()).mean()
+        # same quality of fp32 answer -- allow a small margin either way, but catch a
+        # real regression such as accumulating in bf16 or re-squaring a norm.
+        assert err_new < err_aten * 1.25, (rows, err_new.item(), err_aten.item())


### PR DESCRIPTION
## The problem

`Block.hc_pre` and `Transformer.hc_head` compute the inverse RMS of the hidden state:

```python
xf    = x.flatten(2).float()
rsqrt = torch.rsqrt(xf.square().mean(-1, keepdim=True) + eps)
```

`square()` writes a second full fp32 copy of the hidden state. `mean()` then reads that copy back and reduces it to one value per row. At DeepSeek-V4-Flash shapes (`hc_dim` 16384, T=8192) the pair moves 1.6 GB to produce a `[T, 1]` result.

## The change

This PR adds `inv_rms` to `kernel/triton/dsv4/norm.py`, beside the existing `rms_norm`. It reduces each row in one pass and returns the scalar.

`rms_norm` cannot serve here. It applies the scale to `x` and writes a full-size output, but the hyper-connection pre-norm multiplies the scalar into a `[.., mix_hc]` tensor instead.

The kernel reads the bf16 source rather than the fp32 upcast. The upcast is exact, so the squares do not change, and this halves the bytes again.

## Measurements

One RTX 6000 Ada, `hc_dim` 16384, measured on `main`.

| rows | before | after | speedup |
|---:|---:|---:|---:|
| 64 | 0.020 ms | 0.017 ms | 1.2x |
| 512 | 0.030 ms | 0.016 ms | 1.9x |
| 4096 | 0.972 ms | 0.153 ms | 6.3x |
| 8192 | 1.944 ms | 0.304 ms | 6.4x |

The whole pre-norm block, which also includes the upcast and the narrow fp32 linear that follows:

| T | before | after | speedup |
|---:|---:|---:|---:|
| 1024 | 0.307 ms | 0.108 ms | 2.83x |
| 4096 | 1.819 ms | 0.966 ms | 1.88x |
| 8192 | 3.628 ms | 1.969 ms | 1.84x |

At 8192 rows the kernel moves 268 MB in 0.304 ms. That is 880 GB/s, against a 960 GB/s peak on this card.

## Effect on a running server

Two nsys captures of `main`, one without the change and one with it. DeepSeek-V4-Flash, `--moe-backend offload`, TP=1, 16 concurrent requests, prompts of about 1700 tokens. Both runs completed 33 requests in the 45-second window, so the work is comparable.

| kernel | baseline | with `inv_rms` |
|---|---:|---:|
| `vectorized_elementwise_kernel` (the `square`) | 633 launches, 181.8 ms | 0 |
| `reduce_kernel<512,1,ReduceOp<float>>` (the `mean`) | 633 launches, 91.9 ms | 0 |
| `_inv_rms_kernel` | absent | 629 launches, 48.9 ms |
| total GPU kernel time | 5.830 s | 5.587 s |

273.7 ms of kernel time becomes 48.9 ms. Total GPU kernel time falls 4.2%.

That figure is small in wall-clock terms on the machine it was measured on, because `--moe-backend offload` puts the routed experts on the CPU and leaves the GPU 13% busy. A GPU-resident deployment spends a larger share of its time here.

## Accuracy

The result is not bit-identical to `square().mean()`, and it cannot be. ATen chooses its reduction order per shape. A tree-of-two fold reproduces it exactly at M=4, and no candidate order reproduces it at M=64, because the block and grid split changes with M. Any fused form therefore moves the last bit.

What matters is that accuracy does not get worse. Measured against an fp64 reference:

| rows | ATen mean relative error | `inv_rms` |
|---:|---:|---:|
| 64 | 3.00e-08 | 3.24e-08 |
| 512 | 3.47e-08 | 3.50e-08 |
| 4096 | 3.63e-08 | 3.60e-08 |
| 8192 | 3.60e-08 | 3.65e-08 |

`inv_rms` is ahead at 4096 rows and behind at the other three, always within 8% of ATen's own distance from the truth. A test pins this.

Two faster-looking forms were rejected on that test. `linalg.vector_norm` matches the speed but is consistently about 23% worse, at 4.47e-08, because taking a square root and then squaring it rounds twice. `einsum` over bf16 accumulates in bf16 and reaches 1.9e-03.

Bit-identical forms exist, but none is faster. `vecdot(xf, xf)` lowers to the same path and takes 1.944 ms. `vecdot` with fp32 accumulation over bf16 takes 4.557 ms.

## Effect on generated text

The server is deterministic. Two baseline runs produced byte-identical greedy output. Moving the last bit therefore changes greedy continuations. Reviewers who depend on exact-output tests should treat this as a deliberate trade, not an invisible one.

## Testing

`tests/dsv4/test_hc_inv_rms.py` covers shape, dtype, leading dimensions, magnitude range, and the accuracy floor.

On `main` with this change: `tests/dsv4 tests/models tests/kernels` gives 265 passed, 1 skipped, 1 failed. The failure is `test_e4m3_compat.py::test_forced_emu_matches_native`, which also fails on `main` without this change. #85 fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpGe2fQ5pDShGrnSuksfun