### PR TITLE
fix(download): include json files when fetching weights, so NVFP4's index.json is no longer silently skipped

### DIFF
--- a/python/freetoken/utils/hf.py
+++ b/python/freetoken/utils/hf.py
@@ -210,7 +210,7 @@ def download_hf_weight(model_path: str) -> str:
     try:
         return snapshot_download(
             model_path,
-            allow_patterns=["*.safetensors"],
+            allow_patterns=["*.safetensors", "*.json"],
             tqdm_class=DisabledTqdm,
         )
     except Exception as e:


### PR DESCRIPTION
Fixes #124.

## Root cause

`download_hf_weight()` fetches only `*.safetensors` from the Hub:

```python
return snapshot_download(
    model_path,
    allow_patterns=["*.safetensors"],
    tqdm_class=DisabledTqdm,
)
```

`model.safetensors.index.json` doesn't match that glob, so it never downloads.
Most weight-loading paths reconstruct the shard map from each shard's own
safetensors header and never miss it. `nvfp4_banks.load_nvfp4_expert_source_banks`
does require the prebuilt index file, so NVFP4 checkpoints fail at load with:

```
FileNotFoundError: [Errno 2] No such file or directory:
'...\snapshots\<rev>\model.safetensors.index.json'
```

despite the repo (e.g. `nvidia/Qwen3.6-35B-A3B-NVFP4`) shipping the file —
`download_hf_weight` simply never asked for it.

## Fix

Add `*.json` to the allow-list. Same call, one extra pattern.

## Tested

Verified against `huggingface_hub.utils.filter_repo_objects` — the actual
function `snapshot_download` uses internally to decide what to fetch — not a
reimplementation of the filtering logic:

```
CURRENT pattern (bug reproduced):
    FETCHED  model-00001-of-00003.safetensors
    FETCHED  model-00002-of-00003.safetensors
    skipped  model.safetensors.index.json
    skipped  config.json
    skipped  tokenizer.json

FIXED pattern (add *.json):
    FETCHED  model-00001-of-00003.safetensors
    FETCHED  model-00002-of-00003.safetensors
    FETCHED  model.safetensors.index.json
    FETCHED  config.json
    FETCHED  tokenizer.json
```

Also confirmed operationally: manually placing the missing file from the repo
into an existing snapshot (workaround noted in #124) lets
`nvidia/Qwen3.6-35B-A3B-NVFP4` load and serve normally — 262,144-token context,
42.2 tok/s decode, on an RTX 4090. This PR makes that automatic instead of a
manual step.

The added `*.json` pattern also brings in `config.json` / `tokenizer.json` /
etc. up front, which are small (tens of KB, `hf_quant_config.json` ~35 KB) —
no meaningful download-size impact, and likely redundant with whatever second
mechanism already fetches those today, but harmless either way.

Per the AI policy in CONTRIBUTING: this change was produced with AI assistance;
the submitter has reviewed and tested everything in it and takes responsibility
for it.
