### PR TITLE
test(pinned): use mapped memory for UVA pointer check

### DIFF
--- a/tests/kernels/test_pinned_tensor.py
+++ b/tests/kernels/test_pinned_tensor.py
@@ -115,17 +115,21 @@ def test_host_device_ptr_is_identity_under_uva():
     if not torch.cuda.is_available():
         pytest.skip("needs CUDA")
 
-    from freetoken.kernel.pinned import _host_ptr_identity, _load_pinned_extension
+    from freetoken.kernel.pinned import (
+        _host_ptr_identity,
+        _load_pinned_extension,
+        alloc_pinned_tensor,
+    )
 
     torch.cuda.init()
     if not _host_ptr_identity():
         pytest.skip("non-UVA platform: host_device_ptr rejects unregistered memory instead")
-    # Under UVA cudaHostGetDevicePointer degenerates to identity for any host pointer
-    # (no registration validation); rejection of pageable memory only exists on
-    # non-identity platforms (Windows/WDDM), where the translation is real.
-    pageable = torch.empty(64, dtype=torch.uint8)
+    # CUDA 13 rejects unregistered pageable pointers even on Linux/UVA. Exercise
+    # only the supported pinned + mapped contract; pageable-pointer behavior is
+    # outside host_device_ptr's contract.
+    pinned = alloc_pinned_tensor(64, dtype=torch.uint8)
     ext = _load_pinned_extension()
-    assert ext.host_device_ptr(pageable.data_ptr()) == pageable.data_ptr()
+    assert ext.host_device_ptr(pinned.data_ptr()) == pinned.data_ptr()
 
 
 def test_host_bank_pin_registers_and_translates():


### PR DESCRIPTION
## Summary

- use `alloc_pinned_tensor` in `test_host_device_ptr_is_identity_under_uva`
- verify UVA pointer identity with mapped pinned memory, which is the supported `host_device_ptr` contract
- update the test comment to reflect CUDA 13 registration validation

## Why

On Linux/UVA with CUDA 13, `cudaHostGetDevicePointer` rejects an unregistered pageable host pointer with `cudaErrorInvalidValue`. The existing test passes a pageable tensor, contradicting the pinned + mapped contract of `host_device_ptr` and failing before pointer identity can be checked.

This is a test-only change; runtime code is unchanged.

## Testing

Environment:

- OS: Ubuntu 26.04 LTS, x86_64
- CPU: Intel Core i9-9920X
- GPU: 4 × NVIDIA TITAN RTX 24 GiB (SM75); test executed on the default CUDA device
- NVIDIA driver: 610.57.04
- Python: 3.14.4
- PyTorch: 2.12.0+cu130
- CUDA runtime: 13.0
- CUDA toolkit: 13.3 (`nvcc` V13.3.73)
- Checkpoint: N/A; these tests do not load model weights

Commands:

```bash
pytest -q tests/kernels/test_pinned_tensor.py::test_host_device_ptr_is_identity_under_uva
pytest -q tests/kernels/test_pinned_tensor.py
```

Results:

- `origin/main` at `bd372b6`: targeted test failed with `cudaHostGetDevicePointer failed ... invalid argument`
- this branch at `cb44bde`: targeted test passed (`1 passed`)
- this branch at `cb44bde`: complete pinned-memory test file passed (`8 passed`)