### PR TITLE
feat(server): Add OpenAI /v1/models/{model_id} endpoint

### DIFF
--- a/python/freetoken/server/openai_api.py
+++ b/python/freetoken/server/openai_api.py
@@ -143,6 +143,35 @@ def register_openai_routes(
             default_reasoning_effort=default_effort,
         )])
 
+    @app.get("/v1/models/{model_id:path}")
+    async def v1_model(model_id: str):
+        """Retrieve metadata for the currently served model.
+
+        OpenAI-compatible clients may use this endpoint to validate a model
+        name before sending completion requests.
+        """
+        state = get_state()
+        served_model_id = _served_model_name(state)
+
+        if model_id != served_model_id:
+            return create_error_response(
+                f"The model '{model_id}' does not exist",
+                status_code=404,
+                err_type="invalid_request_error",
+                param="model",
+                code="model_not_found",
+            )
+
+        ctx = _model_context_length(state)
+        efforts, default_effort = await _effort_fields(state)
+        return ModelCard(
+            id=served_model_id,
+            root=state.config.model_path,
+            max_model_len=ctx,
+            context_length=ctx,
+            supported_reasoning_efforts=efforts,
+            default_reasoning_effort=default_effort,
+        )
 
 async def handle_chat_completion(
     req: ChatCompletionRequest,


### PR DESCRIPTION
In Microsoft Visual Studio, you can use local AI endpoints. When you point it at the OpenAI compatible API, it makes a request to:

GET http://127.0.0.1:1919/v1/models

and returns:
```

{
  "object": "list",
  "data": [
    {
      "id": "Qwen3.6-35B-A3B-NVFP4",
      ...
    }
  ]
}
```

Afterwards, Visual Studio then makes a follow up request to:

GET http://127.0.0.1:1919/v1/models/Qwen3.6-35B-A3B-NVFP4 and currently gets a 404, even though the model really is loaded. This then prevents FreeToken server from being used as Visual Studio assumes the OpenAPI server and/or model name is invalid.

This is a small OpenAI-compatibility gap. The OpenAI API has a “retrieve model” operation corresponding to GET /v1/models/{model}, and some clients evidently use it to validate a manually specified model name.

This change leaves the existing /v1/models endpoint unchanged and only adds the missing OpenAI-compatible retrieve-model operation. The existing route currently constructs its ModelCard using the same context-length and reasoning-effort metadata shown above.