### PR TITLE
fix(engine): reserve explicit KV pages during MoE auto-sizing

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -490,7 +490,11 @@ class Engine:
             num_experts=num_experts,
             total_experts=total_experts,
             prefill_overlap=config.moe_prefill_overlap,
-            kv_reserve_tokens=max(config.kv_reserve_tokens, min_reserve),
+            kv_reserve_tokens=max(
+                config.kv_reserve_tokens,
+                min_reserve,
+                (config.num_page_override or 0) * page_tokens,
+            ),
             page_size=page_tokens,
             quant_format=banks.quant_format,
         )

--- a/tests/engine/test_cache_budget.py
+++ b/tests/engine/test_cache_budget.py
@@ -265,7 +265,7 @@ def test_mha_kv_cost_simple_full_attention():
     assert fixed == 0
 
 
-def test_engine_resolve_auto_moe_cache_size_maps_kwargs():
+def test_engine_resolve_auto_moe_cache_size_maps_kwargs(monkeypatch):
     import torch
 
     from freetoken.engine.engine import Engine
@@ -292,6 +292,7 @@ def test_engine_resolve_auto_moe_cache_size_maps_kwargs():
         memory_ratio = 0.9
         moe_prefill_overlap = True
         kv_reserve_tokens = 0
+        num_page_override = 64
         swa_full_tokens_ratio = 0.2
         swa_num_pages_override = None
         model_config = StubModelConfig()
@@ -314,21 +315,23 @@ def test_engine_resolve_auto_moe_cache_size_maps_kwargs():
     engine._weights_bytes = 1_000_000
     engine._pool_cls = MHAKVCache  # __init__ skipped -> install the generic pool family
 
-    size, pages, overlap = engine._resolve_auto_moe_cache_size(StubConfig(), StubBanks())
+    captured = {}
 
-    # cross-check against the same pure functions, proving the kwarg mapping is faithful
-    from freetoken.engine.cache_budget import expert_bytes_per_slot, resolve_moe_cache_auto
-    from freetoken.kvcache.mha_pool import MHAKVCache
+    def fake_resolve(**kwargs):
+        captured.update(kwargs)
+        return 8, 64, True
 
-    cache_per_page, fixed, _, _ = MHAKVCache.kv_cost(StubConfig())
-    expected = resolve_moe_cache_auto(
-        baseline_free=10_000_000, weights_bytes=1_000_000, memory_ratio=0.9,
-        cache_per_page=cache_per_page, fixed_cache_size=fixed,
-        per_expert_bytes=expert_bytes_per_slot(StubBanks.sources),
-        num_experts=4, total_experts=8, prefill_overlap=True,
-        kv_reserve_tokens=0, page_size=16, quant_format="bf16",
+    monkeypatch.setattr(
+        "freetoken.engine.cache_budget.resolve_moe_cache_auto", fake_resolve
     )
-    assert (size, pages, overlap) == expected
+    got = engine._resolve_auto_moe_cache_size(StubConfig(), StubBanks())
+
+    assert got == (8, 64, True)
+    assert captured["kv_reserve_tokens"] == 64 * 16
+    assert captured["page_size"] == 16
+    assert captured["num_experts"] == 4
+    assert captured["total_experts"] == 8
+    assert captured["per_expert_bytes"] == 512 + 256
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- include an explicit `--num-pages` KV allocation in the reserve passed to the joint MoE/KV auto-sizing solver
- also covers `--num-tokens`, which resolves to `num_page_override` after page size is finalized
- preserve the existing `kv_reserve_tokens` and model-specific minimum-reserve floors by taking the maximum of all three

## Problem

`Engine._resolve_auto_moe_cache_size()` runs before the KV pool is allocated. It previously passed only:

```python
max(config.kv_reserve_tokens, min_reserve)
```

When a user explicitly requested more KV pages/tokens, that allocation did not participate in the MoE cache budget. The solver could therefore assign those bytes to expert slots and leave startup to fail later during KV allocation.

This is the explicit-context half of the tradeoff described in #111. It does not change the default 8,192-token reserve or admission behavior for over-capacity requests.

## Test plan

Regression test on current `main`:

- configure 64 pages with a resolved page size of 16
- intercept the arguments passed to `resolve_moe_cache_auto`
- verify `kv_reserve_tokens == 64 * 16`

The test failed before the fix with `0 != 1024` and passes after it.

Executed:

```text
PYTHONPATH=$PWD/python pytest -q tests/engine/test_cache_budget.py
24 passed in 1.50s
```

`git diff --check` and Python compile checks also pass.

## Risk and exclusions

- No behavior changes when neither `--num-pages` nor `--num-tokens` is set.
- An explicit context request can now make the budget solver reject startup earlier instead of allowing a later CUDA OOM; that is intentional.
- This PR does not change the default MoE/KV split, scheduler admission, GGUF cache layout, or parser behavior.

Addresses part of #111.
