### PR TITLE
feat(sm70): support Volta / Tesla V100 via torch 2.10 cu128 downgrade

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -47,6 +47,31 @@ Notes for the sm_70 build:
   headroom:
   `ft serve --model <dir> --memory-ratio 0.75` (default 0.9 OOMs).
 
+## Serving on 16 GiB Volta with large system prompts
+
+A 35B-class MoE on a V100-16GB with expert offload needs careful memory tuning
+once the client sends a large system prompt (e.g. agent harnesses that inject
+~8K tokens of runtime context into every request). Measured on
+Qwen3.6-35B-A3B-FP8 + r570:
+
+- `--memory-ratio 0.9` (default): OOMs on the 8K-token prefill (~2.3 GiB
+  headroom is not enough for the prefill activations).
+- `--memory-ratio 0.6`: fits the prefill but the smaller expert cache collapses
+  decode to ~0.1-0.4 tok/s (expert fetch thrash over PCIe).
+- **`--memory-ratio 0.75 --moe-cache-rate 0.2 --num-tokens 16384`**: ~4.1 GiB
+  free after init; the 8099-token system prompt prefills at ~800 tok/s without
+  OOM and decode stays at ~20 tok/s for normal prompts. This is the setting to
+  run under a client that always streams with a big system prompt.
+- `--moe-cache-rate` is a fraction of all experts (0.4 of the 30 GiB banks
+  alone OOMs at startup on 16 GiB); 0.2 is the practical ceiling here.
+- Streaming is OpenAI-compatible (progressive `data:` chunks and a terminal
+  `data: [DONE]`), verified against the OpenAI SDK client; the earlier "stream
+  hangs with one empty chunk" symptom was queue starvation, not the wire format.
+- OpenAI-compatible gateway clients (e.g. a DSH `llm-pi-ai` provider route)
+  must supply `api: openai-completions`, `baseURL: <host>:<port>/v1`, and an
+  `apiKeyEnv` credential — pi-ai's adapter requires a key string even when the
+  gateway ignores it.
+
 ## Method 1: Install from PyPI
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,9 +29,18 @@ uv pip install -e . --python .venv-sm70/bin/python
 
 Notes for the sm_70 build:
 
-- Install the **base** package (no `[accel]`): flashinfer/sglang fused kernels
-  target sm_80+ and are not usable on Volta; the runtime falls back to the
-  pure-Triton kernels automatically.
+- Install the **base** package (**no `[accel]`**): flashinfer/sglang fused kernels
+  target sm_80+/sm_100+ and ship CUDA 13 builds only, so they are not usable on
+  Volta — if they are present the engine fails to load with `common_ops` /
+  `libnvrtc.so.13` / `no kernel image` errors. The runtime falls back to the
+  pure-Triton kernels automatically, which is what Volta uses.
+- If you upgraded an existing cu130 venv in place (e.g. a FreeToken Desktop
+  engine venv), also uninstall the accel native kernels and any leftover cu13
+  libs so the cu12 runtime is the one loaded:
+  `uv pip uninstall --python <venv>/bin/python sglang-kernel flashinfer-python`
+  and remove the lingering `nvidia/cu13` package dir under the venv site-packages.
+  The FreeToken Desktop engine venv (typically `~/.freetoken/venv` or
+  `~/.freetoken-cli/.venv`) needs the same treatment.
 - `freetoken_kernel_cache` (cu130) is skipped; JIT kernels compile on first use
   with the local nvcc.
 - On 16 GiB cards (V100-16GB), lower the serve memory ratio so requests have

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,38 @@
 - Python >= 3.10, with [uv](https://docs.astral.sh/uv/) recommended (plain
   `pip` + `venv` works too)
 
