### PR TITLE
feat(server): expose swa_full_tokens_ratio as a startup CLI flag

### DIFF
--- a/python/freetoken/server/args.py
+++ b/python/freetoken/server/args.py
@@ -109,6 +109,15 @@ def parse_args(
             raise argparse.ArgumentTypeError("must be >= 1")
         return n
 
+    def _swa_ratio(value: str) -> float:
+        try:
+            r = float(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError("must be a number in (0, 1]") from exc
+        if not 0.0 < r <= 1.0:
+            raise argparse.ArgumentTypeError("must be in (0, 1]")
+        return r
+
     def _infer_tool_call_parser(model_path: str) -> str:
         try:
             from freetoken.utils import cached_load_hf_config
@@ -250,6 +259,21 @@ def parse_args(
         help=(
             "Fraction of total GPU free memory the engine may use for weights + MoE "
             "cache + KV cache combined; the remainder is reserved runtime headroom."
+        ),
+    )
+
+    parser.add_argument(
+        "--swa-full-tokens-ratio",
+        type=_swa_ratio,
+        default=ServerArgs.swa_full_tokens_ratio,
+        help=(
+            "Window/full ratio for the SWA radix cache (--cache-type radix on sliding-window "
+            "models) and the DSV4 window tier: the startup window-pool size = "
+            "max(working-set floor, ratio x full-pool tokens). A larger ratio retains more "
+            "window-prefix KV for cross-request reuse (a shared prefix longer than the window "
+            "is reusable only when its windowed KV is retained), at the cost of full-pool "
+            "capacity; < 1.0 trades that reuse for memory. Must be in (0, 1]. Equivalent to a "
+            "startup /v1/cache/rebuild with swa_full_tokens_ratio, sized at load."
         ),
     )
 

--- a/tests/server/test_swa_full_tokens_ratio_flag.py
+++ b/tests/server/test_swa_full_tokens_ratio_flag.py
@@ -1,0 +1,49 @@
+"""`--swa-full-tokens-ratio`: the SWA radix-cache window/full ratio, set at startup.
+
+Exposes the existing ``EngineConfig.swa_full_tokens_ratio`` (previously reachable only via a runtime
+``/v1/cache/rebuild``) as a load-time CLI flag, so a sliding-window model can size its window pool
+up front -- e.g. large enough to retain a fixed prompt prefix for cross-request reuse. The value
+must be in ``(0, 1]``, mirroring the ``/v1/cache/rebuild`` validation.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from freetoken.server.args import ServerArgs, parse_args
+
+ANON_PATH = "/models/anon"
+
+
+class _Config:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def to_dict(self) -> dict:
+        return self._data
+
+
+def _parse(*extra):
+    # Mock the checkpoint config so parse_args' auto-parser cascade resolves without a real model.
+    config = _Config({"architectures": ["LlamaForCausalLM"], "torch_dtype": "bfloat16"})
+    with patch("freetoken.utils.cached_load_hf_config", lambda _path: config):
+        args, _run_shell = parse_args(["--model", ANON_PATH, *extra])
+    return args
+
+
+def test_defaults_to_the_engine_config_value_when_absent():
+    assert _parse().swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio
+
+
+def test_an_explicit_value_in_range_is_accepted():
+    assert _parse("--swa-full-tokens-ratio", "0.3").swa_full_tokens_ratio == 0.3
+    assert _parse("--swa-full-tokens-ratio", "1").swa_full_tokens_ratio == 1.0
+
+
+@pytest.mark.parametrize("bad", ["0", "1.5", "-0.1", "nan", "abc"])
+def test_out_of_range_or_non_numeric_is_rejected_at_parse_time(bad):
+    # argparse validates the arg type before any checkpoint config is loaded, so no mock is needed:
+    # the reject must not depend on reaching the model.
+    with pytest.raises(SystemExit):
+        parse_args(["--model", ANON_PATH, "--swa-full-tokens-ratio", bad])


### PR DESCRIPTION
## What

Adds a `--swa-full-tokens-ratio` CLI flag that sets `EngineConfig.swa_full_tokens_ratio` at model load — the SWA radix cache's window/full pool ratio (and the DSV4 window-tier ratio). It could previously only be changed at runtime via `POST /v1/cache/rebuild`, so the window pool was always first sized at its `0.2` default and only resized afterward — which can't grow past a runtime rebuild's tighter double-buffer budget, and needs an out-of-band call after every start.

The flag mirrors `--memory-ratio`, validates to `(0, 1]` (matching the `/v1/cache/rebuild` check), and threads through unchanged via `ServerArgs(**kwargs)`.

## Why

On a sliding-window model, a shared prompt prefix longer than the window is reusable across requests only if its windowed KV is retained — which requires the window pool ≥ the prefix. When the pool is smaller than a fixed leading prompt, that prefix is never reused and every request re-prefills it. Sizing the window pool at startup (rather than a post-start rebuild) also keeps more full-pool capacity, since it isn't bounded by the rebuild's reallocation budget. The same ratio drives the DSV4 window tier, so this is not specific to SWA-radix models.

## Tested on

Linux, NVIDIA RTX 5070 Laptop (8 GB), driver 595.84, CUDA 13.

**Unit test (no GPU):** `tests/server/test_swa_full_tokens_ratio_flag.py` — default resolves to the config value; an in-range value is accepted; out-of-range / non-numeric values are rejected at parse time (follows the `parse_args` mock pattern in `test_parser_auto_selection.py`).

**Full-attention model on `main` — `Qwen/Qwen3-0.6B`** (no window pool): the flag is accepted and applied (`swa_full_tokens_ratio=0.3` in `ServerArgs`), the model loads and serves normally — a no-op, as expected.
```
ft serve --model-path Qwen3-0.6B --swa-full-tokens-ratio 0.3 --memory-ratio 0.82 \
         --max-running-requests 1 --cuda-graph-max-bs 1
```

**SWA effect — `gemma-4-E2B-it` (q4_0 GGUF).** The model support is my separate open PR #59, so this A/B is on `main` + #59 + this flag (the flag itself is model-family-independent). Request ≈ 55k tokens (a ~27k fixed leading prefix + ~28k body); a second, near-identical request measures prefix reuse:

| `swa_full_tokens_ratio` | window pool | full pool | 2nd-call cached tokens | 2nd-call latency |
|---:|---:|---:|---:|---:|
| 0.2 (default = `main` behavior) | 25,921 | 129,604 | **0** | ~39 s (full re-prefill) |
| 0.3 (this flag, at load) | 34,023 | 113,410 | **46,615** | **0.3 s** |

Cold first-call prefill is ~39 s either way; the flag changes whether the shared prefix is *reused* on later calls (the default pool is smaller than the 27k prefix, so it can't be retained).
```
ft serve --model-path <gemma-4-E2B q4_0 gguf> --swa-full-tokens-ratio 0.3 \
         --memory-ratio 0.82 --max-running-requests 1 --cuda-graph-max-bs 1
```

## Notes

- One change, no behavior change unless the flag is passed (default is unchanged).
- Not a Roadmap item — happy to move to an issue / Slack first if the maintainers prefer.
- AI-assisted (disclosed in the commit trailer); authored, run, and verified on the hardware above.
