### PR TITLE
feat(models): support TP for qwen3_5_moe

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -1331,9 +1331,12 @@ def _adjust_config(config: EngineConfig):
 
     if (
         is_moe
-        and expert_quant not in ("none", "fp8_block")
+        and expert_quant not in ("none", "fp8_block", "nvfp4")
         and not is_offload_moe_backend(config.moe_backend)
     ):
+        # The resident (fused) backend supports bf16 ("none"), block-fp8, and native NVFP4
+        # experts (TP-sharded on the intermediate dim); the other quant formats (mxfp4,
+        # q4_0, ds_fp4, ...) have no resident allocation and need the offload/cpu backends.
         raise ValueError(
             f"{expert_quant} experts require --moe-backend offload or cpu, "
             f"got {config.moe_backend!r}"

--- a/python/freetoken/kernel/triton/fp8_block_linear.py
+++ b/python/freetoken/kernel/triton/fp8_block_linear.py
@@ -294,23 +294,63 @@ class Fp8BlockLinear(BaseOP):
 
 
 class Fp8BlockColMerged(Fp8BlockLinear):
-    """Block-fp8 column-merged linear (drop-in for ``LinearColParallelMerged`` at TP=1).
+    """Block-fp8 column-merged linear (drop-in for ``LinearColParallelMerged``).
 
     Holds one fp8 weight that is the concatenation of several projections along the output
-    dim; the caller splits the bf16 output by ``output_sizes`` exactly as before. Each part's
-    out dim must be a multiple of 128 so the concatenated ``weight_scale_inv`` blocks align."""
+    dim; the caller splits the bf16 output by the (TP-local) part sizes. Each part's
+    out dim must be a multiple of 128 so the concatenated ``weight_scale_inv`` blocks align.
 
-    def __init__(self, in_features: int, output_sizes: list[int], has_bias: bool = False):
+    With ``local_output_sizes`` (TP>1) each part is sharded along the output dim
+    independently (GQA KV-head replication included) and ``weight_scale_inv`` is sharded
+    identically along its row axis."""
+
+    def __init__(self, in_features: int, output_sizes: list[int], has_bias: bool = False,
+                 local_output_sizes: list[int] | None = None):
         for o in output_sizes:
             assert o % _BLOCK == 0, (output_sizes, "each merged output size must be /128 for fp8")
         self.output_sizes = list(output_sizes)
-        super().__init__(in_features, sum(output_sizes), has_bias)
+        if local_output_sizes is not None:
+            assert len(local_output_sizes) == len(output_sizes), (
+                local_output_sizes, output_sizes
+            )
+            for o in local_output_sizes:
+                assert o % _BLOCK == 0, (local_output_sizes, "local sizes must be /128 for fp8")
+            out_features = sum(local_output_sizes)
+        else:
+            out_features = sum(output_sizes)
+        super().__init__(in_features, out_features, has_bias)
+
+
+class Fp8BlockRowParallel(Fp8BlockLinear):
+    """Row-parallel block-fp8 linear (drop-in for ``LinearRowParallel``): fp8 ``weight``
+    ``[out, in/tp]`` + ``weight_scale_inv`` ``[out//128, in/tp//128]``. Each rank reduces
+    over its input shard only (activations are quantized per 128-K group *within* the
+    shard, so the dequant stays exact per rank); the all-reduce completes the sum and the
+    bias (if any) is added once, after it."""
+
+    def __init__(self, in_features: int, out_features: int, has_bias: bool = False):
+        from freetoken.distributed import DistributedCommunicator, get_tp_info
+        from freetoken.utils import div_even
+
+        tp_info = get_tp_info()
+        self._tp_size = tp_info.size
+        self._comm = DistributedCommunicator() if tp_info.size > 1 else None
+        super().__init__(div_even(in_features, tp_info.size), out_features, has_bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = block_fp8_linear(x, self.weight, self.weight_scale_inv, None)
+        if self._tp_size > 1:
+            y = self._comm.all_reduce(y)
+        if self.bias is not None:
+            y = y + self.bias.to(y.dtype)
+        return y
 
 
 __all__ = [
     "FP8",
     "Fp8BlockLinear",
     "Fp8BlockColMerged",
+    "Fp8BlockRowParallel",
     "block_fp8_linear",
     "block_fp8_matmul",
     "per_token_group_quant_fp8",

--- a/python/freetoken/kernel/triton/fp8_pertensor_linear.py
+++ b/python/freetoken/kernel/triton/fp8_pertensor_linear.py
@@ -327,18 +327,61 @@ class Fp8PerTensorLinear(BaseOP):
 
 
 class Fp8PerTensorColMerged(Fp8PerTensorLinear):
-    """Column-merged per-tensor-FP8 linear (drop-in for ``LinearColParallelMerged`` at TP=1):
+    """Column-merged per-tensor-FP8 linear (drop-in for ``LinearColParallelMerged``):
     one fp8 weight concatenating several projections along the output dim; the caller splits
-    the bf16 output by ``output_sizes`` as before."""
+    the bf16 output by the (TP-local) part sizes.
 
-    def __init__(self, in_features: int, output_sizes: list[int], has_bias: bool = False):
+    With ``local_output_sizes`` (TP>1) each part is sharded along the output dim
+    independently -- including GQA KV-head replication when ``num_kv_heads < tp_size`` --
+    and the per-row ``weight_scale`` is sharded identically (it is piecewise-constant, one
+    scalar per part, so row sharding keeps every part's scale exact)."""
+
+    def __init__(self, in_features: int, output_sizes: list[int], has_bias: bool = False,
+                 local_output_sizes: list[int] | None = None):
         self.output_sizes = list(output_sizes)
-        super().__init__(in_features, sum(output_sizes), has_bias)
+        if local_output_sizes is not None:
+            assert len(local_output_sizes) == len(output_sizes), (
+                local_output_sizes, output_sizes
+            )
+            out_features = sum(local_output_sizes)
+        else:
+            out_features = sum(output_sizes)
+        super().__init__(in_features, out_features, has_bias)
+
+class Fp8PerTensorRowParallel(Fp8PerTensorLinear):
+    """Row-parallel per-tensor-FP8 linear (drop-in for ``LinearRowParallel``): fp8 ``weight``
+    ``[out, in/tp]`` + per-row ``weight_scale`` ``[out]`` (the output dim is not sharded).
+    Each rank reduces over its input shard only, so the result is a partial sum that the
+    all-reduce completes. The bias (if any) is added once, after the all-reduce.
+
+    ``input_scale`` is unchanged: every rank quantizes its own activation shard with the
+    same per-tensor scale, so the W8A8 path stays exact per rank."""
+
+    def __init__(self, in_features: int, out_features: int, has_bias: bool = False):
+        from freetoken.distributed import DistributedCommunicator, get_tp_info
+        from freetoken.utils import div_even
+
+        tp_info = get_tp_info()
+        self._tp_size = tp_info.size
+        self._comm = DistributedCommunicator() if tp_info.size > 1 else None
+        super().__init__(div_even(in_features, tp_info.size), out_features, has_bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = fp8_pertensor_linear(
+            x, self.weight, self.weight_scale, None,
+            self.input_scale, self._uniform_scale,
+        )
+        if self._tp_size > 1:
+            y = self._comm.all_reduce(y)
+        if self.bias is not None:
+            y = y + self.bias.to(y.dtype)
+        return y
 
 
 __all__ = [
     "FP8",
     "Fp8PerTensorLinear",
     "Fp8PerTensorColMerged",
+    "Fp8PerTensorRowParallel",
     "fp8_pertensor_linear",
 ]

--- a/python/freetoken/kernel/triton/nvfp4_linear.py
+++ b/python/freetoken/kernel/triton/nvfp4_linear.py
@@ -884,14 +884,55 @@ class Nvfp4DenseLinear(BaseOP):
 
 
 class Nvfp4DenseColMerged(Nvfp4DenseLinear):
-    """Column-merged NVFP4 dense linear (drop-in for ``LinearColParallelMerged`` at TP=1):
+    """Column-merged NVFP4 dense linear (drop-in for ``LinearColParallelMerged``):
     one packed weight concatenating several projections on the output dim; each part keeps its
     own per-row ``weight_global`` (and block scales), so the fused weight is exact. The caller
-    splits the output by ``output_sizes`` (e.g. shared-expert gate|up) as before."""
+    splits the output by the (TP-local) part sizes (e.g. shared-expert gate|up).
 
-    def __init__(self, in_features: int, output_sizes: list[int], has_bias: bool = False):
+    With ``local_output_sizes`` (TP>1) each part is sharded along the output dim
+    independently and the block scales / per-row globals are sharded identically."""
+
+    def __init__(self, in_features: int, output_sizes: list[int], has_bias: bool = False,
+                 local_output_sizes: list[int] | None = None):
         self.output_sizes = list(output_sizes)
-        super().__init__(in_features, sum(output_sizes), has_bias)
+        if local_output_sizes is not None:
+            assert len(local_output_sizes) == len(output_sizes), (
+                local_output_sizes, output_sizes
+            )
+            out_features = sum(local_output_sizes)
+        else:
+            out_features = sum(output_sizes)
+        super().__init__(in_features, out_features, has_bias)
+
+
+class Nvfp4DenseRowParallel(Nvfp4DenseLinear):
+    """Row-parallel NVFP4 dense linear (drop-in for ``LinearRowParallel``): packed ``weight``
+    ``[out, in/tp//2]`` + block ``weight_scale`` ``[out, in/tp//16]`` + per-row
+    ``weight_global`` ``[out]`` (the output dim is not sharded). Each rank reduces over its
+    input shard only; the all-reduce completes the sum and the bias (if any) is added once,
+    after it. The K-major repack at load is an exact permutation, so it works on the shard."""
+
+    def __init__(self, in_features: int, out_features: int, has_bias: bool = False):
+        from freetoken.distributed import DistributedCommunicator, get_tp_info
+        from freetoken.utils import div_even
+
+        tp_info = get_tp_info()
+        self._tp_size = tp_info.size
+        self._comm = DistributedCommunicator() if tp_info.size > 1 else None
+        super().__init__(div_even(in_features, tp_info.size), out_features, has_bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self._transposed:
+            y = nvfp4_dense_linear_t(
+                x, self.weight, self.weight_scale, self.weight_global, None
+            )
+        else:
+            y = nvfp4_dense_linear(x, self.weight, self.weight_scale, self.weight_global, None)
+        if self._tp_size > 1:
+            y = self._comm.all_reduce(y)
+        if self.bias is not None:
+            y = y + self.bias.to(y.dtype)
+        return y
 
 
 class Nvfp4LMHead(BaseOP):
@@ -937,5 +978,6 @@ __all__ = [
     "nvfp4_transpose_resident",
     "Nvfp4DenseLinear",
     "Nvfp4DenseColMerged",
+    "Nvfp4DenseRowParallel",
     "Nvfp4LMHead",
 ]

--- a/python/freetoken/layers/linear.py
+++ b/python/freetoken/layers/linear.py
@@ -59,10 +59,14 @@ class LinearColParallelMerged(_LinearTPImpl):
         input_size: int,
         output_sizes: List[int],
         has_bias: bool,
+        local_output_sizes: List[int] | None = None,
     ):
         # check that all output sizes are divisible by tp_size
         tp_info = get_tp_info()
-        tp_output_sizes = [div_even(size, tp_info.size) for size in output_sizes]
+        if local_output_sizes is not None:
+            tp_output_sizes = local_output_sizes
+        else:
+            tp_output_sizes = [div_even(size, tp_info.size) for size in output_sizes]
         output_size = sum(output_sizes)
         tp_output_size = sum(tp_output_sizes)
         super().__init__(input_size, output_size, input_size, tp_output_size, has_bias)

--- a/python/freetoken/layers/moe.py
+++ b/python/freetoken/layers/moe.py
@@ -77,6 +77,23 @@ class MoELayer(BaseOP):
             self.down_proj = torch.empty(n, h, i, dtype=FP8)
             self.down_scale_inv = torch.empty(n, h // blk, i // blk, dtype=torch.bfloat16)
             return
+        if self.weight_format == "nvfp4":
+            # Native ModelOpt NVFP4 rows (W4A16), TP-sharded on the intermediate dim:
+            # gate_up is column-parallel (shard the 2*I output rows), down is row-parallel
+            # (shard the I input cols); the down global scale keeps the full H output rows.
+            # The plain *_nvfp4 Triton kernels read these directly (inline dequant in the
+            # K-loop, no pre-tile, no BF16 copy) -- the resident mirror of the offload
+            # cache's "nvfp4" quant_format.
+            n, h = self.num_experts, self.hidden_size
+            i = intermediate_size_per_partition
+            fp8 = torch.float8_e4m3fn
+            self.gate_up_packed = torch.empty(n, 2 * i, h // 2, dtype=torch.uint8)
+            self.gate_up_scale = torch.empty(n, 2 * i, h // 16, dtype=fp8)
+            self.gate_up_global = torch.empty(n, 2 * i, dtype=torch.float16)
+            self.down_packed = torch.empty(n, h, i // 2, dtype=torch.uint8)
+            self.down_scale = torch.empty(n, h, i // 16, dtype=fp8)
+            self.down_global = torch.empty(n, h, dtype=torch.float16)
+            return
         assert self.weight_format == "bf16", (
             f"no resident expert allocation for weight_format {self.weight_format!r}"
         )
@@ -138,6 +155,37 @@ class MoELayer(BaseOP):
             return fused_experts_decode_fp8_block(
                 hidden_states, self.gate_up_proj, self.gate_up_scale_inv,
                 self.down_proj, self.down_scale_inv, topk_weights, topk_ids,
+            )
+        if self.weight_format == "nvfp4":
+            # Native NVFP4 rows: the plain *_nvfp4 Triton kernels read the banks directly
+            # (inline dequant in the K-loop, no BF16 copy). One kernel per phase, mirroring
+            # OffloadMoELayer._expert_gemm's "nvfp4" branch. The swigluoai scalars (if any)
+            # live on the layer via make_moe_layer's extra_attrs and are ignored by the
+            # plain *_and_mul activations.
+            act_alpha = getattr(self, "hidden_act_alpha", 1.702)
+            act_limit = getattr(self, "swiglu_limit", None)
+            # None == "no clamp" everywhere else in the repo (mxfp4 maps it to +inf).
+            act_limit = float("inf") if act_limit is None else act_limit
+            if get_global_ctx().batch.is_prefill:
+                from freetoken.moe.fused_nvfp4 import fused_experts_nvfp4
+
+                return fused_experts_nvfp4(
+                    hidden_states,
+                    self.gate_up_packed, self.gate_up_scale, self.gate_up_global,
+                    self.down_packed, self.down_scale, self.down_global,
+                    topk_weights, topk_ids, self.num_experts,
+                    self.activation, self.apply_router_weight_on_input,
+                    act_alpha, act_limit,
+                )
+            from freetoken.moe.fused_nvfp4 import fused_experts_decode_nvfp4_marlin
+
+            return fused_experts_decode_nvfp4_marlin(
+                hidden_states,
+                self.gate_up_packed, self.gate_up_scale, self.gate_up_global,
+                self.down_packed, self.down_scale, self.down_global,
+                topk_weights, topk_ids,
+                self.activation, self.apply_router_weight_on_input,
+                act_alpha, act_limit,
             )
         assert self.weight_format == "bf16", (
             f"no resident expert kernel for weight_format {self.weight_format!r}"

--- a/python/freetoken/layers/moe.py
+++ b/python/freetoken/layers/moe.py
@@ -219,6 +219,11 @@ class OffloadMoELayer(MoELayer):
         self.layer_id = layer_id
         self.offload_cache: OffloadMoeCache | None = None
 
+    def _maybe_all_reduce(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Offload MoE: each rank computes the full expert output (banks are not TP-sharded),
+        so no all-reduce is needed — the result is already the complete output."""
+        return hidden_states
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/python/freetoken/models/nvfp4_banks.py
+++ b/python/freetoken/models/nvfp4_banks.py
@@ -320,8 +320,149 @@ def load_nvfp4_expert_source_banks_parallel(
     }
 
 
+def load_nvfp4_expert_resident_banks(
+    model_path: str,
+    config,
+    spec: Nvfp4ExpertSourceSpec,
+    *,
+    drop_page_cache: DropPageCache,
+    primary: bool,
+    rank: int,
+    world_size: int,
+) -> dict[str, list[torch.Tensor]]:
+    """Build the 6 native NVFP4 expert banks for the RESIDENT (fused) path, TP-sharded on
+    the intermediate dim, on host (pageable; the engine's ``_materialize`` moves them to GPU).
+
+    The resident mirror of :func:`load_nvfp4_expert_source_banks`: same 6-bank native ModelOpt
+    layout, but each rank allocates only its TP slice of the intermediate dim and places only
+    that slice -- gate_up is column-parallel (shard the 2*I output rows, an un-packed row dim),
+    down is row-parallel (shard the I input cols, a packed dim: //2 for the FP4 bytes, //16 for
+    the per-16 block scale); the down global scale keeps the full H output rows. The banks are
+    never pinned (the resident path copies them to GPU and drops them).
+
+    Returns 6 lists of ``[E, ...]`` host tensors (one per MoE layer), sharded to this rank.
+    """
+    folder = download_hf_weight(model_path)
+    index_path = os.path.join(folder, "model.safetensors.index.json")
+    with open(index_path, encoding="utf-8") as f:
+        weight_map = json.load(f)["weight_map"]
+
+    E = config.num_experts
+    H = config.hidden_size
+    I = config.moe_intermediate_size
+    assert I % world_size == 0, f"moe_intermediate_size {I} not divisible by tp {world_size}"
+    i = I // world_size
+    assert i % 16 == 0, (
+        f"per-rank intermediate {i} not a multiple of 16 (NVFP4 per-16 block scale must "
+        f"not straddle a rank boundary)"
+    )
+    num_layers = _num_moe_layers(config)
+
+    fp8 = torch.float8_e4m3fn
+    # Sharded (per-rank) bank shapes: gate_up output rows 2*I -> 2*i; down input cols I -> i.
+    specs = {
+        "gate_up_packed": ((E, 2 * i, H // 2), torch.uint8),
+        "gate_up_scale": ((E, 2 * i, H // 16), fp8),
+        "gate_up_global": ((E, 2 * i), torch.float16),
+        "down_packed": ((E, H, i // 2), torch.uint8),
+        "down_scale": ((E, H, i // 16), fp8),
+        "down_global": ((E, H), torch.float16),
+    }
+    banks = {
+        name: [torch.empty(shape, dtype=dt) for _ in range(num_layers)]
+        for name, (shape, dt) in specs.items()
+    }
+    gate_up_packed = banks["gate_up_packed"]
+    gate_up_scale = banks["gate_up_scale"]
+    gate_up_global = banks["gate_up_global"]
+    down_packed = banks["down_packed"]
+    down_scale = banks["down_scale"]
+    down_global = banks["down_global"]
+
+    # This rank's slice of the full intermediate dim (row units for gate_up, col units for down).
+    g0, g1 = rank * i, (rank + 1) * i
+
+    for shard in sorted(set(weight_map.values())):
+        drop_page_cache(os.path.join(folder, shard))
+
+    weight_shards: dict[str, list[tuple[str, re.Match[str], int]]] = collections.defaultdict(list)
+    global_shards: dict[str, list[tuple[str, re.Match[str], int]]] = collections.defaultdict(list)
+    for name, shard in weight_map.items():
+        match = spec.key_pattern.match(name)
+        if match is None:
+            continue
+        layer = int(match.group("layer"))
+        bank_layer = _bank_layer(spec, layer, config)
+        if bank_layer is None:
+            continue
+        proj = match.group("proj")
+        if proj not in spec.proj_to_role:
+            raise ValueError(f"{spec.desc}: unknown NVFP4 expert projection {proj!r}")
+        kind = match.group("kind")
+        if kind == "weight_scale_2":
+            global_shards[shard].append((name, match, bank_layer))
+        elif kind in {"weight", "weight_scale"}:
+            weight_shards[shard].append((name, match, bank_layer))
+        else:
+            raise ValueError(f"{spec.desc}: unknown NVFP4 expert tensor kind {kind!r}")
+
+    globals_map: dict[tuple[int, int, str], torch.Tensor] = {}
+    for shard in sorted(global_shards):
+        path = os.path.join(folder, shard)
+        with safetensors.safe_open(path, framework="pt", device="cpu") as f:
+            for name, match, _bl in global_shards[shard]:
+                key = (int(match.group("layer")), int(match.group("expert")), match.group("proj"))
+                globals_map[key] = f.get_tensor(name).to(torch.float16)
+        drop_page_cache(path)
+
+    placed = 0
+    for shard in tqdm(
+        sorted(weight_shards),
+        desc=f"Loading {spec.desc} (resident tp={world_size}, rank={rank})",
+        disable=not primary,
+    ):
+        path = os.path.join(folder, shard)
+        with safetensors.safe_open(path, framework="pt", device="cpu") as f:
+            for name, match, bank_layer_id in weight_shards[shard]:
+                layer = int(match.group("layer"))
+                expert = int(match.group("expert"))
+                proj = match.group("proj")
+                role = spec.proj_to_role[proj]
+                kind = match.group("kind")
+                tensor = f.get_tensor(name)
+                if kind == "weight":
+                    if role == "gate":
+                        gate_up_packed[bank_layer_id][expert, :i] = tensor[g0:g1]
+                    elif role == "up":
+                        gate_up_packed[bank_layer_id][expert, i:] = tensor[g0:g1]
+                    elif role == "down":
+                        down_packed[bank_layer_id][expert] = tensor[:, g0 // 2 : g1 // 2]
+                    else:
+                        raise ValueError(f"{spec.desc}: unknown projection role {role!r}")
+                else:  # weight_scale
+                    g = globals_map[(layer, expert, proj)]
+                    if role == "gate":
+                        gate_up_scale[bank_layer_id][expert, :i] = tensor[g0:g1]
+                        gate_up_global[bank_layer_id][expert, :i] = g
+                    elif role == "up":
+                        gate_up_scale[bank_layer_id][expert, i:] = tensor[g0:g1]
+                        gate_up_global[bank_layer_id][expert, i:] = g
+                    elif role == "down":
+                        down_scale[bank_layer_id][expert] = tensor[:, g0 // 16 : g1 // 16]
+                        down_global[bank_layer_id][expert] = g
+                    else:
+                        raise ValueError(f"{spec.desc}: unknown projection role {role!r}")
+                placed += 1
+        drop_page_cache(path)
+
+    expected = num_layers * E * 6
+    assert placed == expected, f"{spec.desc}: loaded {placed} expert tensors, expected {expected}"
+    return banks
+
+
 __all__ = [
     "Nvfp4ExpertSourceSpec",
     "load_nvfp4_expert_source_banks",
     "load_nvfp4_expert_source_banks_parallel",
+    "load_nvfp4_expert_resident_banks",
 ]

--- a/python/freetoken/models/quant_linear.py
+++ b/python/freetoken/models/quant_linear.py
@@ -14,21 +14,26 @@ from __future__ import annotations
 def make_col_merged_quant(expert_quant: str, attn_quant: str, in_f: int,
                           output_sizes: list[int], has_bias: bool = False,
                           local_output_sizes: list[int] | None = None):
-    """Column-merged linear for a dense projection: block-fp8 / per-tensor-fp8 / nvfp4 / bf16."""
-    if local_output_sizes is not None and (expert_quant != "none" or attn_quant != "none"):
-        raise NotImplementedError("local_output_sizes (GQA KV replication) not yet supported for quantized checkpoints")
+    """Column-merged linear for a dense projection: block-fp8 / per-tensor-fp8 / nvfp4 / bf16.
+
+    ``local_output_sizes`` (TP>1) shards each part along the output dim independently
+    (GQA KV-head replication included); the quantized layers carry their per-row / per-block
+    scales, which the weight loader shards identically."""
     if expert_quant == "fp8_block":
         from freetoken.kernel.triton.fp8_block_linear import Fp8BlockColMerged
 
-        return Fp8BlockColMerged(in_f, output_sizes, has_bias)
+        return Fp8BlockColMerged(in_f, output_sizes, has_bias,
+                                 local_output_sizes=local_output_sizes)
     if attn_quant == "fp8_pertensor":
         from freetoken.kernel.triton.fp8_pertensor_linear import Fp8PerTensorColMerged
 
-        return Fp8PerTensorColMerged(in_f, output_sizes, has_bias)
+        return Fp8PerTensorColMerged(in_f, output_sizes, has_bias,
+                                     local_output_sizes=local_output_sizes)
     if attn_quant == "nvfp4":  # compressed-tensors W4A16 attention (q/k/v fused)
         from freetoken.kernel.triton.nvfp4_linear import Nvfp4DenseColMerged
 
-        return Nvfp4DenseColMerged(in_f, output_sizes, has_bias)
+        return Nvfp4DenseColMerged(in_f, output_sizes, has_bias,
+                                   local_output_sizes=local_output_sizes)
     from freetoken.layers import LinearColParallelMerged
 
     return LinearColParallelMerged(in_f, output_sizes, has_bias=has_bias,
@@ -60,11 +65,17 @@ def make_row_parallel_quant(expert_quant: str, attn_quant: str, in_f: int, out_f
     """Row-parallel linear for a dense projection: block-fp8 / per-tensor-fp8 / nvfp4 / bf16.
     Shards the input dimension by tp_size and all-reduces on forward."""
     if expert_quant == "fp8_block":
-        raise NotImplementedError("row-parallel Fp8BlockLinear not yet implemented")
+        from freetoken.kernel.triton.fp8_block_linear import Fp8BlockRowParallel
+
+        return Fp8BlockRowParallel(in_f, out_f, has_bias)
     if attn_quant == "fp8_pertensor":
-        raise NotImplementedError("row-parallel Fp8PerTensorLinear not yet implemented")
+        from freetoken.kernel.triton.fp8_pertensor_linear import Fp8PerTensorRowParallel
+
+        return Fp8PerTensorRowParallel(in_f, out_f, has_bias)
     if attn_quant == "nvfp4":
-        raise NotImplementedError("row-parallel Nvfp4DenseLinear not yet implemented")
+        from freetoken.kernel.triton.nvfp4_linear import Nvfp4DenseRowParallel
+
+        return Nvfp4DenseRowParallel(in_f, out_f, has_bias)
     from freetoken.layers import LinearOProj
 
     return LinearOProj(in_f, out_f, has_bias=has_bias)
@@ -91,7 +102,7 @@ def make_col_merged(config, in_f: int, output_sizes: list[int], has_bias: bool =
 
 
 def make_row_parallel(config, in_f: int, out_f: int, has_bias: bool = False):
-    """Config-driven row-parallel linear: ``LinearOProj`` (bf16); quant variants TBD."""
+    """Config-driven row-parallel linear: quant variants (W4A16 / W8A16) or ``LinearOProj`` (bf16)."""
     return make_row_parallel_quant(
         getattr(config, "expert_quant", "none"), getattr(config, "attn_quant", "none"),
         in_f, out_f, has_bias,

--- a/python/freetoken/models/quant_linear.py
+++ b/python/freetoken/models/quant_linear.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 
 
 def make_col_merged_quant(expert_quant: str, attn_quant: str, in_f: int,
-                          output_sizes: list[int], has_bias: bool = False):
+                          output_sizes: list[int], has_bias: bool = False,
+                          local_output_sizes: list[int] | None = None):
     """Column-merged linear for a dense projection: block-fp8 / per-tensor-fp8 / nvfp4 / bf16."""
+    if local_output_sizes is not None and (expert_quant != "none" or attn_quant != "none"):
+        raise NotImplementedError("local_output_sizes (GQA KV replication) not yet supported for quantized checkpoints")
     if expert_quant == "fp8_block":
         from freetoken.kernel.triton.fp8_block_linear import Fp8BlockColMerged
 
@@ -28,7 +31,8 @@ def make_col_merged_quant(expert_quant: str, attn_quant: str, in_f: int,
         return Nvfp4DenseColMerged(in_f, output_sizes, has_bias)
     from freetoken.layers import LinearColParallelMerged
 
-    return LinearColParallelMerged(in_f, output_sizes, has_bias=has_bias)
+    return LinearColParallelMerged(in_f, output_sizes, has_bias=has_bias,
+                                   local_output_sizes=local_output_sizes)
 
 
 def make_replicated_quant(expert_quant: str, attn_quant: str, in_f: int, out_f: int,
@@ -51,6 +55,21 @@ def make_replicated_quant(expert_quant: str, attn_quant: str, in_f: int, out_f: 
     return LinearReplicated(in_f, out_f, has_bias=has_bias)
 
 
+def make_row_parallel_quant(expert_quant: str, attn_quant: str, in_f: int, out_f: int,
+                            has_bias: bool = False):
+    """Row-parallel linear for a dense projection: block-fp8 / per-tensor-fp8 / nvfp4 / bf16.
+    Shards the input dimension by tp_size and all-reduces on forward."""
+    if expert_quant == "fp8_block":
+        raise NotImplementedError("row-parallel Fp8BlockLinear not yet implemented")
+    if attn_quant == "fp8_pertensor":
+        raise NotImplementedError("row-parallel Fp8PerTensorLinear not yet implemented")
+    if attn_quant == "nvfp4":
+        raise NotImplementedError("row-parallel Nvfp4DenseLinear not yet implemented")
+    from freetoken.layers import LinearOProj
+
+    return LinearOProj(in_f, out_f, has_bias=has_bias)
+
+
 def make_replicated(config, in_f: int, out_f: int, has_bias: bool = False):
     """Config-driven replicated linear: ``Fp8BlockLinear`` under block-fp8, ``Fp8PerTensorLinear``
     under per-tensor-fp8 attention, ``Nvfp4DenseLinear`` under nvfp4, else ``LinearReplicated``."""
@@ -60,19 +79,30 @@ def make_replicated(config, in_f: int, out_f: int, has_bias: bool = False):
     )
 
 
-def make_col_merged(config, in_f: int, output_sizes: list[int], has_bias: bool = False):
+def make_col_merged(config, in_f: int, output_sizes: list[int], has_bias: bool = False,
+                     local_output_sizes: list[int] | None = None):
     """Config-driven column-merged linear: ``Fp8BlockColMerged`` under block-fp8,
     ``Fp8PerTensorColMerged`` under per-tensor-fp8 attention, ``Nvfp4DenseColMerged`` under
     nvfp4, else ``LinearColParallelMerged``."""
     return make_col_merged_quant(
         getattr(config, "expert_quant", "none"), getattr(config, "attn_quant", "none"),
-        in_f, output_sizes, has_bias,
+        in_f, output_sizes, has_bias, local_output_sizes=local_output_sizes,
+    )
+
+
+def make_row_parallel(config, in_f: int, out_f: int, has_bias: bool = False):
+    """Config-driven row-parallel linear: ``LinearOProj`` (bf16); quant variants TBD."""
+    return make_row_parallel_quant(
+        getattr(config, "expert_quant", "none"), getattr(config, "attn_quant", "none"),
+        in_f, out_f, has_bias,
     )
 
 
 __all__ = [
     "make_col_merged_quant",
     "make_replicated_quant",
+    "make_row_parallel_quant",
     "make_replicated",
     "make_col_merged",
+    "make_row_parallel",
 ]

--- a/python/freetoken/models/qwen3_5_moe/attention.py
+++ b/python/freetoken/models/qwen3_5_moe/attention.py
@@ -4,11 +4,12 @@ from typing import TYPE_CHECKING
 
 import torch
 from freetoken.core import get_global_ctx
+from freetoken.distributed import get_tp_info
 from freetoken.layers import BaseOP, GemmaRMSNorm
 from freetoken.layers.rotary import get_rope
-from freetoken.utils import nvtx_annotate
+from freetoken.utils import div_even, nvtx_annotate
 
-from .quant_linear import make_col_merged, make_replicated
+from .quant_linear import make_col_merged, make_row_parallel
 
 if TYPE_CHECKING:
     from freetoken.models.config import ModelConfig
@@ -22,9 +23,6 @@ class Qwen3_5Attention(BaseOP):
         q, k = rope(q, k)                       # first rotary_dim dims
         attn = paged_attention(q, k, v)
         out = o_proj(attn * sigmoid(gate))
-
-    TP note: uses replicated linears (tp=1 correctness milestone); swap to
-    column/row-parallel for tensor parallelism later.
     """
 
     def __init__(self, config: ModelConfig, layer_id: int):
@@ -36,13 +34,21 @@ class Qwen3_5Attention(BaseOP):
         self.qo_attn_dim = self.num_q * head_dim
         self.kv_attn_dim = self.num_kv * head_dim
 
+        tp = get_tp_info()
         # Fused q/k/v projection (one GEMM instead of three); q half is 2x for the
         # output gate. Split sizes: [num_q*head_dim*2, num_kv*head_dim, num_kv*head_dim].
-        self._qkv_split = [self.num_q * head_dim * 2, self.kv_attn_dim, self.kv_attn_dim]
+        # _qkv_split is TP-local (for torch.split in forward); make_col_merged gets full sizes.
         # Block-fp8 (Fp8BlockColMerged) when the checkpoint is quantized, else bf16
         # LinearColParallelMerged. q/k/v out dims are all /128, so the merged fp8 weight +
         # weight_scale_inv concatenate cleanly along the output dim.
-        self.qkv_proj = make_col_merged(config, config.hidden_size, self._qkv_split, has_bias=False)
+        full_split = [self.num_q * head_dim * 2, self.kv_attn_dim, self.kv_attn_dim]
+        self._local_num_q = div_even(self.num_q, tp.size)
+        self._local_num_kv = div_even(self.num_kv, tp.size, allow_replicate=True)
+        self._local_qo_attn_dim = self._local_num_q * head_dim
+        self._local_kv_attn_dim = self._local_num_kv * head_dim
+        self._qkv_split = [self._local_num_q * head_dim * 2, self._local_kv_attn_dim, self._local_kv_attn_dim]
+        local_qkv_sizes = [self._local_num_q * head_dim * 2, self._local_kv_attn_dim, self._local_kv_attn_dim]
+        self.qkv_proj = make_col_merged(config, config.hidden_size, full_split, has_bias=False, local_output_sizes=local_qkv_sizes)
         # Qwen3.5 uses Gemma-style (1+weight) RMSNorm; the weight loader bakes the +1
         # into the stored weight (GemmaRMSNorm scales by the raw weight).
         self.q_norm = GemmaRMSNorm(head_dim, eps=config.rms_norm_eps)
@@ -58,7 +64,7 @@ class Qwen3_5Attention(BaseOP):
                 else None
             ),
         )
-        self.o_proj = make_replicated(config, self.qo_attn_dim, config.hidden_size, has_bias=False)
+        self.o_proj = make_row_parallel(config, self.qo_attn_dim, config.hidden_size, has_bias=False)
 
     def _project(self, x: torch.Tensor):
         """Returns (q, k, v, gate): q [N, num_q, head_dim] post qk-norm+rope,
@@ -66,18 +72,18 @@ class Qwen3_5Attention(BaseOP):
         positions = get_global_ctx().batch.positions
         qkv = self.qkv_proj.forward(x)
         qg, k, v = torch.split(qkv, self._qkv_split, dim=-1)
-        qg = qg.view(-1, self.num_q, self.head_dim * 2)
+        qg = qg.view(-1, self._local_num_q, self.head_dim * 2)
         q = qg[..., : self.head_dim].contiguous()  # [N, num_q, head_dim]
-        gate = qg[..., self.head_dim :].reshape(-1, self.qo_attn_dim)
-        k = k.view(-1, self.num_kv, self.head_dim).contiguous()
+        gate = qg[..., self.head_dim :].reshape(-1, self._local_qo_attn_dim)
+        k = k.reshape(-1, self._local_num_kv, self.head_dim).contiguous()
         v = v.contiguous()  # split view has the qkv row stride; the KV store needs contiguous
-        q = self.q_norm.forward(q).reshape(-1, self.qo_attn_dim)
-        k = self.k_norm.forward(k).reshape(-1, self.kv_attn_dim)
+        q = self.q_norm.forward(q).reshape(-1, self._local_qo_attn_dim)
+        k = self.k_norm.forward(k).reshape(-1, self._local_kv_attn_dim)
         q, k = self.rotary.forward(positions, q, k)
-        return q.view(-1, self.num_q, self.head_dim), k, v, gate
+        return q.view(-1, self._local_num_q, self.head_dim), k, v, gate
 
     def _combine(self, attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
-        gated = attn_out.reshape(-1, self.qo_attn_dim) * torch.sigmoid(gate)
+        gated = attn_out.reshape(-1, self._local_qo_attn_dim) * torch.sigmoid(gate)
         return self.o_proj.forward(gated)
 
     @nvtx_annotate("MHA")

--- a/python/freetoken/models/qwen3_5_moe/gdn.py
+++ b/python/freetoken/models/qwen3_5_moe/gdn.py
@@ -92,7 +92,8 @@ class Qwen3_5GatedDeltaNet(BaseOP):
         if self._fp8:
             ColMerged = Fp8BlockColMerged if self._block_fp8 else Fp8PerTensorColMerged
             self.in_proj_qkvz = ColMerged(
-                hidden_size, [self.conv_dim, self.value_dim], has_bias=False
+                hidden_size, [self.conv_dim, self.value_dim], has_bias=False,
+                local_output_sizes=[self._local_conv_dim, self._local_value_dim],
             )
             self.in_proj_ba = LinearColParallelMerged(
                 hidden_size, [num_v_heads, num_v_heads], has_bias=False

--- a/python/freetoken/models/qwen3_5_moe/gdn.py
+++ b/python/freetoken/models/qwen3_5_moe/gdn.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 from freetoken.core import get_global_ctx
+from freetoken.distributed import get_tp_info
 from freetoken.kernel.causal_conv1d import causal_conv1d_decode, causal_conv1d_varlen
 from freetoken.layers import BaseOP, LinearColParallelMerged
+from freetoken.utils import div_even
 
 from freetoken.kernel.triton.fp8_block_linear import Fp8BlockColMerged
 from freetoken.kernel.triton.fp8_pertensor_linear import Fp8PerTensorColMerged
 
 from .gdn_kernels import gdn_decode_fla, gdn_prefill_chunk_fla
-from .quant_linear import make_replicated_quant
+from .quant_linear import make_row_parallel_quant
 
 
 class _DepthwiseConv1d(BaseOP):
@@ -56,6 +58,7 @@ class Qwen3_5GatedDeltaNet(BaseOP):
         attn_quant: str = "none",
     ):
         self.layer_id = layer_id
+        tp = get_tp_info()
         # The fla chunk/decode kernels read+write the recurrent state and the per-chunk h as
         # [V, K] while the LinearStatePool declares it [K, V]; these coincide (and the
         # hybrid-radix snapshot scatter h[h_row]->slot is a plain copy) only when the two head
@@ -71,6 +74,12 @@ class Qwen3_5GatedDeltaNet(BaseOP):
         self.value_dim = num_v_heads * head_v_dim
         self.conv_dim = 2 * self.key_dim + self.value_dim
         self.conv_kernel_size = conv_kernel_size
+        # TP-local head counts for forward (reshape/split); LinearColParallelMerged gets full sizes
+        self._local_num_k_heads = div_even(num_k_heads, tp.size)
+        self._local_num_v_heads = div_even(num_v_heads, tp.size, allow_replicate=True)
+        self._local_key_dim = self._local_num_k_heads * head_k_dim
+        self._local_value_dim = self._local_num_v_heads * head_v_dim
+        self._local_conv_dim = 2 * self._local_key_dim + self._local_value_dim
         # qkv|z carry a weight scale (block-fp8 weight_scale_inv, or per-tensor FP8
         # weight_scale); b|a stay bf16. Both quant modes therefore split the four-way
         # fusion into an fp8 qkvz GEMM + a bf16 ba GEMM (matches sglang/vLLM).
@@ -78,7 +87,8 @@ class Qwen3_5GatedDeltaNet(BaseOP):
         self._pertensor_fp8 = attn_quant == "fp8_pertensor"
         self._fp8 = self._block_fp8 or self._pertensor_fp8
 
-        self._in_proj_split = [self.conv_dim, self.value_dim, num_v_heads, num_v_heads]
+        full_split = [self.conv_dim, self.value_dim, num_v_heads, num_v_heads]
+        self._in_proj_split = [div_even(s, tp.size) for s in full_split]  # TP-local for torch.split
         if self._fp8:
             ColMerged = Fp8BlockColMerged if self._block_fp8 else Fp8PerTensorColMerged
             self.in_proj_qkvz = ColMerged(
@@ -89,19 +99,19 @@ class Qwen3_5GatedDeltaNet(BaseOP):
             )
         else:
             # Fused input projection (one GEMM instead of four): qkv | z | b | a.
-            self.in_proj = LinearColParallelMerged(hidden_size, self._in_proj_split, has_bias=False)
-        self.conv1d = _DepthwiseConv1d(self.conv_dim, conv_kernel_size)
+            self.in_proj = LinearColParallelMerged(hidden_size, full_split, has_bias=False)
+        self.conv1d = _DepthwiseConv1d(self._local_conv_dim, conv_kernel_size)
         # Recurrence-gating params kept in fp32 (exp/softplus is precision-sensitive,
         # and the fla kernel reads them as fp32) -- matches HF/sglang, and avoids a
         # per-call .float() upcast in the decode wrapper. The weight loader exempts
         # *.A_log / *.dt_bias from the model-dtype downcast.
-        self.dt_bias = torch.empty(num_v_heads, dtype=torch.float32)
-        self.A_log = torch.empty(num_v_heads, dtype=torch.float32)
+        self.dt_bias = torch.empty(self._local_num_v_heads, dtype=torch.float32)
+        self.A_log = torch.empty(self._local_num_v_heads, dtype=torch.float32)
         self.norm = _GatedRMSNorm(head_v_dim, eps=rms_norm_eps)
         # out_proj follows the checkpoint quant: block-fp8 / per-tensor-fp8 / compressed-tensors
         # NVFP4 (W4A16) / bf16. in_proj_* stay bf16 in every mode (above), so a compressed-tensors
         # NVFP4 checkpoint (attn_quant=="nvfp4") only makes out_proj native FP4.
-        self.out_proj = make_replicated_quant(
+        self.out_proj = make_row_parallel_quant(
             expert_quant, attn_quant, self.value_dim, hidden_size, has_bias=False
         )
 
@@ -163,13 +173,13 @@ class Qwen3_5GatedDeltaNet(BaseOP):
 
         if self._fp8:
             qkvz = self.in_proj_qkvz.forward(hidden_states)
-            conv_in, z = torch.split(qkvz, [self.conv_dim, self.value_dim], dim=-1)
+            conv_in, z = torch.split(qkvz, [self._local_conv_dim, self._local_value_dim], dim=-1)
             ba = self.in_proj_ba.forward(hidden_states)
-            b, a = torch.split(ba, [self.num_v_heads, self.num_v_heads], dim=-1)
+            b, a = torch.split(ba, [self._local_num_v_heads, self._local_num_v_heads], dim=-1)
         else:
             proj = self.in_proj.forward(hidden_states)
             conv_in, z, b, a = torch.split(proj, self._in_proj_split, dim=-1)
-        z = z.reshape(total, self.num_v_heads, self.head_v_dim)
+        z = z.reshape(total, self._local_num_v_heads, self.head_v_dim)
         li = pool.local_index(self.layer_id)
 
         if batch.is_decode:
@@ -178,10 +188,10 @@ class Qwen3_5GatedDeltaNet(BaseOP):
             # no clone, no external l2norm). q/k stay at num_k_heads (kernel handles GQA).
             mixed = self._conv_decode(conv_in, fla.cache_indices, pool)  # [B, conv_dim]
             B = mixed.shape[0]
-            qf, kf, vf = torch.split(mixed, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
-            q = qf.reshape(1, B, self.num_k_heads, self.head_k_dim).to(dtype)
-            k = kf.reshape(1, B, self.num_k_heads, self.head_k_dim).to(dtype)
-            v = vf.reshape(1, B, self.num_v_heads, self.head_v_dim).to(dtype)
+            qf, kf, vf = torch.split(mixed, [self._local_key_dim, self._local_key_dim, self._local_value_dim], dim=-1)
+            q = qf.reshape(1, B, self._local_num_k_heads, self.head_k_dim).to(dtype)
+            k = kf.reshape(1, B, self._local_num_k_heads, self.head_k_dim).to(dtype)
+            v = vf.reshape(1, B, self._local_num_v_heads, self.head_v_dim).to(dtype)
             core_out = gdn_decode_fla(
                 q, k, v, a, b, A_log=self.A_log, dt_bias=self.dt_bias,
                 state_source=pool.recurrent_states[li], indices=fla.cache_indices,
@@ -191,13 +201,13 @@ class Qwen3_5GatedDeltaNet(BaseOP):
             mixed = self._conv_prefill(
                 conv_in, pool, fla.cu_seqlens, fla.cache_indices, fla.has_initial_state)
             # fla chunk handles GQA in-kernel: q/k stay at num_k_heads, v at num_v_heads.
-            qf, kf, vf = torch.split(mixed, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
-            q = qf.reshape(1, total, self.num_k_heads, self.head_k_dim).to(dtype)
-            k = kf.reshape(1, total, self.num_k_heads, self.head_k_dim).to(dtype)
-            v = vf.reshape(1, total, self.num_v_heads, self.head_v_dim).to(dtype)
+            qf, kf, vf = torch.split(mixed, [self._local_key_dim, self._local_key_dim, self._local_value_dim], dim=-1)
+            q = qf.reshape(1, total, self._local_num_k_heads, self.head_k_dim).to(dtype)
+            k = kf.reshape(1, total, self._local_num_k_heads, self.head_k_dim).to(dtype)
+            v = vf.reshape(1, total, self._local_num_v_heads, self.head_v_dim).to(dtype)
             g, beta = self._gate_params(a, b)
-            g = g.reshape(1, total, self.num_v_heads)
-            beta = beta.float().reshape(1, total, self.num_v_heads)
+            g = g.reshape(1, total, self._local_num_v_heads)
+            beta = beta.float().reshape(1, total, self._local_num_v_heads)
             # The chunk kernel reads + writes back initial_state[cache_indices] in place;
             # fresh sequences (cached_len==0) must start from a zeroed slot.
             if fla.fresh_state_indices is not None:

--- a/python/freetoken/models/qwen3_5_moe/moe.py
+++ b/python/freetoken/models/qwen3_5_moe/moe.py
@@ -65,8 +65,11 @@ class Qwen3_5MoE(BaseOP):
     """
 
     def __init__(self, config: ModelConfig, layer_id: int | None = None):
+        eq = getattr(config, "expert_quant", "none")
         weight_format = (
-            "fp8_block" if getattr(config, "expert_quant", "none") == "fp8_block" else "bf16"
+            "fp8_block" if eq == "fp8_block"
+            else "nvfp4" if eq == "nvfp4"
+            else "bf16"
         )
         self.experts = make_moe_layer(
             config, layer_id=layer_id, renormalize=True, weight_format=weight_format

--- a/python/freetoken/models/qwen3_5_moe/quant_linear.py
+++ b/python/freetoken/models/qwen3_5_moe/quant_linear.py
@@ -9,11 +9,15 @@ from freetoken.models.quant_linear import (
     make_col_merged_quant,
     make_replicated,
     make_replicated_quant,
+    make_row_parallel,
+    make_row_parallel_quant,
 )
 
 __all__ = [
     "make_col_merged_quant",
     "make_replicated_quant",
+    "make_row_parallel_quant",
     "make_replicated",
     "make_col_merged",
+    "make_row_parallel",
 ]

--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -340,8 +340,9 @@ def iter_weights(
                         shared_buf=nvfp4_shared_buf,
                     )
                     if emit is not _NOT_DENSE_NVFP4:
-                        for ename, etensor in emit:
-                            yield ename, _maybe_shard(ename, etensor)
+                        # NVFP4-native layers (shared_expert / dense MLP / lm_head) are held
+                        # replicated at every rank -- never shard them (or their scales).
+                        yield from emit
                         continue
 
                 tensor = _load_maybe_quantized(f, raw_name, keyset)
@@ -685,8 +686,10 @@ def _iter_weights_attn_fp8(
                 if tp_info.size > 1:
                     # TP sharding of the non-fused dense weights. NVFP4 dense
                     # (shared_expert, lm_head), norms, router and shared_expert_gate stay
-                    # full: the model holds them replicated at every rank.
-                    if name.endswith("embed_tokens.weight") \
+                    # full: the model holds them replicated at every rank. (An NVFP4
+                    # lm_head never reaches here -- it is emitted native above; a bf16
+                    # lm_head is vocab-parallel like embed_tokens.)
+                    if name.endswith(("embed_tokens.weight", "lm_head.weight")) \
                             or name.endswith(("A_log", "dt_bias")):
                         tensor = _shard_tp(tensor, rank=tp_info.rank,
                                            world_size=tp_info.size, dim=0)

--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -422,7 +422,8 @@ def _per_row_scale(scalar: torch.Tensor, rows: int) -> torch.Tensor:
 
 
 def _pt_fp8_fuse(base: str, weight: torch.Tensor, scalar: torch.Tensor,
-                 act_scale: torch.Tensor | None, buf: dict):
+                 act_scale: torch.Tensor | None, buf: dict,
+                 tp_info=None, local_part_sizes: tuple | None = None):
     """Buffer an fp8 fusion part ``(weight, scalar, act_scale)``; once all parts arrive emit
     the concatenated ``(.weight fp8, .weight_scale per-row fp32)`` plus the shared
     ``.input_scale``. ``[]`` while incomplete, ``None`` if ``base`` is not an fp8 fusion part.
@@ -430,7 +431,17 @@ def _pt_fp8_fuse(base: str, weight: torch.Tensor, scalar: torch.Tensor,
     The fused parts all read the *same* activation, so modelopt calibrates one activation
     range for all of them and their ``input_scale`` values come out bit-identical (verified on
     Qwen3.8-27B-NVFP4: q/k/v all 0.2053571492, GDN qkv/z both 0.1121651828). Taking the max is
-    therefore exact here, and stays correct if a future checkpoint lets them drift."""
+    therefore exact here, and stays correct if a future checkpoint lets them drift.
+
+    Under TP>1 (``tp_info.size > 1``) each sub-part is sharded along the output dim BEFORE
+    concatenation, so the emitted fused weight is already TP-local:
+      * ``qkv_proj``: parts q|k|v; ``local_part_sizes`` gives the per-part local row count
+        (k/v may be replicated under GQA when ``num_kv_heads < tp_size``; a ``None`` entry
+        means a plain /tp split);
+      * ``in_proj_qkvz``: the qkv part is expanded into (key_dim, key_dim, value_dim) and
+        every sub-part (plus z) takes a plain /tp split.
+    Each sub-part carries its own scalar, so the per-row scale is re-broadcast at the local
+    size -- no slicing of the scale is needed."""
     for fused_suffix, parts in _PT_FP8_FUSE.items():
         for idx, part in enumerate(parts):
             if base.endswith(part):
@@ -440,8 +451,33 @@ def _pt_fp8_fuse(base: str, weight: torch.Tensor, scalar: torch.Tensor,
                 if len(slots) < len(parts):
                     return []
                 del buf[key]
-                ws = [slots[i][0] for i in range(len(parts))]
-                ss = [_per_row_scale(slots[i][1], slots[i][0].shape[0]) for i in range(len(parts))]
+                rank = tp_info.rank if tp_info is not None else 0
+                world = tp_info.size if tp_info is not None else 1
+                # (sub-part weight rows, scalar, local row count) in output order
+                if key.endswith(".qkv_proj"):
+                    subs = []
+                    for i in range(len(parts)):
+                        w = slots[i][0]
+                        local = (local_part_sizes[i] if local_part_sizes is not None
+                                 else None)
+                        subs.append((w, slots[i][1],
+                                     local if local is not None
+                                     else div_even(w.shape[0], world)))
+                else:  # in_proj_qkvz: expand qkv into (key_dim, key_dim, value_dim)
+                    qkv_w, qkv_s = slots[0][0], slots[0][1]
+                    z_w, z_s = slots[1][0], slots[1][1]
+                    value_dim = z_w.shape[0]
+                    key_dim = (qkv_w.shape[0] - value_dim) // 2
+                    subs = [
+                        (qkv_w[:key_dim], qkv_s, div_even(key_dim, world)),
+                        (qkv_w[key_dim:2 * key_dim], qkv_s, div_even(key_dim, world)),
+                        (qkv_w[2 * key_dim:], qkv_s, div_even(value_dim, world)),
+                        (z_w, z_s, div_even(value_dim, world)),
+                    ]
+                ws = [_shard_tp_parts(w, (w.shape[0],), rank=rank, world_size=world,
+                                      local_part_sizes=(local,))
+                      for w, _, local in subs]
+                ss = [_per_row_scale(s, local) for _, s, local in subs]
                 emit = [
                     (key + ".weight", torch.cat(ws, dim=0)),
                     (key + ".weight_scale", torch.cat(ss, dim=0).contiguous()),
@@ -544,12 +580,19 @@ def _iter_weights_attn_fp8(
     (fp8 block) + ``.weight_global`` (fp16 per-row) for the W4A16 kernels -- when
     ``dense_nvfp4`` else dequantized to bf16. Routed NVFP4 experts are excluded (served by
     the offload cache). Gemma (1+w) norms get +1."""
-    if get_tp_info().size > 1:
-        raise NotImplementedError("qwen3_5_moe weight loading currently supports TP=1 only")
     if not include_non_moe:
         return  # experts-only call: NVFP4 experts are loaded by the offload bank provider
 
     tp_info = get_tp_info()
+    config = parse_config(cached_load_hf_config(model_path))
+    # qkv_proj local part sizes (TP>1): q takes a plain /tp split; k/v take the GQA
+    # KV-head-replicated local size (num_kv_heads < tp_size -> replicated heads).
+    qkv_local: tuple | None = None
+    if tp_info.size > 1:
+        local_kv = div_even(config.num_kv_heads, tp_info.size, allow_replicate=True) \
+            * config.head_dim
+        qkv_local = (None, local_kv, local_kv)
+    gdn = config.linear_attention_group()
     fp8_buf: dict[str, dict[int, tuple]] = {}
     bf16_buf: dict[str, dict[int, torch.Tensor]] = {}
     shared_buf: dict[str, dict[str, torch.Tensor]] = {}
@@ -587,12 +630,16 @@ def _iter_weights_attn_fp8(
                         # W8A16. Absent -> the layer stays on the W8A16 kernel.
                         act = (f.get_tensor(raw_base + ".input_scale")
                                if raw_base + ".input_scale" in keyset else None)
-                        emit = _pt_fp8_fuse(base, w, sc, act, fp8_buf)
+                        emit = _pt_fp8_fuse(base, w, sc, act, fp8_buf,
+                                             tp_info, qkv_local)
                         if emit is not None:
                             yield from emit
                             continue
-                        # standalone fp8 (self_attn.o_proj, linear_attn.out_proj)
-                        yield base + ".weight", w
+                        # standalone fp8 (self_attn.o_proj, linear_attn.out_proj):
+                        # row-parallel -- shard the input dim; the per-row scale and the
+                        # per-tensor input_scale cover the full (unsharded) output dim.
+                        yield base + ".weight", _shard_tp(
+                            w, rank=tp_info.rank, world_size=tp_info.size, dim=1)
                         yield base + ".weight_scale", _per_row_scale(sc, w.shape[0]).contiguous()
                         if act is not None:
                             yield base + ".input_scale", act.reshape(()).to(torch.float32)
@@ -609,7 +656,14 @@ def _iter_weights_attn_fp8(
                     tensor = _load_maybe_quantized(f, raw_name, keyset)
                     emit = _ct_bf16_fuse(base, tensor, bf16_buf, _PT_BF16_FUSE)
                     if emit is not None:
-                        yield from emit
+                        for ename, etensor in emit:
+                            # in_proj_ba: column-parallel -- shard b|a per part (heads).
+                            if ename.endswith(".in_proj_ba.weight") and gdn is not None:
+                                n_v = gdn.num_value_heads
+                                etensor = _shard_tp_parts(
+                                    etensor, (n_v, n_v),
+                                    rank=tp_info.rank, world_size=tp_info.size)
+                            yield ename, etensor
                         continue
                 else:
                     tensor = f.get_tensor(raw_name)
@@ -627,6 +681,21 @@ def _iter_weights_attn_fp8(
 
                 if _is_gemma_norm(name):
                     tensor = tensor + 1.0  # (1 + weight) baked into the stored norm weight
+
+                if tp_info.size > 1:
+                    # TP sharding of the non-fused dense weights. NVFP4 dense
+                    # (shared_expert, lm_head), norms, router and shared_expert_gate stay
+                    # full: the model holds them replicated at every rank.
+                    if name.endswith("embed_tokens.weight") \
+                            or name.endswith(("A_log", "dt_bias")):
+                        tensor = _shard_tp(tensor, rank=tp_info.rank,
+                                           world_size=tp_info.size, dim=0)
+                    elif name.endswith("conv1d.weight") and gdn is not None:
+                        key_dim = gdn.num_key_heads * gdn.key_head_dim
+                        value_dim = gdn.num_value_heads * gdn.value_head_dim
+                        tensor = _shard_tp_parts(
+                            tensor, (key_dim, key_dim, value_dim),
+                            rank=tp_info.rank, world_size=tp_info.size)
 
                 yield name, tensor
 
@@ -779,8 +848,8 @@ def iter_weights_parallel(
     )
     from freetoken.models.weight import iter_expert_tensors_parallel
 
-    if get_tp_info().size > 1:
-        raise NotImplementedError("qwen3_5_moe weight loading currently supports TP=1 only")
+    # TP>1: every rank builds its FULL expert bank (the offload cache is not TP-aware,
+    # upstream #62) -- the parallel reader yields the complete experts to each rank.
 
     def _is_expert(raw_name: str) -> bool:
         name = _rename(raw_name)
@@ -837,10 +906,16 @@ def _split_kind(name: str) -> tuple[str, str]:
     return name, ""
 
 
-def _fp8_fuse(base: str, suf: str, tensor: torch.Tensor, buf: dict) -> tuple[str, torch.Tensor] | tuple[()] | None:
+def _fp8_fuse(base: str, suf: str, tensor: torch.Tensor, buf: dict,
+              tp_info=None, qkv_local: tuple | None = None, gdn=None):
     """Buffer a fusion part keyed by (fused_full_name, kind); return the concatenated
     ``(name, tensor)`` once all parts for that kind arrive, ``()`` while incomplete,
-    ``None`` if ``base`` is not a fusion part."""
+    ``None`` if ``base`` is not a fusion part.
+
+    Under TP>1 the qkv / in_proj_qkvz / in_proj_ba groups are sharded per part before
+    concatenation (GQA KV-head replication for qkv k/v; the GDN qkv part expands into
+    (key_dim, key_dim, value_dim) sub-parts); the gate_up groups stay full -- the model
+    holds the shared/dense experts replicated at every rank."""
     for fused_suffix, parts in _FP8_FUSIONS.items():
         for idx, part in enumerate(parts):
             if base.endswith(part):
@@ -850,9 +925,48 @@ def _fp8_fuse(base: str, suf: str, tensor: torch.Tensor, buf: dict) -> tuple[str
                 slots[idx] = tensor
                 if len(slots) == len(parts):
                     del buf[key]
-                    return fused_base + suf, torch.cat([slots[i] for i in range(len(parts))], dim=0)
+                    sharded = [
+                        _fp8_shard_part(fused_suffix, i, slots[i], suf,
+                                        tp_info, qkv_local, gdn)
+                        for i in range(len(parts))
+                    ]
+                    return fused_base + suf, torch.cat(sharded, dim=0)
                 return ()
     return None
+
+
+def _fp8_shard_part(fused_suffix: str, idx: int, tensor: torch.Tensor, suf: str,
+                    tp_info, qkv_local: tuple | None, gdn) -> torch.Tensor:
+    """TP-local rows for one block-fp8 fusion part. ``suf`` distinguishes the fp8 weight
+    (rows = output rows) from the bf16 scale (rows = output rows // 128)."""
+    if tp_info is None or tp_info.size == 1:
+        return tensor
+    world, rank = tp_info.size, tp_info.rank
+    s = 128 if suf == ".weight_scale_inv" else 1
+    full = tensor.shape[0] * s  # full output rows for this part
+    if fused_suffix == ".self_attn.qkv_proj":
+        local = div_even(full, world) if idx == 0 else qkv_local[idx]
+        return _shard_tp_parts(tensor, (tensor.shape[0],), rank=rank, world_size=world,
+                               local_part_sizes=(local // s,))
+    if fused_suffix == ".linear_attn.in_proj_qkvz":
+        if idx == 0:  # expand qkv -> (key_dim, key_dim, value_dim)
+            value_dim = gdn.num_value_heads * gdn.value_head_dim
+            key_dim = (full - value_dim) // 2
+            subs = (tensor[:key_dim // s], tensor[key_dim // s:2 * key_dim // s],
+                    tensor[2 * key_dim // s:])
+            locals_ = (div_even(key_dim, world) // s, div_even(key_dim, world) // s,
+                       div_even(value_dim, world) // s)
+            return torch.cat([
+                _shard_tp_parts(t, (t.shape[0],), rank=rank, world_size=world,
+                                local_part_sizes=(loc,))
+                for t, loc in zip(subs, locals_)
+            ], dim=0)
+        return _shard_tp_parts(tensor, (tensor.shape[0],), rank=rank, world_size=world,
+                               local_part_sizes=(div_even(full, world) // s,))
+    if fused_suffix == ".linear_attn.in_proj_ba":
+        return _shard_tp_parts(tensor, (tensor.shape[0],), rank=rank, world_size=world,
+                               local_part_sizes=(div_even(full, world) // s,))
+    return tensor  # gate_up groups: replicated
 
 
 def _iter_weights_fp8(
@@ -868,12 +982,18 @@ def _iter_weights_fp8(
     Routed experts: skipped under offload (loaded by setup_offload_expert_banks). Under the
     resident (non-offload) path ``include_moe_experts`` is True -> per-layer stacked fp8
     experts for the Fp8ResidentMoE buffers are yielded too."""
-    if get_tp_info().size > 1:
-        raise NotImplementedError("qwen3_5_moe fp8 weight loading supports TP=1 only")
     if include_non_moe:
+        tp_info = get_tp_info()
+        config = parse_config(cached_load_hf_config(model_path))
+        gdn = config.linear_attention_group()
+        qkv_local = None
+        if tp_info.size > 1:
+            local_kv = div_even(config.num_kv_heads, tp_info.size, allow_replicate=True) \
+                * config.head_dim
+            qkv_local = (None, local_kv, local_kv)
         fuse_buf: dict = {}
         for file in tqdm(iter_weight_files(model_path), desc="Loading fp8 weights",
-                         disable=not get_tp_info().is_primary()):
+                         disable=not tp_info.is_primary()):
             with safetensors.safe_open(file, framework="pt", device=str(device)) as f:
                 for raw_name in f.keys():
                     name = _rename(raw_name)
@@ -881,13 +1001,34 @@ def _iter_weights_fp8(
                         continue  # routed experts handled below / by the offload cache
                     tensor = f.get_tensor(raw_name)
                     base, suf = _split_kind(name)
-                    fused = _fp8_fuse(base, suf, tensor, fuse_buf)
+                    fused = _fp8_fuse(base, suf, tensor, fuse_buf,
+                                      tp_info, qkv_local, gdn)
                     if fused is not None:
                         if fused != ():
                             yield fused
                         continue
                     if _is_gemma_norm(name):
                         tensor = tensor + 1.0  # (1 + weight) baked into the stored norm weight
+                    if tp_info.size > 1:
+                        # Row-parallel o_proj / out_proj: shard the input dim (weight rows
+                        # and scale blocks keep the full, unsharded output dim).
+                        if name.endswith((".o_proj.weight", ".out_proj.weight")):
+                            tensor = _shard_tp(tensor, rank=tp_info.rank,
+                                               world_size=tp_info.size, dim=1)
+                        elif name.endswith((".o_proj.weight_scale_inv",
+                                            ".out_proj.weight_scale_inv")):
+                            tensor = _shard_tp(tensor, rank=tp_info.rank,
+                                               world_size=tp_info.size, dim=1)
+                        elif name.endswith("embed_tokens.weight") \
+                                or name.endswith(("A_log", "dt_bias")):
+                            tensor = _shard_tp(tensor, rank=tp_info.rank,
+                                               world_size=tp_info.size, dim=0)
+                        elif name.endswith("conv1d.weight") and gdn is not None:
+                            key_dim = gdn.num_key_heads * gdn.key_head_dim
+                            value_dim = gdn.num_value_heads * gdn.value_head_dim
+                            tensor = _shard_tp_parts(
+                                tensor, (key_dim, key_dim, value_dim),
+                                rank=tp_info.rank, world_size=tp_info.size)
                     yield name, tensor
         assert not fuse_buf, f"Incomplete fp8 fusions: {sorted(k for k, _ in fuse_buf)}"
 
@@ -962,8 +1103,8 @@ def setup_offload_expert_banks(
         return _PROVIDERS[eq](model_path, model_config, device, dtype, dummy,
                               parallel=parallel, workers=workers, chunk=chunk,
                               decode_target=decode_target, layer_sink=layer_sink)
-    if get_tp_info().size > 1:
-        raise NotImplementedError("qwen3_5_moe fp8 expert banks support TP=1 only")
+    # TP>1: every rank builds its FULL bank (the offload cache is not TP-aware, upstream
+    # #62) -- note this doubles the host-RAM footprint at TP=2.
     from freetoken.moe.expert_banks import ExpertBanks
 
     mode = os.environ.get("FREETOKEN_FP8_EXPERTS", "fp8").strip().lower()

--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -9,6 +9,7 @@ import safetensors
 import torch
 from freetoken.distributed import get_tp_info
 from freetoken.kernel.triton.nvfp4_dequant import dequant_nvfp4
+from freetoken.utils import div_even
 from freetoken.models.loader import (
     CT_SCALE_SUFFIXES,
     ShardReader,
@@ -79,6 +80,77 @@ _FUSIONS: dict[str, tuple[str, ...]] = {
         ".mlp.gate_proj.weight", ".mlp.up_proj.weight",
     ),
 }
+
+
+def _shard_tp(tensor: torch.Tensor, *, rank: int, world_size: int, dim: int) -> torch.Tensor:
+    """Simple chunk sharding along ``dim``."""
+    if world_size == 1:
+        return tensor
+    return tensor.chunk(world_size, dim=dim)[rank].clone()
+
+
+def _shard_tp_parts(
+    tensor: torch.Tensor,
+    part_sizes: tuple[int, ...],
+    *,
+    rank: int,
+    world_size: int,
+    local_part_sizes: tuple[int, ...] | None = None,
+) -> torch.Tensor:
+    """Per-part column-parallel sharding (dim=0). Each part is sharded independently,
+    matching ``LinearColParallelMerged``'s per-output-size sharding.
+
+    When ``local_part_sizes`` is provided, parts where ``local < full`` but
+    ``local * world != full`` are replicated by head index (``rank % num_heads``),
+    for GQA KV head replication when ``num_kv < tp_size``."""
+    if world_size == 1:
+        return tensor
+    shards: list[torch.Tensor] = []
+    offset = 0
+    for i, full_size in enumerate(part_sizes):
+        chunk = tensor[offset:offset + full_size]
+        local_size = full_size // world_size if local_part_sizes is None else local_part_sizes[i]
+        if local_size >= full_size:
+            shards.append(chunk.clone())
+        elif local_size * world_size == full_size:
+            shards.append(chunk.chunk(world_size, dim=0)[rank].clone())
+        else:
+            num_heads = full_size // local_size
+            head_idx = rank * num_heads // world_size
+            shards.append(chunk[head_idx * local_size:(head_idx + 1) * local_size].clone())
+        offset += full_size
+    return torch.cat(shards, dim=0)
+
+
+def _maybe_shard(name: str, tensor: torch.Tensor) -> torch.Tensor:
+    """Apply TP sharding to a non-fused weight based on its state-dict key suffix.
+    Fused projections (qkv_proj, in_proj, gate_up_proj) are handled by ``_try_fuse``
+    → ``_shard_tp_parts`` in ``iter_weights`` before reaching here.
+    conv1d.weight is also handled in ``iter_weights`` (needs config for sub-part sizes)."""
+    tp = get_tp_info()
+    if tp.size == 1:
+        return tensor
+    if name.endswith((".o_proj.weight", ".down_proj.weight", ".out_proj.weight")):
+        return _shard_tp(tensor, rank=tp.rank, world_size=tp.size, dim=1)
+    if name.endswith(("embed_tokens.weight", "lm_head.weight")):
+        return _shard_tp(tensor, rank=tp.rank, world_size=tp.size, dim=0)
+    if name.endswith(("A_log", "dt_bias")):
+        return _shard_tp(tensor, rank=tp.rank, world_size=tp.size, dim=0)
+    # Routed expert weights (3D stacked: [num_experts, ...]) — resident mode only.
+    # gate_up_proj is [num_experts, 2*intermediate, hidden] = [gate, up] fused on dim=1.
+    # Must shard gate and up independently (like _shard_tp_parts on dim=1).
+    # down_proj is [num_experts, hidden, intermediate] — single dim, simple chunk on dim=2.
+    if name.endswith("experts.gate_up_proj"):
+        intermediate = tensor.shape[1] // 2
+        gate = tensor[:, :intermediate, :]
+        up = tensor[:, intermediate:, :]
+        return torch.cat([
+            gate.chunk(tp.size, dim=1)[tp.rank].clone(),
+            up.chunk(tp.size, dim=1)[tp.rank].clone(),
+        ], dim=1)
+    if name.endswith("experts.down_proj"):
+        return _shard_tp(tensor, rank=tp.rank, world_size=tp.size, dim=2)
+    return tensor
 
 
 def _dequant_fp8_weight(weight: torch.Tensor, weight_scale: torch.Tensor) -> torch.Tensor:
@@ -154,8 +226,8 @@ def _is_gemma_norm(name: str) -> bool:
 
 def _try_fuse(
     name: str, tensor: torch.Tensor, buf: dict[str, dict[int, torch.Tensor]]
-) -> tuple[str, torch.Tensor] | tuple[()] | None:
-    """buffer a fusion part; return merged ``(name, tensor)`` once all parts arrive,
+) -> tuple[str, torch.Tensor, tuple[int, ...]] | tuple[()] | None:
+    """buffer a fusion part; return merged ``(name, tensor, part_sizes)`` once all parts arrive,
     ``()`` while incomplete, ``None`` if not a fusion part."""
     for fused_suffix, parts in _FUSIONS.items():
         for idx, part in enumerate(parts):
@@ -165,7 +237,18 @@ def _try_fuse(
                 slots[idx] = tensor
                 if len(slots) == len(parts):
                     del buf[key]
-                    return key, torch.cat([slots[i] for i in range(len(parts))], dim=0)
+                    tensors = [slots[i] for i in range(len(parts))]
+                    part_sizes = tuple(t.shape[0] for t in tensors)
+                    # in_proj_qkv is itself a fusion of [q, k, v] with sizes
+                    # (key_dim, key_dim, value_dim). value_dim == z_size, and
+                    # key_dim = (qkv_size - value_dim) // 2. Expand qkv into
+                    # its sub-parts so _shard_tp_parts shards each independently.
+                    if key.endswith(".in_proj.weight") and len(part_sizes) == 4:
+                        qkv_size, z_size, b_size, a_size = part_sizes
+                        value_dim = z_size
+                        key_dim = (qkv_size - value_dim) // 2
+                        part_sizes = (key_dim, key_dim, value_dim, z_size, b_size, a_size)
+                    return key, torch.cat(tensors, dim=0), part_sizes
                 return ()
     return None
 
@@ -210,8 +293,6 @@ def iter_weights(
         )
         return
     tp_info = get_tp_info()
-    if tp_info.size > 1:
-        raise NotImplementedError("qwen3_5_moe weight loading currently supports TP=1 only")
 
     # Pure-NVFP4 checkpoint (bf16 attn): the dense MLP projections (shared_expert) are still
     # stored as packed FP4 -- keep them native (W4A16) when dense_quant=="nvfp4" rather than
@@ -259,7 +340,8 @@ def iter_weights(
                         shared_buf=nvfp4_shared_buf,
                     )
                     if emit is not _NOT_DENSE_NVFP4:
-                        yield from emit
+                        for ename, etensor in emit:
+                            yield ename, _maybe_shard(ename, etensor)
                         continue
 
                 tensor = _load_maybe_quantized(f, raw_name, keyset)
@@ -272,20 +354,43 @@ def iter_weights(
                     if "gate" in slots and "up" in slots:
                         merged = torch.cat([slots["gate"], slots["up"]], dim=0)
                         del shared_buf[prefix]
-                        yield f"{prefix}.mlp.shared_expert.gate_up_proj.weight", merged
+                        merged_name = f"{prefix}.mlp.shared_expert.gate_up_proj.weight"
+                        gate_size = slots["gate"].shape[0]
+                        up_size = slots["up"].shape[0]
+                        yield merged_name, _shard_tp_parts(merged, (gate_size, up_size), rank=tp_info.rank, world_size=tp_info.size)
                     continue
 
                 # fuse q/k/v -> qkv_proj and GDN in_proj_{qkv,z,b,a} -> in_proj
                 fused = _try_fuse(name, tensor, fuse_buf)
                 if fused is not None:
                     if fused != ():  # () means buffered, not yet complete
-                        yield fused
+                        fused_name, fused_tensor, part_sizes = fused
+                        # For qkv_proj: compute local part sizes with KV head replication
+                        # when num_kv_heads < tp_size (GQA replication).
+                        local_part_sizes = None
+                        if fused_name.endswith(".qkv_proj.weight"):
+                            num_kv = config.num_kv_heads
+                            head_dim = config.head_dim
+                            local_kv = div_even(num_kv, tp_info.size, allow_replicate=True) * head_dim
+                            local_q = div_even(part_sizes[0], tp_info.size)
+                            local_part_sizes = (local_q, local_kv, local_kv)
+                        yield fused_name, _shard_tp_parts(
+                            fused_tensor, part_sizes, rank=tp_info.rank, world_size=tp_info.size,
+                            local_part_sizes=local_part_sizes)
                     continue
 
                 if _is_gemma_norm(name):
                     tensor = tensor + 1.0  # (1 + weight) baked into the stored weight
 
-                yield name, tensor
+                if name.endswith("conv1d.weight") and tp_info.size > 1:
+                    g = config.linear_attention_group()
+                    if g is not None:
+                        key_dim = g.num_key_heads * g.key_head_dim
+                        value_dim = g.num_value_heads * g.value_head_dim
+                        tensor = _shard_tp_parts(tensor, (key_dim, key_dim, value_dim),
+                                                 rank=tp_info.rank, world_size=tp_info.size)
+
+                yield name, _maybe_shard(name, tensor)
 
     assert not shared_buf, f"Incomplete shared-expert merges: {list(shared_buf.keys())}"
     assert not nvfp4_shared_buf, f"Incomplete NVFP4 shared-expert merges: {list(nvfp4_shared_buf.keys())}"

--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -21,6 +21,7 @@ from freetoken.models.loader import (
 )
 from freetoken.models.nvfp4_banks import (
     Nvfp4ExpertSourceSpec,
+    load_nvfp4_expert_resident_banks,
     load_nvfp4_expert_source_banks,
 )
 from freetoken.utils import cached_load_hf_config, download_hf_weight
@@ -397,6 +398,11 @@ def iter_weights(
     assert not nvfp4_shared_buf, f"Incomplete NVFP4 shared-expert merges: {list(nvfp4_shared_buf.keys())}"
     assert not fuse_buf, f"Incomplete projection fusions: {list(fuse_buf.keys())}"
 
+    if include_moe_experts:
+        # Resident (fused) NVFP4 experts: TP-sharded native banks (the offload path loads
+        # these via load_nvfp4_expert_sources instead; include_moe_experts is False there).
+        yield from _iter_resident_nvfp4_experts(model_path, config)
+
 
 # ======================================================================================
 # Mixed-precision modelopt checkpoint (per-tensor FP8 attn/GDN + NVFP4 experts/shared/lm_head)
@@ -706,6 +712,12 @@ def _iter_weights_attn_fp8(
     assert not bf16_buf, f"Incomplete bf16 fusions: {list(bf16_buf.keys())}"
     assert not shared_buf, f"Incomplete shared-expert merges: {list(shared_buf.keys())}"
     assert not nvfp4_shared_buf, f"Incomplete NVFP4 shared-expert merges: {list(nvfp4_shared_buf.keys())}"
+
+    if include_moe_experts:
+        # Resident (fused) NVFP4 experts: TP-sharded native banks. The offload path never
+        # reaches here (include_moe_experts is False; it loads the experts via
+        # load_nvfp4_expert_sources into the offload cache instead).
+        yield from _iter_resident_nvfp4_experts(model_path, config)
 
 
 # ======================================================================================
@@ -1304,6 +1316,37 @@ def _setup_bf16_dequant_banks(model_path, model_config, device, dummy: bool, *, 
     else:
         _load(None)  # CUDA-less: mmap banks stay pageable, never pinned
     return ExpertBanks("bf16", banks, streamed=layer_sink is not None)
+
+
+def _iter_resident_nvfp4_experts(model_path: str, config) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield the resident (fused) TP-sharded NVFP4 expert banks as per-layer state-dict views.
+
+    Called by the dense passes when ``include_moe_experts`` is True (the fused backend). The
+    offload path never calls this -- it loads the routed experts via
+    :func:`load_nvfp4_expert_sources` into the offload cache instead. The keys match the
+    MoELayer's resident NVFP4 tensor attributes (``gate_up_packed``/``gate_up_scale``/
+    ``gate_up_global``/``down_packed``/``down_scale``/``down_global``) under the
+    ``...mlp.experts`` prefix; the engine's ``_materialize`` moves each to GPU.
+    """
+    tp_info = get_tp_info()
+    banks = load_nvfp4_expert_resident_banks(
+        model_path,
+        config,
+        _NVFP4_SOURCE_SPEC,
+        drop_page_cache=drop_page_cache,
+        primary=tp_info.is_primary(),
+        rank=tp_info.rank,
+        world_size=tp_info.size,
+    )
+    L, E, H, I, dense = _moe_dims(config)
+    for li in range(L):
+        pre = f"model.layers.{dense + li}.mlp.experts"
+        yield f"{pre}.gate_up_packed", banks["gate_up_packed"][li]
+        yield f"{pre}.gate_up_scale", banks["gate_up_scale"][li]
+        yield f"{pre}.gate_up_global", banks["gate_up_global"][li]
+        yield f"{pre}.down_packed", banks["down_packed"][li]
+        yield f"{pre}.down_scale", banks["down_scale"][li]
+        yield f"{pre}.down_global", banks["down_global"][li]
 
 
 def load_nvfp4_expert_sources(

--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -969,6 +969,29 @@ def _fp8_shard_part(fused_suffix: str, idx: int, tensor: torch.Tensor, suf: str,
     return tensor  # gate_up groups: replicated
 
 
+def _fp8_shard_standalone(name: str, tensor: torch.Tensor, tp_info, gdn) -> torch.Tensor:
+    """TP-local view of a non-fused block-fp8 weight (or its scale).
+
+    Row-parallel o_proj / out_proj shard the input dim (weight rows and scale blocks keep
+    the full, unsharded output dim); embed_tokens / lm_head are vocab-parallel (dim 0);
+    A_log / dt_bias are per-head scalars (dim 0); conv1d shards its (k, k, v) sub-parts.
+    Everything else (norms, router, shared_expert_gate) stays replicated."""
+    if tp_info is None or tp_info.size == 1:
+        return tensor
+    rank, world = tp_info.rank, tp_info.size
+    if name.endswith((".o_proj.weight", ".out_proj.weight",
+                      ".o_proj.weight_scale_inv", ".out_proj.weight_scale_inv")):
+        return _shard_tp(tensor, rank=rank, world_size=world, dim=1)
+    if name.endswith(("embed_tokens.weight", "lm_head.weight", "A_log", "dt_bias")):
+        return _shard_tp(tensor, rank=rank, world_size=world, dim=0)
+    if name.endswith("conv1d.weight") and gdn is not None:
+        key_dim = gdn.num_key_heads * gdn.key_head_dim
+        value_dim = gdn.num_value_heads * gdn.value_head_dim
+        return _shard_tp_parts(tensor, (key_dim, key_dim, value_dim),
+                               rank=rank, world_size=world)
+    return tensor
+
+
 def _iter_weights_fp8(
     model_path: str, device: torch.device, *, include_non_moe: bool, include_moe_experts: bool = False
 ) -> Iterator[tuple[str, torch.Tensor]]:
@@ -1009,26 +1032,7 @@ def _iter_weights_fp8(
                         continue
                     if _is_gemma_norm(name):
                         tensor = tensor + 1.0  # (1 + weight) baked into the stored norm weight
-                    if tp_info.size > 1:
-                        # Row-parallel o_proj / out_proj: shard the input dim (weight rows
-                        # and scale blocks keep the full, unsharded output dim).
-                        if name.endswith((".o_proj.weight", ".out_proj.weight")):
-                            tensor = _shard_tp(tensor, rank=tp_info.rank,
-                                               world_size=tp_info.size, dim=1)
-                        elif name.endswith((".o_proj.weight_scale_inv",
-                                            ".out_proj.weight_scale_inv")):
-                            tensor = _shard_tp(tensor, rank=tp_info.rank,
-                                               world_size=tp_info.size, dim=1)
-                        elif name.endswith("embed_tokens.weight") \
-                                or name.endswith(("A_log", "dt_bias")):
-                            tensor = _shard_tp(tensor, rank=tp_info.rank,
-                                               world_size=tp_info.size, dim=0)
-                        elif name.endswith("conv1d.weight") and gdn is not None:
-                            key_dim = gdn.num_key_heads * gdn.key_head_dim
-                            value_dim = gdn.num_value_heads * gdn.value_head_dim
-                            tensor = _shard_tp_parts(
-                                tensor, (key_dim, key_dim, value_dim),
-                                rank=tp_info.rank, world_size=tp_info.size)
+                    tensor = _fp8_shard_standalone(name, tensor, tp_info, gdn)
                     yield name, tensor
         assert not fuse_buf, f"Incomplete fp8 fusions: {sorted(k for k, _ in fuse_buf)}"
 

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -115,7 +115,9 @@ def physical_core_cpus() -> list[int]:
     return reps or allowed or [0]
 
 
-def resolve_threads_and_affinity(requested: int) -> tuple[int, list[int]]:
+def resolve_threads_and_affinity(
+    requested: int, rank: int = 0, world_size: int = 1
+) -> tuple[int, list[int]]:
     """Return (num_threads, core_ids) for the worker pool.
 
     ``requested == 0`` -> one thread per physical core, pinned to it (best for the
@@ -123,14 +125,25 @@ def resolve_threads_and_affinity(requested: int) -> tuple[int, list[int]]:
     spin-barrier degrades badly when oversubscribed). An explicit count is honored,
     spreading first across physical cores, then across the remaining logical CPUs
     (so distinct hardware threads are used before any core is doubled up).
+
+    Under TP (``world_size > 1``) each rank process gets a disjoint round-robin
+    slice of the physical cores (``reps[rank::world_size]``). Without this every
+    rank auto-pins the whole machine and the rank pools time-slice on the same
+    cores (measured ~4x decode loss on a 2x3090 box); round-robin also keeps a
+    fair P/E-core mix on heterogeneous CPUs.
     """
     reps = physical_core_cpus()
+    if world_size > 1:
+        reps = reps[rank % world_size :: world_size]
     if requested and requested > 0:
         n = int(requested)
         try:
             allowed = sorted(os.sched_getaffinity(0))
         except AttributeError:
             allowed = list(range(os.cpu_count() or 1))
+        if world_size > 1:
+            rank_reps = set(reps)
+            allowed = [c for c in allowed if c in rank_reps]
         # physical-core reps first, then the rest of the logical CPUs.
         order = reps + [c for c in allowed if c not in set(reps)]
         if not order:
@@ -213,7 +226,13 @@ class CpuMoeExecutor:
                 )
                 self._flag_sync = False
 
-        nthreads, core_ids = resolve_threads_and_affinity(num_threads)
+        from freetoken.distributed import try_get_tp_info
+
+        tp_info = try_get_tp_info()
+        tp_rank, tp_world = (tp_info.rank, tp_info.size) if tp_info else (0, 1)
+        nthreads, core_ids = resolve_threads_and_affinity(
+            num_threads, rank=tp_rank, world_size=tp_world
+        )
         coord_core = -1
         if self._flag_sync and num_threads == 0 and nthreads > 2:
             # Auto sizing: give the coordinator the last physical core instead of
@@ -242,7 +261,8 @@ class CpuMoeExecutor:
         self.core_ids = core_ids
         self.isa = self._ext.isa_name()
 
-        spare = len(physical_core_cpus()) - nthreads - (1 if coord_core >= 0 else 0) - 1
+        rank_core_count = len(physical_core_cpus()[tp_rank::tp_world]) if tp_world > 1 else len(physical_core_cpus())
+        spare = rank_core_count - nthreads - (1 if coord_core >= 0 else 0) - 1
         clamp = max(1, min(torch.get_num_threads(), spare))
         if clamp < torch.get_num_threads():
             logger.info_rank0(
@@ -310,11 +330,14 @@ class CpuMoeExecutor:
                 "(bit-identical grid; the CPU-side scalar round-trip is skipped)"
             )
 
-        logger.info_rank0(
+        # Log on ALL ranks (not info_rank0): under TP the per-rank core partition
+        # must be visible per rank, or a pinning collision is invisible in the logs.
+        logger.info(
             f"CPU MoE executor ready: threads={nthreads} (pinned to cores "
-            f"{core_ids[0]}..{core_ids[-1]}) isa={self.isa} fmt={fmt} "
-            f"H={self.H} I={self.I} experts={self.num_experts} layers={self.num_layers} "
-            f"top_k={self.top_k} act={activation} max_tokens={self.max_tokens}"
+            f"{core_ids[0]}..{core_ids[-1]}) tp_rank={tp_rank}/{tp_world} isa={self.isa} "
+            f"fmt={fmt} H={self.H} I={self.I} experts={self.num_experts} "
+            f"layers={self.num_layers} top_k={self.top_k} act={activation} "
+            f"max_tokens={self.max_tokens}"
         )
 
     def _make_table(self, layers: list[torch.Tensor]) -> torch.Tensor:

--- a/tests/ab_long.py
+++ b/tests/ab_long.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Long-form TP1 vs TP2 token-identity check: full reasoning + content, 512 tokens."""
+import json
+import sys
+import urllib.request
+
+PROMPTS = [
+    "What is 17 * 23 + 5? Show your working, then answer with just the number.",
+    "Write a Python function that returns the nth Fibonacci number iteratively. Include a docstring and one example.",
+    "Explain in detail how tensor parallelism works in a transformer, including what is sharded and what collectives are used.",
+    "Solve step by step: a train leaves A at 9:00 going 80 km/h. Another leaves B (240 km away) at 9:30 going 100 km/h toward A. When and where do they meet?",
+    "Write a haiku about GPUs, then explain your syllable count.",
+]
+
+
+def complete(base: str, prompt: str) -> dict:
+    body = json.dumps({
+        "model": "default",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "max_tokens": 512,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }).encode()
+    req = urllib.request.Request(
+        base.rstrip("/") + "/chat/completions", data=body,
+        headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=900) as r:
+        d = json.load(r)
+    m = d["choices"][0]["message"]
+    return {
+        "prompt": prompt,
+        "full": (m.get("reasoning_content") or "") + "\n===ANSWER===\n" + (m.get("content") or ""),
+        "finish": d["choices"][0].get("finish_reason"),
+    }
+
+
+def main():
+    if sys.argv[1] == "--diff":
+        a = json.load(open(sys.argv[2]))
+        b = json.load(open(sys.argv[3]))
+        same = 0
+        for ra, rb in zip(a, b):
+            ok = ra["full"] == rb["full"]
+            same += ok
+            print(f"{'SAME ' if ok else 'DIFF '} | {ra['prompt'][:60]}")
+            if not ok:
+                # find first divergence
+                for i, (ca, cb) in enumerate(zip(ra["full"], rb["full"])):
+                    if ca != cb:
+                        print(f"  first divergence at char {i}:")
+                        print(f"  A: ...{ra['full'][max(0,i-80):i+120]!r}")
+                        print(f"  B: ...{rb['full'][max(0,i-80):i+120]!r}")
+                        break
+                else:
+                    print(f"  length differs: {len(ra['full'])} vs {len(rb['full'])}")
+        print(f"\n{same}/{len(a)} token-identical (full reasoning+answer)")
+        return
+    base, tag = sys.argv[1], sys.argv[2]
+    out = []
+    for i, p in enumerate(PROMPTS):
+        r = complete(base, p)
+        print(f"[{i+1}/{len(PROMPTS)}] {len(r['full'])} chars, {r['finish']}")
+        out.append(r)
+    json.dump(out, open(f"{tag}_long.json", "w"), indent=1)
+    print(f"wrote {tag}_long.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ab_suite.py
+++ b/tests/ab_suite.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Deterministic A/B prompt suite for the FreeToken TP1 vs TP2 correctness check.
+
+Usage:  python ab_suite.py <base_url> <tag>
+Sends 10 temperature-0 prompts and writes <tag>.json with the raw completions.
+Compare two runs with:  python ab_suite.py --diff tp1.json tp2.json
+"""
+import json
+import sys
+import time
+import urllib.request
+
+PROMPTS = [
+    "What is 17 * 23 + 5? Answer with just the number.",
+    "Capital of France in one word.",
+    "Write a Python function that returns the nth Fibonacci number iteratively.",
+    "Explain tensor parallelism in two sentences.",
+    "List the first 5 prime numbers, comma separated.",
+    "Translate to German: The quick brown fox jumps over the lazy dog.",
+    "Why is the sky blue? Three sentences max.",
+    "Solve: if 3x + 7 = 22, what is x? Just the number.",
+    "Write a haiku about GPUs.",
+    "What does HTTP 418 mean? One sentence.",
+]
+
+
+def complete(base: str, prompt: str) -> dict:
+    body = json.dumps({
+        "model": "default",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "max_tokens": 256,
+    }).encode()
+    req = urllib.request.Request(
+        base.rstrip("/") + "/chat/completions", data=body,
+        headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=600) as r:
+        d = json.load(r)
+    return {
+        "prompt": prompt,
+        "content": d["choices"][0]["message"]["content"],
+        "reasoning": (d["choices"][0]["message"].get("reasoning_content") or "")[:200],
+        "finish": d["choices"][0].get("finish_reason"),
+        "usage": d.get("usage"),
+        "wall_s": round(time.time() - t0, 2),
+    }
+
+
+def main():
+    if len(sys.argv) >= 2 and sys.argv[1] == "--diff":
+        a = json.load(open(sys.argv[2]))
+        b = json.load(open(sys.argv[3]))
+        same = 0
+        for ra, rb in zip(a, b):
+            ok = ra["content"].strip() == rb["content"].strip()
+            same += ok
+            print(f"{'SAME ' if ok else 'DIFF '} | {ra['prompt'][:60]}")
+            if not ok:
+                print(f"  A: {ra['content'][:300]!r}")
+                print(f"  B: {rb['content'][:300]!r}")
+        print(f"\n{same}/{len(a)} identical")
+        return
+    base, tag = sys.argv[1], sys.argv[2]
+    out = []
+    for i, p in enumerate(PROMPTS):
+        r = complete(base, p)
+        print(f"[{i+1}/{len(PROMPTS)}] {p[:50]!r} -> {r['wall_s']}s {r['finish']}")
+        out.append(r)
+    json.dump(out, open(f"{tag}.json", "w"), indent=1)
+    print(f"wrote {tag}.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/test_qwen3_5_tp.py
+++ b/tests/models/test_qwen3_5_tp.py
@@ -1,0 +1,32 @@
+import torch
+from freetoken.models.qwen3_5_moe.weight import _shard_tp, _shard_tp_parts
+
+
+def test_shard_tp():
+    t = torch.arange(32).reshape(8, 4)
+    s0, s1 = _shard_tp(t, rank=0, world_size=2, dim=0), _shard_tp(t, rank=1, world_size=2, dim=0)
+    assert s0.shape == (4, 4) and s1.shape == (4, 4)
+    torch.testing.assert_close(torch.cat([s0, s1]), t)
+    assert _shard_tp(t, rank=0, world_size=1, dim=0).equal(t)
+    assert _shard_tp(torch.arange(32).reshape(4, 8), rank=0, world_size=2, dim=1).shape == (4, 4)
+
+
+def test_shard_tp_parts():
+    t = torch.arange(48).reshape(12, 4)
+    s0 = _shard_tp_parts(t, (4, 4, 4), rank=0, world_size=2)
+    s1 = _shard_tp_parts(t, (4, 4, 4), rank=1, world_size=2)
+    assert s0.shape == (6, 4)
+    for i in range(3):
+        torch.testing.assert_close(torch.cat([s0[i*2:i*2+2], s1[i*2:i*2+2]]), t[i*4:i*4+4])
+
+
+def test_shard_tp_parts_replicate():
+    t = torch.arange(16).reshape(8, 2)
+    local = (2, 4)
+    kw = dict(tensor=t, part_sizes=(4, 4), world_size=4, local_part_sizes=local)
+    s0, s1, s2, s3 = [_shard_tp_parts(rank=r, **kw) for r in range(4)]
+    assert s0.shape == (6, 2)
+    torch.testing.assert_close(s0[:2], s1[:2])   # ranks 0,1 share head 0
+    torch.testing.assert_close(s2[:2], s3[:2])   # ranks 2,3 share head 1
+    assert not torch.equal(s0[:2], s2[:2])        # different heads
+    torch.testing.assert_close(s0[2:], s2[2:])    # replicated part identical

--- a/tests/models/test_qwen3_5_tp_quant.py
+++ b/tests/models/test_qwen3_5_tp_quant.py
@@ -270,6 +270,51 @@ def test_fp8_shard_standalone_vocab_row_conv_tp2():
         _fp8_shard_standalone("lm_head.weight", w, DistributedInfo(0, 1), None), w)
 
 
+def test_fp8_iter_weights_tp2_sharding():
+    """Full ``_iter_weights_fp8`` run at TP=2 over a tiny synthetic block-FP8 checkpoint.
+
+    Regression: lm_head was yielded full-width (vocab, hidden) against the vocab-sharded
+    ParallelLMHead -> load_state_dict shape assert at TP=2 (reported on PR #104)."""
+    import tempfile
+
+    from safetensors import safe_open
+
+    from tests.models.tiny_fp8_ckpt import make_tiny_fp8_ckpt
+    from freetoken.models.qwen3_5_moe.weight import _iter_weights_fp8
+
+    V = 2048
+    with tempfile.TemporaryDirectory() as d:
+        ckpt = make_tiny_fp8_ckpt(d, vocab=V, experts=8)
+        got = {}
+        for rank in (0, 1):
+            _set_tp(rank, 2)
+            got[rank] = dict(_iter_weights_fp8(
+                ckpt, torch.device("cpu"), include_non_moe=True, include_moe_experts=False))
+        with safe_open(f"{ckpt}/model.safetensors", framework="pt") as f:
+            full_lm_head = f.get_tensor("lm_head.weight")
+    for rank, half in ((0, 0), (1, 1)):
+        w = got[rank]
+        # Vocab-parallel: lm_head / embed_tokens shard rows (the regression).
+        assert w["lm_head.weight"].shape == (V // 2, 2048)
+        assert w["model.embed_tokens.weight"].shape == (V // 2, 2048)
+        torch.testing.assert_close(
+            w["lm_head.weight"], full_lm_head[half * (V // 2):(half + 1) * (V // 2)])
+        # Row-parallel o_proj / out_proj: input dim sharded (weight + scale).
+        assert w["model.layers.3.self_attn.o_proj.weight"].shape == (2048, 2048)
+        assert w["model.layers.3.self_attn.o_proj.weight_scale_inv"].shape == (16, 16)
+        assert w["model.layers.0.linear_attn.out_proj.weight"].shape == (2048, 2048)
+        # Column-merged qkv / in_proj_qkvz: per-part local rows (GQA KV-head halving).
+        assert w["model.layers.3.self_attn.qkv_proj.weight"].shape == (4096 + 256 + 256, 2048)
+        assert w["model.layers.0.linear_attn.in_proj_qkvz.weight"].shape == (4096 + 2048, 2048)
+        # GDN per-head scalars / conv1d (k, k, v) sub-parts.
+        assert w["model.layers.0.linear_attn.A_log"].shape == (16,)
+        assert w["model.layers.0.linear_attn.conv1d.weight"].shape == (1024 + 1024 + 2048, 1, 4)
+        # Replicated: router, shared expert.
+        assert w["model.layers.0.mlp.gate.weight"].shape == (8, 2048)
+        assert w["model.layers.0.mlp.shared_expert.gate_up_proj.weight"].shape == (1024, 2048)
+    _set_tp(0, 1)
+
+
 # ======================================================================================
 # Row-parallel / column-merged quantized linears (pure-torch reference path)
 # ======================================================================================

--- a/tests/models/test_qwen3_5_tp_quant.py
+++ b/tests/models/test_qwen3_5_tp_quant.py
@@ -315,6 +315,59 @@ def test_fp8_iter_weights_tp2_sharding():
     _set_tp(0, 1)
 
 
+def test_mixed_iter_weights_tp2_sharding():
+    """Full ``_iter_weights_attn_fp8`` run at TP=2 over a tiny synthetic mixed checkpoint.
+
+    Regressions: a bf16 lm_head (lm_head_quant=="none") was yielded full-width against
+    the vocab-sharded ParallelLMHead; and NVFP4-native shared_expert must stay replicated
+    (weight AND scales unsharded) -- the main-path ``_maybe_shard`` used to shard its
+    down_proj while leaving the scales full-width."""
+    import tempfile
+
+    from safetensors import safe_open
+
+    from tests.models.tiny_fp8_ckpt import make_tiny_mixed_ckpt
+    from freetoken.models.qwen3_5_moe.weight import _iter_weights_attn_fp8
+
+    V = 2048
+    with tempfile.TemporaryDirectory() as d:
+        ckpt = make_tiny_mixed_ckpt(d, vocab=V, experts=8)
+        got = {}
+        for rank in (0, 1):
+            _set_tp(rank, 2)
+            got[rank] = dict(_iter_weights_attn_fp8(
+                ckpt, torch.device("cpu"), include_non_moe=True, include_moe_experts=False,
+                dense_nvfp4=True, lmhead_nvfp4=False))
+        with safe_open(f"{ckpt}/model.safetensors", framework="pt") as f:
+            full_lm_head = f.get_tensor("lm_head.weight")
+    for rank, half in ((0, 0), (1, 1)):
+        w = got[rank]
+        # Vocab-parallel: bf16 lm_head / embed_tokens shard rows (the regression).
+        assert w["lm_head.weight"].shape == (V // 2, 2048)
+        assert w["model.embed_tokens.weight"].shape == (V // 2, 2048)
+        torch.testing.assert_close(
+            w["lm_head.weight"], full_lm_head[half * (V // 2):(half + 1) * (V // 2)])
+        # Row-parallel fp8 o_proj / out_proj: input dim sharded, per-row scale full.
+        assert w["model.layers.3.self_attn.o_proj.weight"].shape == (2048, 2048)
+        assert w["model.layers.3.self_attn.o_proj.weight_scale"].shape == (2048,)
+        assert w["model.layers.0.linear_attn.out_proj.weight"].shape == (2048, 2048)
+        # Column-merged fp8 qkv / in_proj_qkvz: per-part local rows (GQA KV-head halving).
+        assert w["model.layers.3.self_attn.qkv_proj.weight"].shape == (4096 + 256 + 256, 2048)
+        assert w["model.layers.0.linear_attn.in_proj_qkvz.weight"].shape == (4096 + 2048, 2048)
+        # GDN bf16: in_proj_ba per-head, conv1d (k, k, v) sub-parts, per-head scalars.
+        assert w["model.layers.0.linear_attn.in_proj_ba.weight"].shape == (32, 2048)
+        assert w["model.layers.0.linear_attn.conv1d.weight"].shape == (1024 + 1024 + 2048, 1, 4)
+        assert w["model.layers.0.linear_attn.A_log"].shape == (16,)
+        # NVFP4-native shared_expert stays replicated (weight AND scales unsharded).
+        assert w["model.layers.0.mlp.shared_expert.gate_up_proj.weight"].shape == (1024, 1024)
+        assert w["model.layers.0.mlp.shared_expert.gate_up_proj.weight_scale"].shape == (1024, 128)
+        assert w["model.layers.0.mlp.shared_expert.down_proj.weight"].shape == (2048, 256)
+        assert w["model.layers.0.mlp.shared_expert.down_proj.weight_scale"].shape == (2048, 32)
+        # Replicated: router.
+        assert w["model.layers.0.mlp.gate.weight"].shape == (8, 2048)
+    _set_tp(0, 1)
+
+
 # ======================================================================================
 # Row-parallel / column-merged quantized linears (pure-torch reference path)
 # ======================================================================================

--- a/tests/models/test_qwen3_5_tp_quant.py
+++ b/tests/models/test_qwen3_5_tp_quant.py
@@ -1,0 +1,301 @@
+"""CPU unit tests for the TP>1 quantized-checkpoint sharding (qwen3_5_moe).
+
+Covers the weight-loader shard math (fused fp8 qkv / in_proj_qkvz with GQA KV-head
+replication, block-fp8 per-part + scale sharding) and the row-parallel / column-merged
+quantized linear layers (via the pure-torch FREETOKEN_DEBUG_FP8_REF reference path).
+
+Run:  FREETOKEN_DEBUG_FP8_REF=1 pytest tests/models/test_qwen3_5_tp_quant.py
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+
+os.environ.setdefault("FREETOKEN_DEBUG_FP8_REF", "1")
+
+import freetoken.distributed.info as _tpinfo  # noqa: E402
+from freetoken.distributed.info import DistributedInfo  # noqa: E402
+
+
+def _set_tp(rank: int, size: int):
+    _tpinfo._TP_INFO = DistributedInfo(rank, size)
+
+
+def _ensure_single_rank_group():
+    """Single-process gloo group: makes DistributedCommunicator.all_reduce a no-op
+    (world_size==1), so a two-rank TP test can sum the partials by hand."""
+    if not dist.is_initialized():
+        dist.init_process_group("gloo", init_method="file:///tmp/ft_tp_quant_test_init",
+                                rank=0, world_size=1)
+
+
+FP8 = torch.float8_e4m3fn
+
+
+def _rand_fp8(shape, seed):
+    g = torch.Generator().manual_seed(seed)
+    return (torch.randn(*shape, generator=g) * 0.1).to(FP8)
+
+
+# ======================================================================================
+# _pt_fp8_fuse (mixed-precision checkpoint: per-tensor FP8 attn/GDN)
+# ======================================================================================
+def test_pt_fp8_fuse_qkv_shard_tp2():
+    from freetoken.models.qwen3_5_moe.weight import _pt_fp8_fuse
+
+    # Qwen3.6-35B dims: q 4096 (16 heads x 256 x 2 for the gate), k/v 512 (2 heads x 256).
+    K = 2048
+    q = _rand_fp8((4096, K), 1)
+    k = _rand_fp8((512, K), 2)
+    v = _rand_fp8((512, K), 3)
+    sq, sk, sv = 0.2, 0.3, 0.4
+    act = torch.tensor(0.205)
+
+    local_kv = 256  # 2 KV heads / 2 ranks
+    out = {}
+    for rank in (0, 1):
+        buf = {}
+        _set_tp(rank, 2)
+        e = _pt_fp8_fuse("model.layers.3.self_attn.q_proj", q, torch.tensor(sq), act,
+                         buf, DistributedInfo(rank, 2), (None, local_kv, local_kv))
+        assert e == []
+        e = _pt_fp8_fuse("model.layers.3.self_attn.k_proj", k, torch.tensor(sk), act,
+                         buf, DistributedInfo(rank, 2), (None, local_kv, local_kv))
+        assert e == []
+        e = _pt_fp8_fuse("model.layers.3.self_attn.v_proj", v, torch.tensor(sv), act,
+                         buf, DistributedInfo(rank, 2), (None, local_kv, local_kv))
+        assert e is not None and e != []
+        out[rank] = dict(e)
+
+    w0, w1 = out[0]["model.layers.3.self_attn.qkv_proj.weight"], \
+        out[1]["model.layers.3.self_attn.qkv_proj.weight"]
+    assert w0.shape == (2048 + 256 + 256, K) and w1.shape == w0.shape
+    torch.testing.assert_close(w0[:2048], q[:2048])
+    torch.testing.assert_close(w0[2048:2304], k[:256])
+    torch.testing.assert_close(w0[2304:], v[:256])
+    torch.testing.assert_close(w1[:2048], q[2048:])
+    torch.testing.assert_close(w1[2048:2304], k[256:])
+    torch.testing.assert_close(w1[2304:], v[256:])
+    # per-row scale: each part's scalar across its local rows
+    s0 = out[0]["model.layers.3.self_attn.qkv_proj.weight_scale"]
+    assert s0.shape == (2560,)
+    torch.testing.assert_close(s0[:2048], torch.full((2048,), sq, dtype=torch.float32))
+    torch.testing.assert_close(s0[2048:2304], torch.full((256,), sk, dtype=torch.float32))
+    torch.testing.assert_close(s0[2304:], torch.full((256,), sv, dtype=torch.float32))
+    # shared input_scale (max) is unchanged
+    torch.testing.assert_close(out[0]["model.layers.3.self_attn.qkv_proj.input_scale"],
+                               torch.tensor(0.205))
+
+
+def test_pt_fp8_fuse_qkv_tp1_unchanged():
+    from freetoken.models.qwen3_5_moe.weight import _pt_fp8_fuse
+
+    q = _rand_fp8((4096, 64), 1)
+    k = _rand_fp8((512, 64), 2)
+    v = _rand_fp8((512, 64), 3)
+    buf = {}
+    _set_tp(0, 1)
+    e = _pt_fp8_fuse("l.self_attn.q_proj", q, torch.tensor(0.2), None,
+                     buf, DistributedInfo(0, 1), None)
+    e = _pt_fp8_fuse("l.self_attn.k_proj", k, torch.tensor(0.3), None,
+                     buf, DistributedInfo(0, 1), None)
+    e = _pt_fp8_fuse("l.self_attn.v_proj", v, torch.tensor(0.4), None,
+                     buf, DistributedInfo(0, 1), None)
+    d = dict(e)
+    torch.testing.assert_close(d["l.self_attn.qkv_proj.weight"],
+                               torch.cat([q, k, v], dim=0))
+
+
+def test_pt_fp8_fuse_qkvz_shard_tp2():
+    from freetoken.models.qwen3_5_moe.weight import _pt_fp8_fuse
+
+    # GDN: qkv = key_dim(2048) + key_dim(2048) + value_dim(4096); z = value_dim(4096).
+    K = 2048
+    qkv = _rand_fp8((8192, K), 7)
+    z = _rand_fp8((4096, K), 8)
+    buf = {}
+    _set_tp(1, 2)
+    e = _pt_fp8_fuse("l.linear_attn.in_proj_qkv", qkv, torch.tensor(0.1), None,
+                     buf, DistributedInfo(1, 2), None)
+    assert e == []
+    e = _pt_fp8_fuse("l.linear_attn.in_proj_z", z, torch.tensor(0.5), None,
+                     buf, DistributedInfo(1, 2), None)
+    d = dict(e)
+    w = d["l.linear_attn.in_proj_qkvz.weight"]
+    assert w.shape == (1024 + 1024 + 2048 + 2048, K)
+    torch.testing.assert_close(w[:1024], qkv[1024:2048])        # rank 1: q[1024:2048]
+    torch.testing.assert_close(w[1024:2048], qkv[3072:4096])    # k[1024:2048]
+    torch.testing.assert_close(w[2048:4096], qkv[4096 + 2048:])  # v[2048:4096]
+    torch.testing.assert_close(w[4096:], z[2048:])              # z[2048:4096]
+    s = d["l.linear_attn.in_proj_qkvz.weight_scale"]
+    torch.testing.assert_close(s[:4096], torch.full((4096,), 0.1, dtype=torch.float32))
+    torch.testing.assert_close(s[4096:], torch.full((2048,), 0.5, dtype=torch.float32))
+
+
+def test_pt_fp8_fuse_qkv_kv_replicate_tp4():
+    from freetoken.models.qwen3_5_moe.weight import _pt_fp8_fuse
+
+    # 2 KV heads at TP=4 -> each KV head replicated on 2 ranks.
+    K = 64
+    q = _rand_fp8((4096, K), 1)
+    k = _rand_fp8((512, K), 2)
+    v = _rand_fp8((512, K), 3)
+    local_kv = 256  # 1 head per rank, replicated
+    out = {}
+    for rank in range(4):
+        buf = {}
+        _set_tp(rank, 4)
+        for name, t, s in (("q_proj", q, 0.2), ("k_proj", k, 0.3), ("v_proj", v, 0.4)):
+            e = _pt_fp8_fuse(f"l.self_attn.{name}", t, torch.tensor(s), None,
+                             buf, DistributedInfo(rank, 4), (None, local_kv, local_kv))
+        out[rank] = dict(e)["l.self_attn.qkv_proj.weight"]
+    # local layout: q 4096/4=1024, then k 256, then v 256
+    # ranks 0,1 share KV head 0; ranks 2,3 share KV head 1
+    torch.testing.assert_close(out[0][1024:1280], out[1][1024:1280])
+    torch.testing.assert_close(out[2][1024:1280], out[3][1024:1280])
+    torch.testing.assert_close(out[0][1024:1280], k[:256])
+    torch.testing.assert_close(out[2][1024:1280], k[256:])
+    torch.testing.assert_close(out[0][1280:], out[1][1280:])
+    torch.testing.assert_close(out[0][1280:], v[:256])
+    # q is a plain /4 split
+    torch.testing.assert_close(out[0][:1024], q[:1024])
+    torch.testing.assert_close(out[3][:1024], q[3072:])
+
+
+# ======================================================================================
+# _fp8_shard_part (block-fp8 checkpoint: 128x128 block scales)
+# ======================================================================================
+def test_fp8_shard_part_qkv_weight_and_scale():
+    from freetoken.models.qwen3_5_moe.weight import _fp8_shard_part
+
+    class Gdn:
+        num_key_heads, key_head_dim = 16, 128
+        num_value_heads, value_head_dim = 32, 128
+
+    K, KB = 2048, 2048 // 128
+    q = _rand_fp8((4096, K), 1)
+    k = _rand_fp8((512, K), 2)
+    v = _rand_fp8((512, K), 3)
+    qs = torch.randn(4096 // 128, KB)
+    ks = torch.randn(512 // 128, KB)
+    vs = torch.randn(512 // 128, KB)
+    qkv_local = (None, 256, 256)
+    tp1 = DistributedInfo(1, 2)
+
+    for suf, parts, locals_ in (
+        (".weight", (q, k, v), (2048, 256, 256)),
+        (".weight_scale_inv", (qs, ks, vs), (16, 2, 2)),
+    ):
+        got = [
+            _fp8_shard_part(".self_attn.qkv_proj", i, t, suf, tp1, qkv_local, Gdn())
+            for i, t in enumerate(parts)
+        ]
+        for g, t, local in zip(got, parts, locals_):
+            assert g.shape[0] == local, (g.shape, local)
+    # rank 1 takes the second half of every part
+    g = _fp8_shard_part(".self_attn.qkv_proj", 0, q, ".weight", tp1, qkv_local, Gdn())
+    torch.testing.assert_close(g, q[2048:])
+    g = _fp8_shard_part(".self_attn.qkv_proj", 1, ks, ".weight_scale_inv", tp1, qkv_local, Gdn())
+    torch.testing.assert_close(g, ks[2:])  # rank 1: second of two scale blocks
+
+
+def test_fp8_shard_part_qkvz_expands():
+    from freetoken.models.qwen3_5_moe.weight import _fp8_shard_part
+
+    class Gdn:
+        num_key_heads, key_head_dim = 16, 128
+        num_value_heads, value_head_dim = 32, 128
+
+    K = 2048
+    qkv = _rand_fp8((8192, K), 5)
+    z = _rand_fp8((4096, K), 6)
+    tp0 = DistributedInfo(0, 2)
+    w = _fp8_shard_part(".linear_attn.in_proj_qkvz", 0, qkv, ".weight", tp0, None, Gdn())
+    assert w.shape == (1024 + 1024 + 2048, K)
+    torch.testing.assert_close(w[:1024], qkv[:1024])
+    torch.testing.assert_close(w[1024:2048], qkv[2048:3072])
+    torch.testing.assert_close(w[2048:], qkv[4096:6144])
+    wz = _fp8_shard_part(".linear_attn.in_proj_qkvz", 1, z, ".weight", tp0, None, Gdn())
+    torch.testing.assert_close(wz, z[:2048])
+    # gate_up groups stay full (replicated model)
+    gu = torch.randn(1024, K)
+    torch.testing.assert_close(
+        _fp8_shard_part(".mlp.shared_expert.gate_up_proj", 0, gu, ".weight", tp0, None, Gdn()),
+        gu)
+
+
+# ======================================================================================
+# Row-parallel / column-merged quantized linears (pure-torch reference path)
+# ======================================================================================
+def test_fp8_pertensor_row_parallel_two_rank_sum():
+    from freetoken.kernel.triton.fp8_pertensor_linear import (
+        Fp8PerTensorLinear, Fp8PerTensorRowParallel,
+    )
+
+    N, K = 256, 512
+    g = torch.Generator().manual_seed(0)
+    w_bf16 = torch.randn(N, K, generator=g) * 0.05
+    scale = 0.25
+    w_fp8 = (w_bf16 / scale).to(FP8)
+    x = torch.randn(7, K, dtype=torch.bfloat16, generator=g)
+
+    full = Fp8PerTensorLinear(K, N)
+    full.weight.copy_(w_fp8)
+    full.weight_scale.copy_(torch.full((N,), scale))
+    full._uniform_scale = True
+    ref = full.forward(x)
+
+    partials = []
+    _ensure_single_rank_group()
+    for rank in (0, 1):
+        _set_tp(rank, 2)
+        layer = Fp8PerTensorRowParallel(K, N)
+        assert layer.weight.shape == (N, K // 2)
+        assert layer.weight_scale.shape == (N,)
+        shard = w_fp8[:, rank * K // 2:(rank + 1) * K // 2]
+        layer.weight.copy_(shard)
+        layer.weight_scale.copy_(torch.full((N,), scale))
+        layer._uniform_scale = True
+        partials.append(layer.forward(x[:, rank * K // 2:(rank + 1) * K // 2]))
+    # all_reduce is the identity on the single-rank group: the two partials must sum
+    # to the full (replicated) computation.
+    torch.testing.assert_close(partials[0] + partials[1], ref, atol=2e-2, rtol=2e-2)
+
+
+def test_fp8_pertensor_col_merged_local_sizes():
+    from freetoken.kernel.triton.fp8_pertensor_linear import Fp8PerTensorColMerged
+
+    _set_tp(1, 2)
+    layer = Fp8PerTensorColMerged(2048, [4096, 512, 512],
+                                  local_output_sizes=[2048, 256, 256])
+    assert layer.weight.shape == (2560, 2048)
+    assert layer.weight_scale.shape == (2560,)
+    # TP=1 default unchanged
+    _set_tp(0, 1)
+    full = Fp8PerTensorColMerged(2048, [4096, 512, 512])
+    assert full.weight.shape == (5120, 2048)
+
+
+def test_nvfp4_row_parallel_shapes():
+    from freetoken.kernel.triton.nvfp4_linear import (
+        Nvfp4DenseColMerged, Nvfp4DenseRowParallel,
+    )
+
+    _set_tp(0, 2)
+    row = Nvfp4DenseRowParallel(2048, 2048)
+    assert row.weight.shape == (2048, 1024 // 2)
+    assert row.weight_scale.shape == (2048, 1024 // 16)
+    assert row.weight_global.shape == (2048,)
+    col = Nvfp4DenseColMerged(2048, [512, 512], local_output_sizes=[256, 256])
+    assert col.weight.shape == (512, 2048 // 2)
+    assert col.weight_scale.shape == (512, 2048 // 16)
+    # load_state_dict round-trips the sharded layout (K-major repack)
+    row.load_state_dict({
+        "weight": torch.randint(0, 255, (2048, 512), dtype=torch.uint8),
+        "weight_scale": torch.randint(1, 10, (2048, 64), dtype=torch.uint8)
+        .view(torch.float8_e4m3fn),
+        "weight_global": torch.rand(2048, dtype=torch.float16),
+    })
+    assert row.weight.shape == (1024 // 8, 2048)  # K-major [K//8, N]
+    assert row.weight_scale.shape == (1024 // 16, 2048)

--- a/tests/models/test_qwen3_5_tp_quant.py
+++ b/tests/models/test_qwen3_5_tp_quant.py
@@ -225,6 +225,51 @@ def test_fp8_shard_part_qkvz_expands():
         gu)
 
 
+def test_fp8_shard_standalone_vocab_row_conv_tp2():
+    from freetoken.models.qwen3_5_moe.weight import _fp8_shard_standalone
+
+    class Gdn:
+        num_key_heads, key_head_dim = 16, 128
+        num_value_heads, value_head_dim = 32, 128
+
+    # Vocab-parallel: lm_head / embed_tokens shard rows (lm_head was previously yielded
+    # full-width against the vocab-sharded ParallelLMHead -> load-time shape assert).
+    w = torch.arange(8 * 4, dtype=torch.bfloat16).reshape(8, 4)
+    for name in ("lm_head.weight", "model.embed_tokens.weight"):
+        torch.testing.assert_close(
+            _fp8_shard_standalone(name, w, DistributedInfo(0, 2), None), w[:4])
+        torch.testing.assert_close(
+            _fp8_shard_standalone(name, w, DistributedInfo(1, 2), None), w[4:])
+    # Row-parallel: o_proj / out_proj shard the input (column) dim, weight and scale.
+    o = torch.randn(16, 256)
+    torch.testing.assert_close(
+        _fp8_shard_standalone("model.layers.0.self_attn.o_proj.weight", o,
+                              DistributedInfo(1, 2), None), o[:, 128:])
+    s = torch.randn(16, 2)
+    torch.testing.assert_close(
+        _fp8_shard_standalone("model.layers.0.self_attn.o_proj.weight_scale_inv", s,
+                              DistributedInfo(1, 2), None), s[:, 1:])
+    # Per-head GDN scalars shard dim 0; conv1d shards its (k, k, v) sub-parts.
+    a = torch.randn(16)
+    torch.testing.assert_close(
+        _fp8_shard_standalone("model.layers.0.linear_attn.A_log", a,
+                              DistributedInfo(1, 2), None), a[8:])
+    conv = torch.randn(2 * 2048 + 4096, 1)
+    got = _fp8_shard_standalone("model.layers.0.linear_attn.conv1d.weight", conv,
+                                DistributedInfo(0, 2), Gdn())
+    assert got.shape == (1024 + 1024 + 2048, 1)
+    torch.testing.assert_close(got[:1024], conv[:1024])
+    torch.testing.assert_close(got[1024:2048], conv[2048:3072])
+    torch.testing.assert_close(got[2048:], conv[4096:6144])
+    # Replicated names and TP=1 pass through unchanged.
+    norm = torch.randn(4)
+    torch.testing.assert_close(
+        _fp8_shard_standalone("model.layers.0.self_attn.o_norm.weight", norm,
+                              DistributedInfo(0, 2), None), norm)
+    torch.testing.assert_close(
+        _fp8_shard_standalone("lm_head.weight", w, DistributedInfo(0, 1), None), w)
+
+
 # ======================================================================================
 # Row-parallel / column-merged quantized linears (pure-torch reference path)
 # ======================================================================================

--- a/tests/models/test_qwen3_5_tp_quant.py
+++ b/tests/models/test_qwen3_5_tp_quant.py
@@ -368,6 +368,85 @@ def test_mixed_iter_weights_tp2_sharding():
     _set_tp(0, 1)
 
 
+def test_resident_nvfp4_expert_banks_tp_sharding():
+    """Full ``_iter_weights_attn_fp8`` run with ``include_moe_experts=True`` over a tiny mixed
+    checkpoint that carries the routed NVFP4 experts. Verifies the resident (fused) TP-sharded
+    bank shapes and that each rank's slice is the correct slice of the checkpoint tensors:
+    gate_up is column-parallel (shard the 2*I output rows), down is row-parallel (shard the I
+    input cols, a packed dim)."""
+    import tempfile
+
+    from safetensors import safe_open
+
+    from tests.models.tiny_fp8_ckpt import make_tiny_mixed_ckpt
+    from freetoken.models.qwen3_5_moe.weight import _iter_weights_attn_fp8
+
+    V = 2048
+    M, H = 512, 2048  # moe_intermediate_size, hidden (tiny_fp8_ckpt dims)
+    with tempfile.TemporaryDirectory() as d:
+        ckpt = make_tiny_mixed_ckpt(d, vocab=V, experts=8, routed_experts=True)
+        got = {}
+        for rank in (0, 1):
+            _set_tp(rank, 2)
+            got[rank] = dict(_iter_weights_attn_fp8(
+                ckpt, torch.device("cpu"), include_non_moe=True, include_moe_experts=True,
+                dense_nvfp4=True, lmhead_nvfp4=False))
+        with safe_open(f"{ckpt}/model.safetensors", framework="pt") as f:
+            # Layer-0 expert-0 checkpoint tensors (ground truth for the sharding).
+            gate = f.get_tensor("model.language_model.layers.0.mlp.experts.0.gate_proj.weight")
+            up = f.get_tensor("model.language_model.layers.0.mlp.experts.0.up_proj.weight")
+            down = f.get_tensor("model.language_model.layers.0.mlp.experts.0.down_proj.weight")
+
+    i = M // 2  # per-rank intermediate at TP=2
+    for rank in (0, 1):
+        w = got[rank]
+        pre = "model.layers.0.mlp.experts"
+        gu = w[f"{pre}.gate_up_packed"]
+        assert gu.shape == (8, 2 * i, H // 2), gu.shape
+        assert w[f"{pre}.gate_up_scale"].shape == (8, 2 * i, H // 16)
+        assert w[f"{pre}.gate_up_global"].shape == (8, 2 * i)
+        assert w[f"{pre}.down_packed"].shape == (8, H, i // 2)
+        assert w[f"{pre}.down_scale"].shape == (8, H, i // 16)
+        assert w[f"{pre}.down_global"].shape == (8, H)
+        # gate_up column-parallel: rank's gate rows [rank*i:(rank+1)*i], up rows likewise.
+        torch.testing.assert_close(gu[0, :i], gate[rank * i:(rank + 1) * i])
+        torch.testing.assert_close(gu[0, i:], up[rank * i:(rank + 1) * i])
+        # down row-parallel: rank's packed cols [rank*(i//2):(rank+1)*(i//2)].
+        torch.testing.assert_close(
+            w[f"{pre}.down_packed"][0], down[:, rank * (i // 2):(rank + 1) * (i // 2)])
+    _set_tp(0, 1)
+
+
+def test_resident_nvfp4_expert_banks_tp1_full():
+    """TP=1 resident NVFP4 banks are the full (unsharded) checkpoint tensors."""
+    import tempfile
+
+    from safetensors import safe_open
+
+    from tests.models.tiny_fp8_ckpt import make_tiny_mixed_ckpt
+    from freetoken.models.qwen3_5_moe.weight import _iter_weights_attn_fp8
+
+    V, M, H = 2048, 512, 2048
+    with tempfile.TemporaryDirectory() as d:
+        ckpt = make_tiny_mixed_ckpt(d, vocab=V, experts=8, routed_experts=True)
+        _set_tp(0, 1)
+        w = dict(_iter_weights_attn_fp8(
+            ckpt, torch.device("cpu"), include_non_moe=True, include_moe_experts=True,
+            dense_nvfp4=True, lmhead_nvfp4=False))
+        with safe_open(f"{ckpt}/model.safetensors", framework="pt") as f:
+            gate = f.get_tensor("model.language_model.layers.0.mlp.experts.0.gate_proj.weight")
+            up = f.get_tensor("model.language_model.layers.0.mlp.experts.0.up_proj.weight")
+            down = f.get_tensor("model.language_model.layers.0.mlp.experts.0.down_proj.weight")
+    pre = "model.layers.0.mlp.experts"
+    assert w[f"{pre}.gate_up_packed"].shape == (8, 2 * M, H // 2)
+    assert w[f"{pre}.down_packed"].shape == (8, H, M // 2)
+    # Full bank: gate rows [0:M], up rows [M:2M]; down unsharded.
+    torch.testing.assert_close(w[f"{pre}.gate_up_packed"][0, :M], gate)
+    torch.testing.assert_close(w[f"{pre}.gate_up_packed"][0, M:], up)
+    torch.testing.assert_close(w[f"{pre}.down_packed"][0], down)
+    _set_tp(0, 1)
+
+
 # ======================================================================================
 # Row-parallel / column-merged quantized linears (pure-torch reference path)
 # ======================================================================================

--- a/tests/models/tiny_fp8_ckpt.py
+++ b/tests/models/tiny_fp8_ckpt.py
@@ -157,10 +157,141 @@ def make_tiny_fp8_ckpt(
     return out_dir
 
 
+def make_tiny_mixed_ckpt(
+    out_dir: str,
+    *,
+    vocab: int = 248320,
+    layers: int = 4,
+    experts: int = 32,
+    seed: int = 0,
+) -> str:
+    """Write a minimal modelopt MIXED_PRECISION checkpoint (random weights).
+
+    Per-tensor FP8 attention/GDN projections + NVFP4 shared_expert (routed experts are
+    NVFP4-tagged but absent -- the dense loader pass skips them for the offload cache)
+    and a BF16 lm_head: the case where the model holds a vocab-sharded ParallelLMHead
+    while the mixed loader pass must shard lm_head like embed_tokens."""
+    from safetensors.torch import save_file
+
+    os.makedirs(out_dir, exist_ok=True)
+    torch.manual_seed(seed)
+
+    def fp8(shape):
+        return (torch.randn(*shape) * 0.05).to(torch.float8_e4m3fn)
+
+    def scale1():
+        return (torch.rand(()) * 0.02 + 0.03).to(torch.float32)
+
+    def bf16(shape, s=0.02):
+        return (torch.randn(*shape) * s).to(torch.bfloat16)
+
+    def nvfp4(shape):
+        o, i = shape
+        return {
+            ".weight": torch.randint(0, 255, (o, i // 2), dtype=torch.uint8),
+            ".weight_scale": (torch.rand(o, i // 16) * 0.02 + 0.03).to(torch.float8_e4m3fn),
+            ".weight_scale_2": (torch.rand(()) * 0.02 + 0.03).to(torch.float32),
+        }
+
+    t: dict[str, torch.Tensor] = {}
+    t["lm_head.weight"] = bf16((vocab, H))
+    t["model.language_model.embed_tokens.weight"] = bf16((vocab, H))
+    t["model.language_model.norm.weight"] = bf16((H,))
+    for li in range(layers):
+        pre = f"model.language_model.layers.{li}"
+        t[f"{pre}.input_layernorm.weight"] = bf16((H,))
+        t[f"{pre}.post_attention_layernorm.weight"] = bf16((H,))
+        t[f"{pre}.mlp.gate.weight"] = bf16((experts, H))
+        t[f"{pre}.mlp.shared_expert_gate.weight"] = bf16((1, H))
+        for p, shape in (("gate", (M, H)), ("up", (M, H)), ("down", (H, M))):
+            t.update({f"{pre}.mlp.shared_expert.{p}_proj{k}": v
+                      for k, v in nvfp4(shape).items()})
+        if li % 4 != 3:  # GDN (linear attention)
+            g = f"{pre}.linear_attn"
+            t[f"{g}.A_log"] = bf16((NV,))
+            t[f"{g}.dt_bias"] = bf16((NV,))
+            t[f"{g}.conv1d.weight"] = bf16((CONV, 1, 4))
+            t[f"{g}.in_proj_a.weight"] = bf16((NV, H))
+            t[f"{g}.in_proj_b.weight"] = bf16((NV, H))
+            t[f"{g}.norm.weight"] = bf16((KDIM,))
+            for p, rows in (("in_proj_qkv", QKV), ("in_proj_z", Z), ("out_proj", O)):
+                t[f"{g}.{p}.weight"] = fp8((rows, H if p != "out_proj" else Z))
+                t[f"{g}.{p}.weight_scale"] = scale1()
+        else:  # full attention
+            a = f"{pre}.self_attn"
+            for p, rows in (("q", Q), ("k", KV), ("v", KV)):
+                t[f"{a}.{p}_proj.weight"] = fp8((rows, H))
+                t[f"{a}.{p}_proj.weight_scale"] = scale1()
+            t[f"{a}.o_proj.weight"] = fp8((O, ODIM))
+            t[f"{a}.o_proj.weight_scale"] = scale1()
+            t[f"{a}.q_norm.weight"] = bf16((HEAD_DIM,))
+            t[f"{a}.k_norm.weight"] = bf16((HEAD_DIM,))
+
+    cfg = {
+        "model_type": "qwen3_5_moe",
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "text_config": {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": H,
+            "num_hidden_layers": layers,
+            "layer_types": [
+                "linear_attention" if i % 4 != 3 else "full_attention" for i in range(layers)
+            ],
+            "full_attention_interval": 4,
+            "num_attention_heads": N_Q_HEADS,
+            "num_key_value_heads": N_KV_HEADS,
+            "head_dim": HEAD_DIM,
+            "attn_output_gate": True,
+            "partial_rotary_factor": 0.25,
+            "rope_parameters": {
+                "rope_theta": 10000000,
+                "partial_rotary_factor": 0.25,
+                "rope_type": "default",
+            },
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": NV,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "num_experts": experts,
+            "num_experts_per_tok": min(8, experts),
+            "moe_intermediate_size": M,
+            "shared_expert_intermediate_size": M,
+            "vocab_size": vocab,
+            "max_position_embeddings": 32768,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": False,
+            "use_cache": True,
+        },
+        "quantization_config": {
+            "quant_algo": "MIXED_PRECISION",
+            "quantized_layers": {
+                "model.language_model.layers.3.self_attn.q_proj": {"quant_algo": "FP8"},
+                "model.language_model.layers.0.linear_attn.in_proj_qkv": {"quant_algo": "FP8"},
+                "model.language_model.layers.0.mlp.experts": {"quant_algo": "W4A16_NVFP4"},
+            },
+        },
+    }
+    json.dump(cfg, open(f"{out_dir}/config.json", "w"), indent=1)
+    save_file(t, f"{out_dir}/model.safetensors")
+    json.dump(
+        {
+            "metadata": {"total_size": sum(x.numel() * x.element_size() for x in t.values())},
+            "weight_map": {k: "model.safetensors" for k in t},
+        },
+        open(f"{out_dir}/model.safetensors.index.json", "w"),
+    )
+    return out_dir
+
+
 if __name__ == "__main__":
     import sys
 
     out = sys.argv[1] if len(sys.argv) > 1 else "tiny-fp8-ckpt"
     vocab = int(sys.argv[2]) if len(sys.argv) > 2 else 248320
-    make_tiny_fp8_ckpt(out, vocab=vocab)
-    print(f"wrote {out} (vocab={vocab})")
+    mode = sys.argv[3] if len(sys.argv) > 3 else "block_fp8"
+    if mode == "mixed":
+        make_tiny_mixed_ckpt(out, vocab=vocab)
+    else:
+        make_tiny_fp8_ckpt(out, vocab=vocab)
+    print(f"wrote {out} (vocab={vocab}, mode={mode})")

--- a/tests/models/tiny_fp8_ckpt.py
+++ b/tests/models/tiny_fp8_ckpt.py
@@ -1,0 +1,166 @@
+"""Tiny block-FP8 qwen3_5_moe checkpoint generator for TP loader tests / E2E boots.
+
+Shrinks the Qwen3.6-35B-A3B-FP8 geometry (4 layers: 3 GDN + 1 full-attn, few experts)
+while keeping hidden 2048, all per-layer dims, and -- by default -- the FULL vocab
+(248320), so lm_head / embed_tokens exercise the exact vocab-parallel shapes the TP=2
+loader bug hit. Weights are random: the point is to load/boot/serve, not to generate
+coherent text.
+
+Used by ``test_qwen3_5_tp_quant.py`` (small vocab, CPU loader test) and manually for
+full E2E boots (full vocab, ``ft serve --tensor-parallel-size 2``).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import torch
+
+# Per-layer dims are the REAL Qwen3.6-35B-A3B-FP8 values (block-fp8, 128x128 scales):
+H = 2048            # hidden
+M = 512             # moe / shared intermediate
+Q = 8192            # full-attn q_proj rows (16 heads * 256 * 2, attn output gate)
+KV = 512            # k / v rows (2 heads * 256)
+ODIM = 4096         # o_proj input (16 heads * 256; the output gate halves q before o_proj)
+O = 2048            # o_proj / out_proj rows
+QKV = 8192          # GDN in_proj_qkv rows (2 * 16 * 128 + 32 * 128)
+Z = 4096            # GDN in_proj_z rows (32 * 128)
+CONV = 8192         # GDN conv1d channels
+NV = 32             # GDN value heads (A_log / dt_bias / in_proj_ba rows)
+KDIM = 128          # GDN norm dim
+HEAD_DIM = 256      # full-attn head dim
+N_Q_HEADS = 16
+N_KV_HEADS = 2
+
+
+def make_tiny_fp8_ckpt(
+    out_dir: str,
+    *,
+    vocab: int = 248320,
+    layers: int = 4,
+    experts: int = 32,
+    seed: int = 0,
+) -> str:
+    """Write a minimal block-FP8 checkpoint (config.json + single safetensors + index)."""
+    from safetensors.torch import save_file
+
+    os.makedirs(out_dir, exist_ok=True)
+    torch.manual_seed(seed)
+
+    def fp8(shape):
+        return (torch.randn(*shape) * 0.05).to(torch.float8_e4m3fn)
+
+    def scale(shape):
+        return (torch.rand(*shape) * 0.02 + 0.03).to(torch.bfloat16)
+
+    def bf16(shape, s=0.02):
+        return (torch.randn(*shape) * s).to(torch.bfloat16)
+
+    t: dict[str, torch.Tensor] = {}
+    t["lm_head.weight"] = bf16((vocab, H))
+    t["model.language_model.embed_tokens.weight"] = bf16((vocab, H))
+    t["model.language_model.norm.weight"] = bf16((H,))
+    for li in range(layers):
+        pre = f"model.language_model.layers.{li}"
+        t[f"{pre}.input_layernorm.weight"] = bf16((H,))
+        t[f"{pre}.post_attention_layernorm.weight"] = bf16((H,))
+        t[f"{pre}.mlp.gate.weight"] = bf16((experts, H))
+        t[f"{pre}.mlp.shared_expert_gate.weight"] = bf16((1, H))
+        for p in ("gate", "up"):
+            t[f"{pre}.mlp.shared_expert.{p}_proj.weight"] = fp8((M, H))
+            t[f"{pre}.mlp.shared_expert.{p}_proj.weight_scale_inv"] = scale((M // 128, H // 128))
+        t[f"{pre}.mlp.shared_expert.down_proj.weight"] = fp8((H, M))
+        t[f"{pre}.mlp.shared_expert.down_proj.weight_scale_inv"] = scale((H // 128, M // 128))
+        for e in range(experts):
+            ep = f"{pre}.mlp.experts.{e}"
+            for p in ("gate", "up"):
+                t[f"{ep}.{p}_proj.weight"] = fp8((M, H))
+                t[f"{ep}.{p}_proj.weight_scale_inv"] = scale((M // 128, H // 128))
+            t[f"{ep}.down_proj.weight"] = fp8((H, M))
+            t[f"{ep}.down_proj.weight_scale_inv"] = scale((H // 128, M // 128))
+        if li % 4 != 3:  # GDN (linear attention)
+            g = f"{pre}.linear_attn"
+            t[f"{g}.A_log"] = bf16((NV,))
+            t[f"{g}.dt_bias"] = bf16((NV,))
+            t[f"{g}.conv1d.weight"] = bf16((CONV, 1, 4))
+            t[f"{g}.in_proj_a.weight"] = bf16((NV, H))
+            t[f"{g}.in_proj_b.weight"] = bf16((NV, H))
+            t[f"{g}.in_proj_qkv.weight"] = fp8((QKV, H))
+            t[f"{g}.in_proj_qkv.weight_scale_inv"] = scale((QKV // 128, H // 128))
+            t[f"{g}.in_proj_z.weight"] = fp8((Z, H))
+            t[f"{g}.in_proj_z.weight_scale_inv"] = scale((Z // 128, H // 128))
+            t[f"{g}.norm.weight"] = bf16((KDIM,))
+            t[f"{g}.out_proj.weight"] = fp8((O, Z))
+            t[f"{g}.out_proj.weight_scale_inv"] = scale((O // 128, Z // 128))
+        else:  # full attention
+            a = f"{pre}.self_attn"
+            for p, rows in (("q", Q), ("k", KV), ("v", KV)):
+                t[f"{a}.{p}_proj.weight"] = fp8((rows, H))
+                t[f"{a}.{p}_proj.weight_scale_inv"] = scale((rows // 128, H // 128))
+            t[f"{a}.o_proj.weight"] = fp8((O, ODIM))
+            t[f"{a}.o_proj.weight_scale_inv"] = scale((O // 128, ODIM // 128))
+            t[f"{a}.q_norm.weight"] = bf16((HEAD_DIM,))
+            t[f"{a}.k_norm.weight"] = bf16((HEAD_DIM,))
+
+    cfg = {
+        "model_type": "qwen3_5_moe",
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "text_config": {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": H,
+            "num_hidden_layers": layers,
+            "layer_types": [
+                "linear_attention" if i % 4 != 3 else "full_attention" for i in range(layers)
+            ],
+            "full_attention_interval": 4,
+            "num_attention_heads": N_Q_HEADS,
+            "num_key_value_heads": N_KV_HEADS,
+            "head_dim": HEAD_DIM,
+            "attn_output_gate": True,
+            "partial_rotary_factor": 0.25,
+            "rope_parameters": {
+                "rope_theta": 10000000,
+                "partial_rotary_factor": 0.25,
+                "rope_type": "default",
+            },
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": NV,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "num_experts": experts,
+            "num_experts_per_tok": min(8, experts),
+            "moe_intermediate_size": M,
+            "shared_expert_intermediate_size": M,
+            "vocab_size": vocab,
+            "max_position_embeddings": 32768,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": False,
+            "use_cache": True,
+        },
+        "quantization_config": {
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "activation_scheme": "dynamic",
+            "weight_block_size": [128, 128],
+        },
+    }
+    json.dump(cfg, open(f"{out_dir}/config.json", "w"), indent=1)
+    save_file(t, f"{out_dir}/model.safetensors")
+    json.dump(
+        {
+            "metadata": {"total_size": sum(x.numel() * x.element_size() for x in t.values())},
+            "weight_map": {k: "model.safetensors" for k in t},
+        },
+        open(f"{out_dir}/model.safetensors.index.json", "w"),
+    )
+    return out_dir
+
+
+if __name__ == "__main__":
+    import sys
+
+    out = sys.argv[1] if len(sys.argv) > 1 else "tiny-fp8-ckpt"
+    vocab = int(sys.argv[2]) if len(sys.argv) > 2 else 248320
+    make_tiny_fp8_ckpt(out, vocab=vocab)
+    print(f"wrote {out} (vocab={vocab})")

--- a/tests/models/tiny_fp8_ckpt.py
+++ b/tests/models/tiny_fp8_ckpt.py
@@ -164,6 +164,7 @@ def make_tiny_mixed_ckpt(
     layers: int = 4,
     experts: int = 32,
     seed: int = 0,
+    routed_experts: bool = False,
 ) -> str:
     """Write a minimal modelopt MIXED_PRECISION checkpoint (random weights).
 
@@ -206,6 +207,12 @@ def make_tiny_mixed_ckpt(
         for p, shape in (("gate", (M, H)), ("up", (M, H)), ("down", (H, M))):
             t.update({f"{pre}.mlp.shared_expert.{p}_proj{k}": v
                       for k, v in nvfp4(shape).items()})
+        if routed_experts:
+            for e in range(experts):
+                ep = f"{pre}.mlp.experts.{e}"
+                for p, shape in (("gate", (M, H)), ("up", (M, H)), ("down", (H, M))):
+                    t.update({f"{ep}.{p}_proj{k}": v
+                              for k, v in nvfp4(shape).items()})
         if li % 4 != 3:  # GDN (linear attention)
             g = f"{pre}.linear_attn"
             t[f"{g}.A_log"] = bf16((NV,))

--- a/tests/moe/test_cpu_executor_affinity.py
+++ b/tests/moe/test_cpu_executor_affinity.py
@@ -1,0 +1,64 @@
+"""TP core-partitioning tests for the CPU MoE executor's worker pool.
+
+Regression test for the TP>1 pinning collision: every rank process auto-pinned
+the whole machine, so the rank pools time-sliced on the same cores (~4-14x
+decode loss measured on 2-GPU boxes). Under TP each rank must get a disjoint
+slice of the physical cores. Pure Python -- no CUDA / compiled extension needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def fake_cores(monkeypatch):
+    """16 physical cores, no SMT."""
+    import freetoken.moe.cpu_executor as ce
+
+    monkeypatch.setattr(ce, "physical_core_cpus", lambda: list(range(16)))
+    return ce
+
+
+def _disjoint_partition(ce, world_size, requested=0):
+    slices = [
+        ce.resolve_threads_and_affinity(requested, rank=r, world_size=world_size)[1]
+        for r in range(world_size)
+    ]
+    for i, a in enumerate(slices):
+        for b in slices[i + 1 :]:
+            assert not set(a) & set(b), f"rank {i} and {b.index(b[0]) if b else '?'} overlap: {a} vs {b}"
+    return slices
+
+
+def test_tp2_auto_slices_are_disjoint_partition(fake_cores):
+    n0, c0 = fake_cores.resolve_threads_and_affinity(0, rank=0, world_size=2)
+    n1, c1 = fake_cores.resolve_threads_and_affinity(0, rank=1, world_size=2)
+    assert (n0, n1) == (8, 8)
+    assert not set(c0) & set(c1)
+    assert sorted(c0 + c1) == list(range(16))
+
+
+def test_tp4_auto_slices_are_disjoint_partition(fake_cores):
+    slices = _disjoint_partition(fake_cores, world_size=4)
+    assert sorted(sum(slices, [])) == list(range(16))
+
+
+def test_explicit_count_stays_in_rank_slice(fake_cores):
+    n, cores = fake_cores.resolve_threads_and_affinity(8, rank=1, world_size=2)
+    assert n == 8
+    assert set(cores) <= set(range(1, 16, 2))
+
+
+def test_single_rank_unchanged(fake_cores):
+    n, cores = fake_cores.resolve_threads_and_affinity(0)
+    assert (n, cores) == (16, list(range(16)))
+    # explicit count behaves as before (spread across all cores)
+    n, cores = fake_cores.resolve_threads_and_affinity(4)
+    assert n == 4 and len(set(cores)) == 4
+
+
+def test_rank_wraps_around(fake_cores):
+    # rank >= world_size must not crash or escape the partition scheme
+    _, c = fake_cores.resolve_threads_and_affinity(0, rank=2, world_size=2)
+    assert c == list(range(0, 16, 2))


### PR DESCRIPTION
## Problem
support TP for Qwen3.5 MoE model in RoadMap https://github.com/FlashML-org/FreeToken/issues/79

Qwen3.5 MoE model (Qwen3.6-35B-A3B) only supported TP=1. The weight loader raised `NotImplementedError("qwen3_5_moe weight loading currently supports TP=1 only")`, and all linear layers used `LinearReplicated` (no sharding, no all-reduce).

## Implementation

### Weight Sharding 
Two sharding functions handle all weight types:

- **`_shard_tp`**: Simple chunk along a given dimension (for o_proj, embed_tokens, lm_head, A_log, dt_bias, expert down_proj).
- **`_shard_tp_parts`**: Per-part column-parallel sharding with optional GQA KV head replication. When `num_kv_heads < tp_size`, KV heads are replicated using `rank * num_heads // world_size` (matching `shard_tensor` in `loader.py`).

Qwen3.5's checkpoint stores pre-fused weights (qkv_proj, in_proj, gate_up_proj). Simple chunk on a fused weight gives incorrect results — e.g., chunking `[gate, up]` gives rank 0 the entire gate and rank 1 the entire up, instead of each rank getting half of both. The fix shards each sub-part independently:


### Model Layers

- **Attention** (`attention.py`): TP-local head counts, `_qkv_split` computed from local heads with `allow_replicate=True` for KV. `o_proj` changed from `make_replicated` to `make_row_parallel` (row-parallel + all-reduce). `.view()` → `.reshape()` for non-contiguous tensors after `torch.split`.

- **GDN** (`gdn.py`): TP-local dimensions for heads, key_dim, value_dim, conv_dim. `in_proj` uses full sizes for `LinearColParallelMerged` (which handles its own sharding). `conv1d`, `A_log`, `dt_bias` use TP-local sizes. `out_proj` changed from `make_replicated_quant` to `make_row_parallel_quant`. FP8 path also uses TP-local dims.

- **MoE** (`moe.py`): `OffloadMoELayer._maybe_all_reduce` is a no-op (expert banks are full on each rank in offload mode). `MoELayer` (resident/fused) retains its own all-reduce.


## Test Results

### UT

tests/models/test_qwen3_5_tp.py::test_shard_tp PASSED
tests/models/test_qwen3_5_tp.py::test_shard_tp_parts PASSED
tests/models/test_qwen3_5_tp.py::test_shard_tp_parts_replicate PASSED

### E2E

**Offload mode (default):**

ft serve --model Qwen/Qwen3.6-35B-A3B --tp-size 1/2/4

| TP  | Output | Status |
|---|---|---|
| 1 | "Here's a thinking process: 1. Analyze User Input: - Question: 'What is 2+3?'" | ✓ |
| 2 | Same | ✓ |
| 4| Same | ✓ |

**Resident (fused) mode:**

ft serve --model Qwen/Qwen3.6-35B-A3B --tp-size 1/2/4 --moe-backend fused

| TP  | Output | Status |
|---|---|---|
| 1 | Same as above | ✓ |
| 2| Same | ✓ |
| 4 | Same | ✓ |

### GPU Memory per Card 

| TP | Mode | Expert | KV cache | Non-expert(Attn+GDN+Shared et al.) |
|---|---|---|---|---|
| 1 | offload | 0 (host RAM) | 75.9 GiB | ~6 GB |
| 2 | offload | 0 | 78.5 GiB | ~3 GB |
| 4 | offload | 0 | 80.0 GiB | ~1.5 GB |
| 1 | Resident | ~60 GB | 19.0 GiB | ~6 GB |
| 2 | Resident | ~30 GB | 51.5 GiB | ~3 GB |
| 4 | Resident | ~15 GB | 68.0 GiB | ~1.5 GB |

CC @jason-fxz @andy-yang-1 
