### PR TITLE
Add loopback runtime process identity endpoint

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,7 @@ parsers all resolve automatically from the checkpoint and the GPU.
 |---|---|---|
 | `--host` | 127.0.0.1 | Bind address |
 | `--port` | 1919 | Bind port |
+| `--launch-nonce` | unset | Optional non-secret local-supervisor correlation token, echoed only by loopback `/v1/runtime/identity` |
 | `--gpu` | GPU 0 | GPU to run on: a UUID from `nvidia-smi -L` or an `nvidia-smi` index; see [below](#choosing-a-gpu) |
 | `--max-running-requests` | 4 | Max concurrently running requests |
 | `--max-output-tokens` | 32768 | Default output budget for requests that omit one |
@@ -172,4 +173,3 @@ profile that `ft serve --moe-backend auto` and `--moe-hybrid-max-fetch -1` then 
 - What to measure: `--dtype`, `--model`, `--formats`, `--isa`.
 - `--threshold` (default 2.0) sets the call: recommend hybrid when CPU bandwidth beats PCIe
   by that factor.
-

--- a/python/freetoken/server/accounting.py
+++ b/python/freetoken/server/accounting.py
@@ -69,9 +69,15 @@ async def prepare_stop_accounting(
         if maintenance not in {"loading", "serving", "stopping", "failed"}:
             raise AccountingDrainError(f"engine cannot prepare stop from state {maintenance!r}")
 
-        # This assignment and FrontendManager.new_user's check run on the same event loop, making
-        # the generation gate atomic with respect to every protocol adapter.
-        state.maintenance_state = "stopping"
+        # This transition and FrontendManager.new_user's check run on the same event loop, making
+        # the generation gate atomic with respect to every protocol adapter. Production state
+        # also serializes it with the backend supervisor so a concurrent failure stays terminal;
+        # the direct assignment preserves compatibility with focused/external state adapters.
+        mark_stopping = getattr(state, "mark_stopping", None)
+        if callable(mark_stopping):
+            mark_stopping()
+        else:
+            state.maintenance_state = "stopping"
 
         stats = state.stats
         drained = await _wait_for_idle(stats, drain_timeout_s)

--- a/python/freetoken/server/api_server.py
+++ b/python/freetoken/server/api_server.py
@@ -38,7 +38,7 @@ from pydantic import BaseModel
 from .args import ServerArgs
 from .anthropic_api import register_anthropic_routes
 from .accounting import AdmissionClosedError, register_accounting_routes
-from .control_api import register_control_routes
+from .control_api import build_runtime_identity_snapshot, register_control_routes
 from .openai_api import register_openai_routes
 from . import request_ring
 from .access_log_filter import install_polling_access_log_filter
@@ -57,6 +57,42 @@ _MODEL_SAMPLING: Dict[str, Any] = {}
 # shutdown is treated as expected — no ERROR log, no "failed" latch. See run_backend_supervisor.
 _SHUTTING_DOWN = threading.Event()
 BACKEND_DEATH_EXIT_GRACE_S = 10.0
+_TRUSTED_PROXY_HOSTS = ("127.0.0.1", "::1", "::ffff:127.0.0.1")
+
+
+def _maintenance_lock_for(state: Any) -> Any:
+    lock = getattr(state, "_maintenance_lock", None)
+    if lock is None:
+        # Production FrontendManager always has this field. The lazy fallback keeps the focused
+        # fake-state tests and compatible external state adapters on the same transition API.
+        lock = threading.Lock()
+        state._maintenance_lock = lock
+    return lock
+
+
+def _transition_maintenance(state: Any, expected: set[str], target: str) -> bool:
+    """Atomic cross-thread lifecycle transition; terminal states cannot be overwritten."""
+    with _maintenance_lock_for(state):
+        if state.maintenance_state not in expected:
+            return False
+        state.maintenance_state = target
+        return True
+
+
+def _refresh_shell_runtime_identity(state: Any) -> None:
+    """Refresh worker process groups after shell workers complete their early detach.
+
+    Shell-mode children call ``setpgrp()`` asynchronously immediately after spawn. The loading
+    snapshot can therefore observe their inherited foreground group; the ready callback is the
+    first point where every acknowledged worker is guaranteed to have completed that detach.
+    The ready path calls this while holding the lifecycle lock, making snapshot publication and
+    the loading-to-serving transition atomic to endpoint readers.
+    """
+    config = getattr(state, "config", None)
+    if getattr(config, "shell_mode", False):
+        state.runtime_identity = build_runtime_identity_snapshot(
+            state, list(getattr(state, "backend_processes", None) or [])
+        )
 
 
 def get_global_state() -> FrontendManager:
@@ -140,6 +176,10 @@ class FrontendManager:
     # Stable identity for this serve process. Generated before the backend is ready so every
     # /health state (loading/ok/error) and /v1/stats can identify the same engine generation.
     instance_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # Process/correlation facts bound immediately after backend spawn. Shell mode rebinds once,
+    # atomically at ready, after workers detach their process groups; the snapshot is immutable
+    # thereafter. Lifecycle is overlaid when /v1/runtime/identity is read.
+    runtime_identity: Dict[str, Any] | None = None
     # Runtime cache-rebuild control plane (correlated by uuid request_id, separate from
     # the int-uid generation ack machinery).
     rebuild_futures: Dict[str, asyncio.Future] = field(default_factory=dict)
@@ -147,6 +187,7 @@ class FrontendManager:
     # API adapters 503 until this flips) -> "serving" once all workers ack ready ->
     # "rebuilding"/"failed" for runtime cache rebuilds.
     maintenance_state: str = "loading"
+    _maintenance_lock: Any = field(default_factory=threading.Lock, repr=False)
     last_rebuild: Dict[str, Any] | None = None
     load_progress: Any = None
     # Monotonic timestamp the server became ready; drives /health + /v1/stats uptime without
@@ -282,11 +323,14 @@ class FrontendManager:
         fut = self.rebuild_futures.pop(msg.request_id, None)
         if fut is not None and not fut.done():
             fut.set_result(self.last_rebuild)
-        if self.fatal_error is not None:
-            # A dead backend stays failed regardless of any (possibly stale/buffered) reply.
-            self.maintenance_state = "failed"
-            return
-        self.maintenance_state = "failed" if msg.status == "failed" else "serving"
+        with _maintenance_lock_for(self):
+            if self.fatal_error is not None:
+                # A dead backend stays failed regardless of a stale/buffered reply.
+                self.maintenance_state = "failed"
+            elif self.maintenance_state == "rebuilding":
+                # A stop/failure transition outranks a late rebuild reply. The result is still
+                # recorded and its waiter is still woken above, but admission stays sealed.
+                self.maintenance_state = "failed" if msg.status == "failed" else "serving"
 
     def fail_pending_rebuilds(self, message: str) -> None:
         """Resolve every in-flight rebuild waiter as failed. Called from the supervisor thread
@@ -377,7 +421,32 @@ class FrontendManager:
         logger.warning("Aborting request for user %s", uid)
         await self.send_one(AbortMsg(uid=uid))
 
+    def mark_stopping(self) -> None:
+        # Failure is terminal and more informative than an orderly-stop label. Every other
+        # state seals as stopping; _on_ready only reopens an exact "loading" state.
+        _transition_maintenance(
+            self,
+            {"loading", "serving", "rebuilding", "stopping"},
+            "stopping",
+        )
+
+    def mark_ready(self) -> bool:
+        """Open admission exactly once, and never after a stop/failure transition."""
+        with _maintenance_lock_for(self):
+            if self.maintenance_state != "loading":
+                return False
+            _refresh_shell_runtime_identity(self)
+            self.maintenance_state = "serving"
+            self.ready_at = time.monotonic()
+            return True
+
+    def mark_failed(self, message: str) -> None:
+        with _maintenance_lock_for(self):
+            self.fatal_error = message
+            self.maintenance_state = "failed"
+
     def shutdown(self):
+        self.mark_stopping()
         self.send_tokenizer.stop()
         self.recv_tokenizer.stop()
         # Tear the workers down ourselves (best-effort). _SHUTTING_DOWN is already set by the
@@ -515,7 +584,12 @@ async def dispatch_rebuild(
     request_id = str(uuid.uuid4())
     fut = asyncio.get_running_loop().create_future()
     state.rebuild_futures[request_id] = fut
-    state.maintenance_state = "rebuilding"
+    if not _transition_maintenance(state, {"serving"}, "rebuilding"):
+        state.rebuild_futures.pop(request_id, None)
+        return {
+            "status": "rejected",
+            "error": f"engine is {state.maintenance_state}; rebuild not started",
+        }
     try:
         await state.send_one(
             CacheRebuildMsg(
@@ -532,7 +606,7 @@ async def dispatch_rebuild(
         # untouched. Roll the gate back to serving (else a transient ZMQ error would latch
         # maintenance forever with no reply ever arriving to clear it) and surface the error.
         state.rebuild_futures.pop(request_id, None)
-        state.maintenance_state = "serving"
+        _transition_maintenance(state, {"rebuilding"}, "serving")
         return {"status": "failed", "error": f"failed to dispatch rebuild: {e!r}"}
     try:
         return await asyncio.wait_for(fut, timeout=timeout)
@@ -861,6 +935,7 @@ def _install_shell_stop_handlers() -> None:
 
     def _flag_shutdown(signum, frame) -> None:
         _SHUTTING_DOWN.set()
+        _GLOBAL_STATE.mark_stopping()
         _terminate_backend_workers(_GLOBAL_STATE.backend_processes)
         prev = previous.get(signum)
         if callable(prev):
@@ -871,6 +946,32 @@ def _install_shell_stop_handlers() -> None:
 
     for sig in previous:
         signal.signal(sig, _flag_shutdown)
+
+
+def _uvicorn_config(host: str, port: int, *, access_log: bool = True) -> uvicorn.Config:
+    # Loopback control endpoints authorize from Request.client. Pin proxy trust to loopback peers
+    # so FORWARDED_ALLOW_IPS=* cannot make a remote direct client spoof that address, while a
+    # local reverse proxy can still preserve the real remote client for the authorization check.
+    return uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        access_log=access_log,
+        proxy_headers=True,
+        forwarded_allow_ips=list(_TRUSTED_PROXY_HOSTS),
+    )
+
+
+def _run_uvicorn(host: str, port: int) -> None:
+    # Keep uvicorn.run's KeyboardInterrupt wrapper for normal `ft serve` Ctrl-C behavior while
+    # applying the same explicit loopback-only proxy trust as shell mode's Config.
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        proxy_headers=True,
+        forwarded_allow_ips=list(_TRUSTED_PROXY_HOSTS),
+    )
 
 
 def _serve_and_run_shell(host: str, port: int) -> None:
@@ -897,7 +998,7 @@ def _serve_and_run_shell(host: str, port: int) -> None:
     netloc = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
     origin = resolve_server_url(f"http://{netloc}").origin
 
-    server = uvicorn.Server(uvicorn.Config(app, host=host, port=port, access_log=False))
+    server = uvicorn.Server(_uvicorn_config(host, port, access_log=False))
     thread = threading.Thread(target=server.run, name="freetoken-uvicorn", daemon=True)
     thread.start()
     _install_shell_stop_handlers()
@@ -913,6 +1014,7 @@ def _serve_and_run_shell(host: str, port: int) -> None:
         # Belt and braces: if uvicorn's lifespan shutdown did not run (thread wedged), flag the
         # stop and tear the workers down here so nothing outlives the shell.
         _SHUTTING_DOWN.set()
+        _GLOBAL_STATE.mark_stopping()
         _terminate_backend_workers(_GLOBAL_STATE.backend_processes)
         _reap_backend_workers(_GLOBAL_STATE.backend_processes)
 
@@ -979,19 +1081,19 @@ def run_api_server(config: ServerArgs, start_backend: Callable[[], "Any"], run_s
     # Hold the worker handles so the orderly-shutdown path can tear them down itself (after
     # setting _SHUTTING_DOWN) rather than relying on OS signal-delivery order.
     _GLOBAL_STATE.backend_processes = list(getattr(handle, "processes", None) or [])
+    _GLOBAL_STATE.runtime_identity = build_runtime_identity_snapshot(
+        _GLOBAL_STATE, _GLOBAL_STATE.backend_processes
+    )
 
     def _on_ready() -> None:
         # A stop requested while weights were loading has already sealed admission.  The backend
         # may finish its ready handshake before SIGTERM arrives; never reopen that gate after the
         # daemon has received a final accounting snapshot.
-        if _GLOBAL_STATE.maintenance_state == "loading":
-            _GLOBAL_STATE.maintenance_state = "serving"
-            _GLOBAL_STATE.ready_at = time.monotonic()
+        if _GLOBAL_STATE.mark_ready():
             logger.info(f"API server is ready to serve on {host}:{port}")
 
     def _on_failure(message: str) -> None:
-        _GLOBAL_STATE.fatal_error = message
-        _GLOBAL_STATE.maintenance_state = "failed"
+        _GLOBAL_STATE.mark_failed(message)
         logger.error("Backend supervisor: %s", message)
         # No CacheRebuildReply will ever arrive from a dead backend, so wake any caller blocked
         # in dispatch_rebuild's await now — otherwise it strands until the full rebuild timeout.
@@ -1037,4 +1139,4 @@ def run_api_server(config: ServerArgs, start_backend: Callable[[], "Any"], run_s
         _serve_and_run_shell(host, port)
         return
     # uvicorn stays on the main thread (signal handling unchanged); ^C reaches the worker group.
-    uvicorn.run(app, host=host, port=port)
+    _run_uvicorn(host, port)

--- a/python/freetoken/server/args.py
+++ b/python/freetoken/server/args.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 from dataclasses import dataclass
 from typing import List, Tuple
 
@@ -22,6 +23,9 @@ class ServerArgs(SchedulerConfig):
     # a turn cannot also kill the engine — see server/launch.py:_detach_process_group.
     shell_mode: bool = False
     served_model_name: str | None = None
+    # Optional, non-secret correlation token supplied by a process supervisor. The runtime
+    # identity endpoint echoes only this validated token, never argv or environment contents.
+    launch_nonce: str | None = None
     tool_call_parser: str = "llama3"
     # Reasoning parser that splits <think> reasoning from content for OpenAI
     # responses. None disables it (default for models without a reasoning protocol).
@@ -112,6 +116,17 @@ def parse_args(
         if n < 1:
             raise argparse.ArgumentTypeError("must be >= 1")
         return n
+
+    def _launch_nonce(value: str) -> str:
+        # Deliberately narrower than arbitrary CLI text: this value is returned by a read-only
+        # control endpoint and may be compared byte-for-byte by a local process supervisor.
+        if not 16 <= len(value) <= 128:
+            raise argparse.ArgumentTypeError("must contain 16 to 128 characters")
+        if re.fullmatch(r"[A-Za-z0-9_-]+", value) is None:
+            raise argparse.ArgumentTypeError(
+                "must use only ASCII letters, digits, '_' or '-'"
+            )
+        return value
 
     def _lazy_gpu_arg(value: str) -> tuple[str, ...]:
         from freetoken.gpu_select import gpu_arg
@@ -306,6 +321,16 @@ def parse_args(
         dest="server_port",
         default=ServerArgs.server_port,
         help="The port number for the server to listen on.",
+    )
+
+    parser.add_argument(
+        "--launch-nonce",
+        type=_launch_nonce,
+        default=ServerArgs.launch_nonce,
+        help=(
+            "Optional non-secret supervisor correlation token (16-128 URL-safe characters) "
+            "reported by /v1/runtime/identity."
+        ),
     )
 
     parser.add_argument(

--- a/python/freetoken/server/control_api.py
+++ b/python/freetoken/server/control_api.py
@@ -1,5 +1,6 @@
 """Read-only control-plane endpoints consumed by the desktop app: /health (lifecycle),
-/v1/stats (runtime metrics, Task 6), /v1/requests (request log ring, Task 5).
+/v1/runtime/identity (local process identity), /v1/stats (runtime metrics, Task 6), and
+/v1/requests (request log ring, Task 5).
 
 All handlers read a shared FrontendManager snapshot via ``get_state``; nothing here touches
 the scheduler or blocks. Registered on the app alongside the OpenAI/Anthropic/Responses routes.
@@ -7,10 +8,115 @@ the scheduler or blocks. Registered on the app alongside the OpenAI/Anthropic/Re
 
 from __future__ import annotations
 
+import copy
+import os
 import time
 from typing import Any, Callable
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from freetoken.daemon.osproc import proc_pgid, read_starttime
+
+from .accounting import _is_loopback
+
+
+RUNTIME_IDENTITY_SCHEMA = "freetoken.runtime_identity"
+RUNTIME_IDENTITY_SCHEMA_VERSION = 1
+
+
+def _process_runtime(pid: int | None) -> dict[str, int | None]:
+    if not isinstance(pid, int) or pid <= 0:
+        return {"pid": None, "pgid": None, "starttime": None}
+    return {
+        "pid": pid,
+        "pgid": proc_pgid(pid),
+        "starttime": read_starttime(pid),
+    }
+
+
+def _worker_role(name: str) -> tuple[str, int | None]:
+    if name.startswith("freetoken-TP") and name.endswith("-scheduler"):
+        try:
+            return "scheduler", int(name[len("freetoken-TP") : -len("-scheduler")])
+        except ValueError:
+            return "scheduler", None
+    if name.startswith("freetoken-detokenizer-"):
+        try:
+            return "detokenizer", int(name.rsplit("-", 1)[1])
+        except ValueError:
+            return "detokenizer", None
+    if name.startswith("freetoken-tokenizer-"):
+        try:
+            return "tokenizer", int(name.rsplit("-", 1)[1])
+        except ValueError:
+            return "tokenizer", None
+    return "worker", None
+
+
+def build_runtime_identity_snapshot(state: Any, processes: list[Any]) -> dict[str, Any]:
+    """Bind caller correlation separately from process facts observed by this frontend.
+
+    The snapshot is intentionally narrow: no argv, environment, model paths, executable paths,
+    or caller-supplied hash claims. A supervisor can independently bind those external facts to
+    this process using the nonce plus PID/PGID/start-time tuple.
+    """
+    workers = []
+    for process in processes:
+        name = str(getattr(process, "name", "worker"))
+        role, index = _worker_role(name)
+        worker = {
+            "worker_id": name,
+            "role": role,
+            "index": index,
+            **_process_runtime(getattr(process, "pid", None)),
+        }
+        workers.append(worker)
+
+    config = getattr(state, "config", None)
+    return {
+        "schema": RUNTIME_IDENTITY_SCHEMA,
+        "schema_version": RUNTIME_IDENTITY_SCHEMA_VERSION,
+        "correlation": {
+            "launch_nonce": getattr(config, "launch_nonce", None),
+        },
+        "runtime": {
+            "instance_id": getattr(state, "instance_id", None),
+            "frontend": {"role": "frontend", **_process_runtime(os.getpid())},
+            "workers": workers,
+        },
+    }
+
+
+def _build_runtime_identity_unlocked(state: Any) -> dict[str, Any] | None:
+    snapshot = getattr(state, "runtime_identity", None)
+    if not isinstance(snapshot, dict):
+        return None
+    doc = copy.deepcopy(snapshot)
+    maintenance = str(getattr(state, "maintenance_state", "failed"))
+    if getattr(state, "fatal_error", None) is not None:
+        status = "failed"
+    elif maintenance in {"serving", "rebuilding"}:
+        status = "ready"
+    elif maintenance in {"loading", "failed", "stopping"}:
+        status = maintenance
+    else:
+        status = "failed"
+    doc["lifecycle"] = {
+        "status": status,
+        "maintenance_state": maintenance,
+    }
+    return doc
+
+
+def build_runtime_identity(state: Any) -> dict[str, Any] | None:
+    # Production FrontendManager publishes shell-mode PGID refreshes and lifecycle transitions
+    # under this lock. Read both under the same lock so a response cannot combine a stale loading
+    # snapshot with a newly-ready lifecycle. Compatible external/fake states need not provide it.
+    lock = getattr(state, "_maintenance_lock", None)
+    if lock is None:
+        return _build_runtime_identity_unlocked(state)
+    with lock:
+        return _build_runtime_identity_unlocked(state)
 
 
 def build_health(state: Any, version: str) -> dict:
@@ -57,6 +163,20 @@ def register_control_routes(
     @app.get("/health")
     async def health():
         return build_health(get_state(), app.version)
+
+    @app.get("/v1/runtime/identity")
+    async def runtime_identity(request: Request):
+        # This is a process-supervisor surface, not a remotely consumable model API. Keep it
+        # loopback-only even when the generation server is deliberately bound to 0.0.0.0.
+        if not _is_loopback(request.client.host if request.client else None):
+            return JSONResponse(status_code=403, content={"error": "loopback access required"})
+        doc = build_runtime_identity(get_state())
+        if doc is None:
+            return JSONResponse(
+                status_code=503,
+                content={"error": "runtime identity is not bound"},
+            )
+        return doc
 
     from . import request_ring
 

--- a/tests/server/test_runtime_identity.py
+++ b/tests/server/test_runtime_identity.py
@@ -1,0 +1,432 @@
+"""CPU-only tests for the loopback runtime identity control plane."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+from freetoken.server.accounting import prepare_stop_accounting, register_accounting_routes
+from freetoken.server.api_server import (
+    FrontendManager,
+    _TRUSTED_PROXY_HOSTS,
+    _refresh_shell_runtime_identity,
+    _uvicorn_config,
+    dispatch_rebuild,
+)
+from freetoken.server.args import parse_args
+from freetoken.server.control_api import (
+    RUNTIME_IDENTITY_SCHEMA,
+    build_runtime_identity,
+    build_runtime_identity_snapshot,
+    register_control_routes,
+)
+
+
+class _Config:
+    def to_dict(self) -> dict:
+        return {"torch_dtype": "bfloat16"}
+
+
+def _parse(*extra: str):
+    with patch("freetoken.utils.cached_load_hf_config", return_value=_Config()):
+        parsed, run_shell = parse_args(["--model", "/private/models/model-a", *extra])
+    assert run_shell is False
+    return parsed
+
+
+def _state(*, nonce: str | None = "runtime_nonce_123456") -> SimpleNamespace:
+    return SimpleNamespace(
+        instance_id="instance-1",
+        maintenance_state="loading",
+        fatal_error=None,
+        config=SimpleNamespace(
+            launch_nonce=nonce,
+            served_model_name="model-a",
+            model_path="/private/models/model-a",
+        ),
+        runtime_identity=None,
+    )
+
+
+def test_launch_nonce_is_optional_and_accepts_only_bounded_url_safe_text():
+    assert _parse().launch_nonce is None
+    assert _parse("--launch-nonce", "runtime_nonce-1234").launch_nonce == "runtime_nonce-1234"
+
+    for invalid in ("short", "contains space 123", "slash/value/123456", "x" * 129):
+        with pytest.raises(SystemExit) as exc_info:
+            _parse("--launch-nonce", invalid)
+        assert exc_info.value.code == 2
+
+
+def test_launch_nonce_help_is_available_without_a_model_or_toolchain_resolution(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--help"])
+    assert exc_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--launch-nonce" in help_text
+    assert "non-secret supervisor correlation token" in " ".join(help_text.split())
+
+
+def test_snapshot_has_runtime_owned_process_facts_and_structured_worker_roles():
+    state = _state()
+    processes = [
+        SimpleNamespace(name="freetoken-TP0-scheduler", pid=os.getpid()),
+        SimpleNamespace(name="freetoken-detokenizer-0", pid=os.getpid()),
+        SimpleNamespace(name="freetoken-tokenizer-2", pid=os.getpid()),
+    ]
+
+    snapshot = build_runtime_identity_snapshot(state, processes)
+    state.runtime_identity = snapshot
+    doc = build_runtime_identity(state)
+
+    assert doc is not None
+    assert doc["schema"] == RUNTIME_IDENTITY_SCHEMA
+    assert doc["schema_version"] == 1
+    assert doc["correlation"] == {"launch_nonce": "runtime_nonce_123456"}
+    assert doc["runtime"]["instance_id"] == "instance-1"
+    frontend = doc["runtime"]["frontend"]
+    assert frontend["role"] == "frontend"
+    assert frontend["pid"] == os.getpid()
+    assert frontend["pgid"] == os.getpgid(os.getpid())
+    assert isinstance(frontend["starttime"], int)
+    assert frontend["starttime"] > 0
+    assert [(worker["role"], worker["index"]) for worker in doc["runtime"]["workers"]] == [
+        ("scheduler", 0),
+        ("detokenizer", 0),
+        ("tokenizer", 2),
+    ]
+    assert all(worker["pid"] == os.getpid() for worker in doc["runtime"]["workers"])
+    assert doc["lifecycle"] == {"status": "loading", "maintenance_state": "loading"}
+
+
+def test_snapshot_is_privacy_narrow_and_missing_nonce_is_explicit():
+    state = _state(nonce=None)
+    state.runtime_identity = build_runtime_identity_snapshot(
+        state, [SimpleNamespace(name="unknown", pid=None)]
+    )
+    doc = build_runtime_identity(state)
+    assert doc is not None
+    assert doc["correlation"]["launch_nonce"] is None
+    assert doc["runtime"]["workers"][0] == {
+        "worker_id": "unknown",
+        "role": "worker",
+        "index": None,
+        "pid": None,
+        "pgid": None,
+        "starttime": None,
+    }
+
+    encoded = json.dumps(doc, sort_keys=True)
+    assert "/private/" not in encoded
+    for forbidden in ("argv", "environment", "executable", "model_path", "source_hash"):
+        assert forbidden not in encoded
+
+
+@pytest.mark.parametrize(
+    ("maintenance", "fatal", "expected"),
+    [
+        ("loading", None, "loading"),
+        ("serving", None, "ready"),
+        ("rebuilding", None, "ready"),
+        ("failed", None, "failed"),
+        ("stopping", None, "stopping"),
+        ("serving", "worker died", "failed"),
+    ],
+)
+def test_lifecycle_changes_without_mutating_bound_process_identity(
+    maintenance: str, fatal: str | None, expected: str
+):
+    state = _state()
+    state.runtime_identity = build_runtime_identity_snapshot(state, [])
+    bound_runtime = json.dumps(state.runtime_identity["runtime"], sort_keys=True)
+    state.maintenance_state = maintenance
+    state.fatal_error = fatal
+
+    doc = build_runtime_identity(state)
+    assert doc is not None
+    assert doc["lifecycle"] == {
+        "status": expected,
+        "maintenance_state": maintenance,
+    }
+    assert json.dumps(doc["runtime"], sort_keys=True) == bound_runtime
+
+
+def test_frontend_stop_is_terminal_against_late_ready_callback():
+    manager = FrontendManager(
+        config=SimpleNamespace(served_model_name="model-a", launch_nonce=None),
+        send_tokenizer=None,
+        recv_tokenizer=None,
+    )
+    manager.mark_stopping()
+    assert manager.maintenance_state == "stopping"
+    assert manager.mark_ready() is False
+    assert manager.maintenance_state == "stopping"
+    assert manager.ready_at is None
+
+    manager.maintenance_state = "failed"
+    manager.mark_stopping()
+    assert manager.maintenance_state == "failed"
+
+
+def test_prepare_stop_cannot_overwrite_a_terminal_frontend_failure():
+    manager = FrontendManager(
+        config=SimpleNamespace(served_model_name="model-a", launch_nonce=None),
+        send_tokenizer=None,
+        recv_tokenizer=None,
+        maintenance_state="serving",
+    )
+    manager.mark_failed("scheduler exited")
+
+    result = asyncio.run(prepare_stop_accounting(manager))
+
+    assert result["drain_complete"] is True
+    assert manager.maintenance_state == "failed"
+    assert manager.fatal_error == "scheduler exited"
+
+
+def _rebuild_reply(request_id: str, status: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_id=request_id,
+        status=status,
+        moe_cache_size=0,
+        num_pages=0,
+        mamba_slots=0,
+        num_swa_pages=0,
+        error=None,
+    )
+
+
+def test_stop_is_terminal_against_late_rebuild_reply_and_dispatch_rollback():
+    stopped = SimpleNamespace(
+        maintenance_state="stopping",
+        fatal_error=None,
+        rebuild_futures={},
+        last_rebuild=None,
+    )
+    FrontendManager._resolve_rebuild(stopped, _rebuild_reply("late", "ok"))
+    assert stopped.maintenance_state == "stopping"
+
+    async def should_not_send(_msg) -> None:
+        raise AssertionError("stopping engine must reject before dispatch")
+
+    stopped.send_one = should_not_send
+    rejected = asyncio.run(dispatch_rebuild(stopped, moe_cache_size=8, num_pages=None))
+    assert rejected["status"] == "rejected"
+    assert stopped.maintenance_state == "stopping"
+    assert stopped.rebuild_futures == {}
+
+    async def stop_then_fail(_msg) -> None:
+        stopped.maintenance_state = "stopping"
+        raise RuntimeError("transport closed during stop")
+
+    stopped.maintenance_state = "serving"
+    stopped.send_one = stop_then_fail
+    result = asyncio.run(dispatch_rebuild(stopped, moe_cache_size=8, num_pages=None))
+    assert result["status"] == "failed"
+    assert stopped.maintenance_state == "stopping"
+
+
+def test_uvicorn_pins_proxy_trust_to_loopback_peers(monkeypatch):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    config = _uvicorn_config("0.0.0.0", 1919)
+    assert config.proxy_headers is True
+    assert config.forwarded_allow_ips == list(_TRUSTED_PROXY_HOSTS)
+
+
+def test_runtime_identity_route_is_loopback_only_and_fails_closed_when_unbound():
+    state = _state()
+    state.runtime_identity = build_runtime_identity_snapshot(state, [])
+    app = FastAPI(version="test")
+    register_control_routes(app, lambda: state)
+
+    loopback = TestClient(app, client=("127.0.0.1", 50000)).get("/v1/runtime/identity")
+    assert loopback.status_code == 200
+    assert loopback.json()["runtime"]["instance_id"] == "instance-1"
+
+    remote = TestClient(app, client=("192.0.2.10", 50000)).get(
+        "/v1/runtime/identity",
+        headers={"X-Forwarded-For": "127.0.0.1"},
+    )
+    assert remote.status_code == 403
+    assert remote.json() == {"error": "loopback access required"}
+
+    proxy_app = ProxyHeadersMiddleware(app, trusted_hosts=list(_TRUSTED_PROXY_HOSTS))
+    proxied_remote = TestClient(proxy_app, client=("127.0.0.1", 50000)).get(
+        "/v1/runtime/identity",
+        headers={"X-Forwarded-For": "192.0.2.10"},
+    )
+    assert proxied_remote.status_code == 403
+    assert proxied_remote.json() == {"error": "loopback access required"}
+
+    state.runtime_identity = None
+    missing = TestClient(app, client=("::1", 50000)).get("/v1/runtime/identity")
+    assert missing.status_code == 503
+    assert missing.json() == {"error": "runtime identity is not bound"}
+
+
+def test_loopback_proxy_preserves_remote_client_for_admin_authorization():
+    state = FrontendManager(
+        config=SimpleNamespace(served_model_name="model-a", launch_nonce=None),
+        send_tokenizer=None,
+        recv_tokenizer=None,
+        maintenance_state="serving",
+    )
+    app = FastAPI()
+    register_accounting_routes(app, lambda: state)
+    proxy_app = ProxyHeadersMiddleware(app, trusted_hosts=list(_TRUSTED_PROXY_HOSTS))
+
+    response = TestClient(proxy_app, client=("127.0.0.1", 50000)).post(
+        "/v1/admin/prepare-stop",
+        headers={"X-Forwarded-For": "192.0.2.10"},
+        json={},
+    )
+
+    assert response.status_code == 403
+    assert state.maintenance_state == "serving"
+
+
+def test_shell_identity_refreshes_worker_pgid_at_ready_boundary():
+    state = _state()
+    state.config.shell_mode = True
+    state.backend_processes = [SimpleNamespace(name="freetoken-TP0-scheduler", pid=123)]
+    state.runtime_identity = {
+        "runtime": {"workers": [{"pid": 123, "pgid": 100, "starttime": 456}]}
+    }
+
+    with (
+        patch("freetoken.server.control_api.os.getpid", return_value=999),
+        patch("freetoken.server.control_api.read_starttime", side_effect=[456, 111]),
+        patch("freetoken.server.control_api.proc_pgid", side_effect=[123, 999]),
+    ):
+        _refresh_shell_runtime_identity(state)
+
+    assert state.runtime_identity["runtime"]["frontend"] == {
+        "role": "frontend",
+        "pid": 999,
+        "pgid": 999,
+        "starttime": 111,
+    }
+    assert state.runtime_identity["runtime"]["workers"][0]["pgid"] == 123
+
+
+def test_ready_publication_cannot_pair_with_stale_shell_identity():
+    state = FrontendManager(
+        config=SimpleNamespace(
+            served_model_name="model-a",
+            launch_nonce="runtime_nonce_123456",
+            shell_mode=True,
+        ),
+        send_tokenizer=None,
+        recv_tokenizer=None,
+    )
+    state.backend_processes = [
+        SimpleNamespace(name="freetoken-TP0-scheduler", pid=os.getpid())
+    ]
+    state.runtime_identity = build_runtime_identity_snapshot(state, state.backend_processes)
+    state.runtime_identity["runtime"]["workers"][0]["pgid"] = -1
+
+    copy_started = threading.Event()
+    allow_copy = threading.Event()
+    original_deepcopy = copy.deepcopy
+
+    def blocking_deepcopy(value):
+        copy_started.set()
+        assert allow_copy.wait(timeout=2)
+        return original_deepcopy(value)
+
+    result = {}
+    with patch("freetoken.server.control_api.copy.deepcopy", side_effect=blocking_deepcopy):
+        reader = threading.Thread(
+            target=lambda: result.setdefault("doc", build_runtime_identity(state))
+        )
+        reader.start()
+        assert copy_started.wait(timeout=2)
+
+        writer = threading.Thread(target=state.mark_ready)
+        writer.start()
+        allow_copy.set()
+        reader.join(timeout=2)
+        writer.join(timeout=2)
+
+    assert not reader.is_alive()
+    assert not writer.is_alive()
+    assert result["doc"]["lifecycle"]["status"] == "loading"
+    assert result["doc"]["runtime"]["workers"][0]["pgid"] == -1
+
+    ready = build_runtime_identity(state)
+    assert ready is not None
+    assert ready["lifecycle"]["status"] == "ready"
+    assert ready["runtime"]["workers"][0]["pgid"] == os.getpgid(os.getpid())
+
+
+def test_run_api_server_binds_identity_after_worker_spawn(monkeypatch):
+    from freetoken.server import api_server
+
+    class Queue:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def stop(self) -> None:
+            pass
+
+    class Thread:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self) -> None:
+            pass
+
+    observed = {}
+
+    def run(_app, **kwargs) -> None:
+        observed["uvicorn_kwargs"] = kwargs
+        observed["identity"] = api_server._GLOBAL_STATE.runtime_identity
+
+    config = SimpleNamespace(
+        sampling_defaults="none",
+        use_dummy_weight=True,
+        model_path="/private/models/model-a",
+        served_model_name="model-a",
+        launch_nonce="runtime_nonce_123456",
+        server_host="127.0.0.1",
+        server_port=1919,
+        cors_origins="",
+        zmq_frontend_addr="inproc://frontend",
+        zmq_tokenizer_addr="inproc://tokenizer",
+        frontend_create_tokenizer_link=True,
+    )
+    worker = SimpleNamespace(name="freetoken-TP0-scheduler", pid=os.getpid())
+    handle = SimpleNamespace(processes=[worker])
+
+    monkeypatch.setattr(api_server, "ZmqAsyncPullQueue", Queue)
+    monkeypatch.setattr(api_server, "ZmqAsyncPushQueue", Queue)
+    monkeypatch.setattr(api_server, "install_cors", lambda *_args: None)
+    monkeypatch.setattr(api_server, "init_request_logging", lambda: None)
+    monkeypatch.setattr(api_server, "install_polling_access_log_filter", lambda: None)
+    monkeypatch.setattr(api_server.threading, "Thread", Thread)
+    monkeypatch.setattr(api_server.uvicorn, "run", run)
+
+    prior = api_server._GLOBAL_STATE
+    api_server._GLOBAL_STATE = None
+    try:
+        api_server.run_api_server(config, lambda: handle, run_shell=False)
+        identity = observed["identity"]
+        assert identity["correlation"]["launch_nonce"] == "runtime_nonce_123456"
+        assert identity["runtime"]["workers"][0]["pid"] == os.getpid()
+        assert observed["uvicorn_kwargs"]["proxy_headers"] is True
+        assert observed["uvicorn_kwargs"]["forwarded_allow_ips"] == list(
+            api_server._TRUSTED_PROXY_HOSTS
+        )
+    finally:
+        api_server._GLOBAL_STATE = prior


### PR DESCRIPTION
## Problem

A local process supervisor can discover a FreeToken HTTP responder through `/health`, but it cannot correlate that responder with the exact frontend and worker processes it launched. This leaves stale-responder and PID-reuse checks entirely outside the runtime.

## Solution

- Add an optional validated, non-secret `--launch-nonce` for supervisor correlation.
- Add versioned, loopback-only `GET /v1/runtime/identity` reporting the runtime-generated instance ID plus frontend and worker PID, PGID, and Linux starttime facts.
- Bind process facts after worker spawn and atomically refresh shell-worker PGIDs at the ready boundary after `setpgrp()`.
- Pin forwarded-header trust to loopback proxy peers so environment configuration cannot broaden trust, while preserving the real remote client address for loopback-proxied admin requests.
- Make ready, stop, failure, and rebuild transitions terminal-safe, including rejected-request cleanup.
- Keep the schema privacy-narrow: it exposes no argv, environment, executable/model paths, or caller-supplied source/model/profile/backend claims.

## Evidence

CPU/static only:

```text
pytest -q tests/server/test_runtime_identity.py \
  tests/server/test_rebuild_maintenance.py \
  tests/server/test_prepare_stop_accounting.py \
  tests/server/test_parser_auto_selection.py \
  tests/server/test_minimax_m3_parsers.py
104 passed, 1 non-failing Starlette/httpx deprecation warning
```

`py_compile` passed for all five changed Python/test files. `git diff --check` passed. Independent review is CLEAN; focused regression coverage includes proxy authorization, shell PGID publication, concurrent identity reads, terminal accounting failure, and rejected rebuild cleanup.

## Scope and residuals

The nonce is correlation data, not authentication. The endpoint is not source, model, profile, or effective-backend attestation; supervisors must still bind its process facts to their owned child and independently verify `/proc`. Linux `/proc` starttime is best-effort and nullable off Linux or after process exit. No GPU, model load, provider, live listener/reverse proxy, or real shell-child acceptance was exercised.