### PR TITLE
fix(kernel): launch GGUF MoE GEMV token axis on grid.x, not grid.z

### DIFF
--- a/python/freetoken/kernel/csrc/gguf/moe_vec.cuh
+++ b/python/freetoken/kernel/csrc/gguf/moe_vec.cuh
@@ -2,6 +2,23 @@
 // https://github.com/vllm-project/vllm/blob/4492e3a55428e161ca8db381edc28263e5da4c8d/csrc/quantization/gguf/moe_vec.cuh
 // copied and adapted from
 // https://github.com/ggerganov/llama.cpp/blob/b2899/ggml-cuda/mmvq.cu
+
+// A kernel launch rejected for its *configuration* (a grid dimension over the device
+// limit, an oversized block) does not raise -- it only sets the error flag. Nothing here
+// checked it, so the flag latched and was reported by whatever unrelated CUDA call ran
+// next: the grid.z overflow fixed below surfaced as a failure inside flashinfer's
+// activation kernel, inside the next ggml_moe_a8_vec, and even inside a torch::zeros.
+#ifndef FT_MOE_VEC_LAUNCH_CHECK
+#define FT_MOE_VEC_LAUNCH_CHECK()                                                        \
+  do {                                                                                   \
+    cudaError_t err_ = cudaGetLastError();                                               \
+    TORCH_CHECK(                                                                         \
+        err_ == cudaSuccess,                                                             \
+        "moe_vec launch failed: ", cudaGetErrorString(err_),                             \
+        " (grid=", block_nums.x, ",", block_nums.y, ",", block_nums.z,                   \
+        " block=", block_dims.x, ",", block_dims.y, ",", block_dims.z, ")");             \
+  } while (0)
+#endif
 template <typename scalar_t, int qk, int qi, typename block_q_t, int vdr, vec_dot_q_cuda_t vec_dot_q_cuda>
 static __global__ void moe_vec_q(
     const void* __restrict__ vx,
@@ -12,10 +29,13 @@ static __global__ void moe_vec_q(
     const int ncols,
     const int nrows,
     const int token_stride) {
-  const auto row = blockIdx.x * blockDim.y + threadIdx.y;
+  // The flat (token, top-k) index rides blockIdx.x, not .z: it reaches tokens*top_k,
+  // which exceeds the 65535 cap on grid.y/.z (grid.x allows 2^31-1). Rows move to .y,
+  // whose extent is ceil(nrows / GGML_CUDA_MMV_Y) and stays far below the cap.
+  const auto row = blockIdx.y * blockDim.y + threadIdx.y;
 
-  const auto token = blockIdx.z / topk;
-  const auto expert = (topk_ids)[blockIdx.z];
+  const auto token = blockIdx.x / topk;
+  const auto expert = (topk_ids)[blockIdx.x];
 
   if (row >= nrows) {
     return;
@@ -47,7 +67,7 @@ static __global__ void moe_vec_q(
   }
 
   if (threadIdx.x == 0) {
-    dst[blockIdx.z * nrows + row] = tmp;
+    dst[blockIdx.x * nrows + row] = tmp;
   }
 }
 
@@ -64,10 +84,11 @@ static void moe_vec_q4_0_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK4_0, QI4_0, block_q4_0, VDR_Q4_0_Q8_1_MMVQ, vec_dot_q4_0_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -83,10 +104,11 @@ static void moe_vec_q4_1_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK4_0, QI4_1, block_q4_1, VDR_Q4_1_Q8_1_MMVQ, vec_dot_q4_1_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -102,10 +124,11 @@ static void moe_vec_q5_0_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK5_0, QI5_0, block_q5_0, VDR_Q5_0_Q8_1_MMVQ, vec_dot_q5_0_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -121,10 +144,11 @@ static void moe_vec_q5_1_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK5_1, QI5_1, block_q5_1, VDR_Q5_1_Q8_1_MMVQ, vec_dot_q5_1_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -140,10 +164,11 @@ static void moe_vec_q8_0_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK8_0, QI8_0, block_q8_0, VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -159,10 +184,11 @@ static void moe_vec_q2_K_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI2_K, block_q2_K, VDR_Q2_K_Q8_1_MMVQ, vec_dot_q2_K_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -178,10 +204,11 @@ static void moe_vec_q3_K_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI3_K, block_q3_K, VDR_Q3_K_Q8_1_MMVQ, vec_dot_q3_K_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -197,10 +224,11 @@ static void moe_vec_q4_K_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI4_K, block_q4_K, VDR_Q4_K_Q8_1_MMVQ, vec_dot_q4_K_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -216,10 +244,11 @@ static void moe_vec_q5_K_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI5_K, block_q5_K, VDR_Q5_K_Q8_1_MMVQ, vec_dot_q5_K_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -235,10 +264,11 @@ static void moe_vec_q6_K_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI6_K, block_q6_K, VDR_Q6_K_Q8_1_MMVQ, vec_dot_q6_K_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -254,10 +284,11 @@ static void moe_vec_iq2_xxs_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI2_XXS, block_iq2_xxs, 1, vec_dot_iq2_xxs_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -273,10 +304,11 @@ static void moe_vec_iq2_xs_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI2_XS, block_iq2_xs, 1, vec_dot_iq2_xs_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -292,10 +324,11 @@ static void moe_vec_iq2_s_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI2_S, block_iq2_s, 1, vec_dot_iq2_s_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -311,10 +344,11 @@ static void moe_vec_iq3_xxs_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI3_XXS, block_iq3_xxs, 1, vec_dot_iq3_xxs_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -330,10 +364,11 @@ static void moe_vec_iq1_s_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI1_S, block_iq1_s, 1, vec_dot_iq1_s_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -349,10 +384,11 @@ static void moe_vec_iq1_m_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI1_M, block_iq1_m, 1, vec_dot_iq1_m_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -368,10 +404,11 @@ static void moe_vec_iq4_nl_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK4_NL, QI4_NL, block_iq4_nl, VDR_Q4_0_Q8_1_MMVQ, vec_dot_iq4_nl_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -387,10 +424,11 @@ static void moe_vec_iq4_xs_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI4_XS, block_iq4_xs, 1, vec_dot_iq4_xs_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>
@@ -406,8 +444,9 @@ static void moe_vec_iq3_s_q8_1_cuda(
     const int token_stride,
     cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
+  const dim3 block_nums(tokens * top_k, block_num_y, 1);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
   moe_vec_q<scalar_t, QK_K, QI3_XS, block_iq3_s, 1, vec_dot_iq3_s_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  FT_MOE_VEC_LAUNCH_CHECK();
 }

--- a/tests/kernels/test_gguf_moe_vec.py
+++ b/tests/kernels/test_gguf_moe_vec.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+
+# maxGridDim{Y,Z} is 65535 on every CUDA compute capability; grid.x reaches 2**31-1.
+MAX_GRID_YZ = 65535
+
+
+def _q4_0_weights(num_experts: int, nrows: int, ncols: int, seed: int = 0) -> torch.Tensor:
+    """Structurally valid Q4_0 banks: each 32-value block is {half d; uint8 qs[16]}.
+
+    The scale has to be a real finite half -- random bytes decode to inf/nan and make any
+    comparison vacuous.
+    """
+    rng = np.random.default_rng(seed)
+    nblocks = ncols // 32
+    blocks = np.zeros((num_experts, nrows, nblocks, 18), dtype=np.uint8)
+    scale = np.array([0.01], dtype=np.float16).view(np.uint8)
+    blocks[..., 0], blocks[..., 1] = scale[0], scale[1]
+    blocks[..., 2:] = rng.integers(0, 256, blocks[..., 2:].shape, dtype=np.uint8)
+    return torch.from_numpy(blocks.reshape(num_experts, nrows, nblocks * 18)).cuda()
+
+
+def test_moe_vec_above_grid_z_limit_matches_split_batches():
+    """A batch whose ``tokens * top_k`` exceeds 65535 must still compute the right thing.
+
+    ``moe_vec_*_q8_1_cuda`` used to launch that product as grid.z, which CUDA rejects with
+    ``cudaErrorInvalidValue`` above 65535. With top_k=8 that made any prefill batch of 8192
+    tokens fail -- and ``--max-extend-tokens`` defaults to exactly 8192, so a single long
+    prompt, or a few concurrent ones packed into one batch, hit it. The launch return code
+    was unchecked, so the failure surfaced at whatever unrelated CUDA call ran next.
+
+    Splitting the same batch in half keeps each launch under the old limit, so the halves
+    are a reference the pre-fix kernel could actually produce.
+    """
+    from freetoken.kernel.gguf import ggml_moe_a8_vec
+    from freetoken.models.gguf.dequant import GGML_Q4_0
+
+    num_experts, hidden, nrows, top_k = 4, 256, 64, 8
+    tokens = (MAX_GRID_YZ // top_k) + 1  # 8192 -> 65536 > 65535, one over the old cap
+    assert tokens * top_k > MAX_GRID_YZ
+
+    torch.manual_seed(0)
+    weight = _q4_0_weights(num_experts, nrows, hidden)
+    x = torch.randn((tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(0, num_experts, (tokens, top_k), dtype=torch.int32, device="cuda")
+
+    out = ggml_moe_a8_vec(x, weight, topk_ids, top_k, int(GGML_Q4_0), nrows, tokens)
+    torch.cuda.synchronize()
+
+    half = tokens // 2
+    assert half * top_k <= MAX_GRID_YZ
+    ref = torch.cat([
+        ggml_moe_a8_vec(
+            x[s:e].contiguous(), weight, topk_ids[s:e].contiguous(),
+            top_k, int(GGML_Q4_0), nrows, e - s,
+        )
+        for s, e in ((0, half), (half, tokens))
+    ])
+    torch.cuda.synchronize()
+
+    assert out.shape == (tokens * top_k, nrows)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, ref, rtol=0, atol=0)


### PR DESCRIPTION
Fixes #186.

## Problem

`moe_vec_*_q8_1_cuda` launches the flat `(token, top-k)` index as **grid.z**:

```c
const dim3 block_nums(block_num_y, 1, tokens * top_k);   // moe_vec.cuh, x19 launchers
```

`maxGridDimZ` is 65535 on every CUDA compute capability, so a batch with
`tokens * top_k > 65535` fails the launch with `cudaErrorInvalidValue`.

With `top_k = 8` that caps a prefill batch at **8191 tokens** — and `--max-extend-tokens`
defaults to exactly **8192**. So a GGUF MoE model reliably dies on the first prompt long
enough to fill one chunk. It is not limited to one long prompt either: the scheduler's token
budget is per *batch*, so a few concurrent medium prompts packed together trip it identically
(observed here as `Prefill batch, #new-seq: 3, #new-token: 7299` — three streams, one batch).

This cost me a long time to find, because **none of the 19 launch sites check the launch
return code**. A rejected launch only sets the error flag, so it was reported by whatever
unrelated CUDA call ran next. I saw the same single fault blamed on three different places:

- `flashinfer.activation.gelu_tanh_and_mul` (the very next CUDA call, via `act_fn` in `fused_q4_0.py`)
- the following `ggml_moe_a8_vec` (once flashinfer was gated off)
- a bare `torch.zeros` in an unrelated allocation

`CUDA_LAUNCH_BLOCKING=1` does not help here — the failure is in the launch *configuration*,
not in execution.

## Fix

Move the flat index to `grid.x` (limit 2³¹−1) and rows to `grid.y`, whose extent is
`ceil(nrows / GGML_CUDA_MMV_Y)` and stays far below the cap. `quantize_row_q8_1_cuda` next
door already tiles its y axis at 65535 for the same reason, so the limit is known in this file's
neighbourhood — `moe_vec.cuh` just missed it.

Also adds `FT_MOE_VEC_LAUNCH_CHECK()` after each of the 19 launches, so a rejected
configuration reports itself with the geometry that caused it instead of latching.

In short, three things: the flat `(token, top-k)` index moves to `grid.x`; every launch site
gains a return-code check; and a regression test is added that fails on `main` and passes here.

## Test

`tests/kernels/test_gguf_moe_vec.py` runs a batch one token over the old cap
(`8192 * 8 = 65536`) and compares against the same batch split in half, each half under the
old limit — so it checks the result is *correct*, not merely that nothing raised.

```
# on main (2757bb5)
FAILED tests/kernels/test_gguf_moe_vec.py::test_moe_vec_above_grid_z_limit_matches_split_batches
E   torch.AcceleratorError: CUDA error: invalid argument
1 failed in 92.68s

# on this branch
1 passed in 89.20s
```

Both runs used a **fresh JIT build cache**. Worth flagging for reviewers: ninja compares
mtimes, so swapping `moe_vec.cuh` in place over a warm `~/.cache/torch_extensions` silently
reuses the old `.so` and the test passes when it should fail.

## Tested on

- **GPU**: Tesla T4 (sm_75, 16 GiB), driver 580.178.04, CUDA 13.0.88, torch 2.11.0+cu130
- **OS/toolchain**: Ubuntu 24.04 container, g++ 13.3, `-std=c++17` (built clean)
- **Checkpoint**: `ggml-org/gemma-4-26B-A4B-it-GGUF` → `gemma-4-26B-A4B-it-Q4_0.gguf`
  (128 experts/layer, `top_k=8`, 30 layers), served via `--moe-backend offload`
- **Command**:
  ```
  ft serve --model=<ckpt> --host=0.0.0.0 --port=1919 --attention-backend=triton \
           --memory-ratio=0.55 --max-running-requests=3 --max-seq-len-override=16384 \
           --num-tokens=49152 --moe-prefill-hit-d2d
  ```
- **End to end**: a 13,962-token prompt that killed the engine on every prior build now
  completes, and a 3-needle recall test passes 3/3 at 14,329 tokens. Server logs show
  `Prefill batch, #new-token: 8192` succeeding — the exact geometry that used to fail.

## Performance

Not the goal, but it measures faster rather than slower. Isolated kernel benchmark, median of
10 after 3 warmups, two independent runs per arm, each arm built from a clean cache
(`nrows=1408`, `hidden=2816`, `top_k=8`):

| tokens | main | this branch | delta |
|---|---|---|---|
| 2048 | 187.1 / 193.5 ms | 174.0 / 176.5 ms | ≈ −8% |
| 4096 | 380.0 / 394.3 ms | 346.1 / 355.1 ms | ≈ −9% |
| 8191 | 768.6 / 808.3 ms | 705.8 / 711.6 ms | ≈ −10% |

The mechanism is not root-caused, and this PR claims none. Swapping the axes changes which
blocks are co-scheduled, but the per-token expert varies, so the obvious weight-reuse story does
not straightforwardly hold. The numbers are recorded here as a measurement, not as a
justification for the change — the fix stands on the correctness bug alone.

## Notes

- Filed as #186, which carries the model-free repro script and full environment details.
- Only `q4_0` is exercised on my hardware, but all 19 launchers in the file shared the
  identical grid expression and are changed identically.
- Sibling kernels were checked for the same mistake: `moe.cuh` puts `tokens/mmq_x` in grid.y
  and `mmvq.cuh` puts `nvecs` in grid.y, both of which can overflow in principle but neither
  is reachable on my config. Left alone to keep this to one change.