+## sm_70 (Volta / Tesla V100) build
+
+Torch 2.11 — the only torch line upstream FreeToken supports — dropped sm_70
+kernels in every CUDA build, so the engine cannot run on Volta GPUs with the
+stock dependency pins. This branch relaxes the torch floor to 2.10.x and
+repoints the CUDA index to the cu128 build, which is the last torch line that
+ships sm_70 cubins and runs on driver r570 (CUDA 12.8) — no driver upgrade and
+no reboot required.
+
+Build it on the target machine (needs a CUDA 12.x toolkit with `nvcc` on PATH
+for the C++ extensions and the JIT kernels; CUDA 12.9 was used here):
+
+```bash
+git clone https://github.com/redoop/FreeToken.git
+cd FreeToken
+git checkout feat/support-sm_70
+export PATH=/usr/local/cuda-12.9/bin:$PATH CUDA_HOME=/usr/local/cuda-12.9
+uv venv --python 3.12 .venv-sm70
+uv pip install -e . --python .venv-sm70/bin/python
+```
+
+Notes for the sm_70 build:
+
+- Install the **base** package (no `[accel]`): flashinfer/sglang fused kernels
+  target sm_80+ and are not usable on Volta; the runtime falls back to the
+  pure-Triton kernels automatically.
+- `freetoken_kernel_cache` (cu130) is skipped; JIT kernels compile on first use
+  with the local nvcc.
+- On 16 GiB cards (V100-16GB), lower the serve memory ratio so requests have
+  headroom:
+  `ft serve --model <dir> --memory-ratio 0.75` (default 0.9 OOMs).
+
 ## Method 1: Install from PyPI
 
 ```bash

--- a/freetoken-kernel-cache/build_backend.py
+++ b/freetoken-kernel-cache/build_backend.py
@@ -102,6 +102,7 @@ def _build_jit_cache() -> None:
     }
     # Multi-arch fatbin: one SASS cubin per listed arch, plus the PTX of the highest one.
     # A GPU whose arch is not listed and is below the highest one has no usable image.
+    #   7.0  -> V100, GV100                             (Volta; sm_70 — added for the sm70/cu128 build)
     #   8.0  -> A100, A800, A30                      (Ampere, datacenter)
     #   8.6  -> RTX 30 series, A10, A40              (Ampere, consumer / workstation)
     #   8.9  -> RTX 40 series, L4, L40, RTX 6000 Ada (Ada Lovelace)
@@ -110,9 +111,11 @@ def _build_jit_cache() -> None:
     #   12.0 -> RTX 50 series, RTX PRO 6000 Blackwell (Blackwell, consumer / workstation)
     # Override with FREETOKEN_KERNEL_CACHE_ARCHES (space-separated maj.min) or
     # TVM_FFI_CUDA_ARCH_LIST directly. Needs an nvcc that supports every listed arch.
+    # NOTE (sm70 build): 7.0 (Volta / Tesla V100) is added to the defaults so a cu128
+    # kernel-cache wheel carries sm_70 SASS instead of forcing JIT on first use.
     if "TVM_FFI_CUDA_ARCH_LIST" not in os.environ:
         os.environ["TVM_FFI_CUDA_ARCH_LIST"] = os.getenv(
-            "FREETOKEN_KERNEL_CACHE_ARCHES", "8.0 8.6 8.9 9.0 10.0 12.0"
+            "FREETOKEN_KERNEL_CACHE_ARCHES", "7.0 8.0 8.6 8.9 9.0 10.0 12.0"
         )
     compile_and_package_kernels(
         out_dir=out_dir,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@
 # own, and a mismatch links the C++ extensions against the wrong libtorch.
 # setuptools floor: 77 is the first release that understands the PEP 639 `license`
 # SPDX string and `license-files` below.
-requires = ["setuptools>=77", "torch>=2.11,<2.12", "wheel"]
+# NOTE (sm_70/V100 build): torch floor lowered from 2.11 to 2.10 — torch 2.11 (all CUDA
+# builds) dropped sm_70 (Volta) kernels; 2.10.x cu128 still ships them.
+requires = ["setuptools>=77", "torch>=2.10,<2.11", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -51,10 +53,11 @@ dependencies = [
     "pydantic>=2.9,<3",
     "pyzmq>=27,<28",
     "safetensors>=0.6,<1",
-    # floor+ceiling: sglang-kernel 0.4.5 links libtorch symbols only 2.11 has.
-    # PyPI's torch 2.11.0 wheel is itself the cu130 build, so plain pip resolves
-    # correctly from PyPI alone; uv additionally pins the index below.
-    "torch>=2.11,<2.12",
+    # NOTE (sm_70/V100 build): floor lowered from 2.11 to 2.10 — torch 2.10.x cu128
+    # (https://download.pytorch.org/whl/cu128) is the last 2.x line with sm_70 kernels and
+    # runs on driver r570 (CUDA 12.8). PyPI's plain torch 2.10.0 wheel is a cu130 build, so
+    # uv's explicit pytorch-cu128 index below must be used for the +cu128 variant.
+    "torch>=2.10,<2.11",
     "tqdm>=4.66,<5",
     "transformers>=5.5,<6",
     "triton==3.6.0; platform_system == 'Linux'",
@@ -74,10 +77,16 @@ dev = ["pytest>=6.0"]
 # Native fused-kernel packages. Without them the runtime falls back to the pure-Triton
 # kernels in freetoken.kernel.triton (and the 'triton' attention backend). Install
 # `freetoken[accel]` for the full native fast path.
-fi = ["flashinfer-python[cu13]>=0.6,<0.7"]
+# NOTE (cu12/V100 build): switched flashinfer from [cu13] to [cu12] so the stack runs on
+# CUDA 12.x drivers (r570, CUDA 12.8) and Volta sm_70 (Tesla V100). flashinfer's fused
+# kernels target sm_80+; on V100 the runtime falls back to pure-Triton kernels, so the
+# flashinfer wheel is optional here and may be omitted entirely.
+fi = ["flashinfer-python[cu12]>=0.6,<0.7"]
 # renamed from sgl-kernel at 0.4; still imports as `sgl_kernel`, so never co-install both
 sgl = ["sglang-kernel==0.4.5"]
-accel = ["freetoken[fi,sgl]"]
+# NOTE (cu12/V100 build): sglang-kernel 0.4.5 has no cu128 wheel (only cu130-era builds),
+# and its fused kernels target sm_80+ anyway; dropped from accel for the cu12 build.
+accel = ["freetoken[fi]"]
 # NOTE: the Marlin W4A16 NVFP4 expert-GEMM path (sm_80-99) borrows vLLM's AOT wheel
 # (vllm>=0.14,<0.15), which pins transformers>=4.56,<5 and so is INCOMPATIBLE with the
 # core transformers>=5.5 requirement. It is therefore not a lockable extra and is left
@@ -89,18 +98,15 @@ accel = ["freetoken[fi,sgl]"]
 # indexes serve. `explicit = true` scopes each index to the one package that needs it
 # (the torch index also mirrors stale copies of common deps, e.g. packaging<=24.1,
 # which would otherwise shadow PyPI under uv's first-index strategy).
+# NOTE (cu12/V100 build): torch index repointed from cu130 to cu128 — torch
+# 2.11.0+cu128 is the last build that ships sm_70 (Volta/V100) kernels and runs on
+# driver r570 (CUDA 12.8). sglang-kernel index removed (no cu128 wheel for 0.4.5).
 [tool.uv.sources]
-torch = { index = "pytorch-cu130" }
-sglang-kernel = { index = "sglang-cu130" }
+torch = { index = "pytorch-cu128" }
 
 [[tool.uv.index]]
-name = "pytorch-cu130"
-url = "https://download.pytorch.org/whl/cu130"
-explicit = true
-
-[[tool.uv.index]]
-name = "sglang-cu130"
-url = "https://docs.sglang.io/whl/cu130"
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [tool.setuptools]


### PR DESCRIPTION
> ### Motivation
> Torch 2.11 — the only torch line the stock dependency pins allow — dropped
> sm_70 (Volta) kernels in every CUDA build, so FreeToken cannot run at all on
> Tesla V100 / other Volta GPUs: `no kernel image is available for execution on
> the device` on every CUDA op, before even reaching the runtime kernels.
> This branch unblocks Volta with a **dependency-level** change only — no engine
> code changes required, since the runtime's capability gates and pure-Triton
> fallback already cover sm_70.
>
> ### Changes
> - **`[build-system]` and `dependencies`**: torch floor lowered from
>   `>=2.11,<2.12` to `>=2.10,<2.11`. `torch 2.10.0+cu128` is the last 2.x line
>   that ships sm_70 cubins and runs on driver r570 (CUDA 12.8) — **no driver
>   upgrade or reboot needed** on existing Volta nodes.
> - **`[tool.uv.index]`**: `pytorch-cu130` → `pytorch-cu128`
>   (https://download.pytorch.org/whl/cu128) so uv resolves the `+cu128` build.
> - **Extras**: `flashinfer-python[cu13]` → `[cu12]`; `sglang-kernel` dropped
>   from `accel` (no cu128 wheel for 0.4.5). On Volta both are unusable anyway
>   (sm_80+/sm_100+ only) and the runtime falls back to pure-Triton kernels.
> - **Docs**: sm_70 install path, Desktop-engine caveats (uninstall
>   sglang/flashinfer + leftover `nvidia/cu13` libs on in-place cu130→cu128
>   upgrades), and 16 GiB V100 serving tuning for large system prompts.
>
> ### Verification (Tesla V100-SXM2-16GB, driver 570.211.01, CUDA 12.9 toolkit)
> - `uv pip install -e .` source build with nvcc 12.9 — OK
> - `torch.cuda.get_arch_list()` includes `sm_70`; matmul on V100 — OK
> - `ft checkpoint`: Qwen3.6-35B-A3B-FP8 (35 GB) → FTW conversion — OK
> - `ft serve`: OpenAI-compatible `/v1/*` chat with reasoning + streaming
>   (progressive chunks + `[DONE]`) — OK; ~20 tok/s decode
> - Wired into an OpenAI-compatible agent harness (DSH `llm-pi-ai`) with the
>   tuned serve flags in the docs.
>
> ### Usage
> ```bash
> git clone -b feat/support-sm_70 https://github.com/redoop/FreeToken.git
> export PATH=/usr/local/cuda-12.9/bin:$PATH CUDA_HOME=/usr/local/cuda-12.9
> uv venv --python 3.12 .venv-sm70
> uv pip install -e .   # base package — no [accel] on Volta
> ```