### PR TITLE
glm5_next: support GLM-5.3-Flash (hybrid KDA + DSA, mHC, NVFP4 expert offload)

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -40,9 +40,14 @@ for them; other checkpoints of the same architectures work too.
 - DeepSeek-V4 checkpoints must keep the `inference/config.json` subdir — the
   authoritative model args are read from there.
 - Qwen3.8-Flash-Next keeps a 47.7 GiB PLE n-gram table pinned in host RAM.
-- GLM-5.3-Flash support is text-only (the vision tower is not loaded). Full expert
+- GLM-5.3-Flash serves text by default; `FREETOKEN_GLM5_VISION=1` loads the vision
+  tower (~1.2 GiB BF16) and enables image input on both APIs (OpenAI `image_url`
+  data URI/http parts, Anthropic base64 `image` blocks) plus video input on the
+  OpenAI API (`video_url` parts; needs `pillow` + `av`). Image/video spans key the
+  prefix cache by pixel-content hash, so identical media prefixes are reused safely
+  with `--cache-type radix`. Full expert
   offload pins ~163 GiB of host RAM; `FREETOKEN_GLM5_RESIDENT_LAYERS` (e.g. `3-6,8-11`)
   keeps the named layers' experts on the GPU as model weights instead, cutting the pin
   footprint to ~129 GiB and removing their PCIe traffic. The MTP head is skipped unless
   `FREETOKEN_GLM5_MTP=1`.
-- Multimodal checkpoints are served text-only.
+- Other multimodal checkpoints are served text-only.

--- a/docs/models.md
+++ b/docs/models.md
@@ -8,6 +8,7 @@ for them; other checkpoints of the same architectures work too.
 |---|---|
 | DeepSeek-V4 | [deepseek-ai/DeepSeek-V4-Flash-0731](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) |
 | GLM-5.2 | [nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4) |
+| GLM-5.3-Flash | [zai-org/GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash) (text tower), [LibertAIDAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/LibertAIDAI/GLM-5.3-Flash-NVFP4) |
 | GLM-4.7 | [nvidia/GLM-4.7-NVFP4](https://huggingface.co/nvidia/GLM-4.7-NVFP4) |
 | Qwen3.8-Flash-Next | [Qwen/Qwen3.8-Flash-Next-FP8](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8), [RadixArk/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/RadixArk/Qwen3.8-Flash-Next-NVFP4) |
 | Qwen3.6 / Qwen3.5 MoE | [Qwen/Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) ([-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8)), [nvidia/Qwen3.6-35B-A3B-NVFP4](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4), [Qwen/Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) ([-FP8](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-FP8)) |
@@ -39,4 +40,9 @@ for them; other checkpoints of the same architectures work too.
 - DeepSeek-V4 checkpoints must keep the `inference/config.json` subdir — the
   authoritative model args are read from there.
 - Qwen3.8-Flash-Next keeps a 47.7 GiB PLE n-gram table pinned in host RAM.
+- GLM-5.3-Flash support is text-only (the vision tower is not loaded). Full expert
+  offload pins ~163 GiB of host RAM; `FREETOKEN_GLM5_RESIDENT_LAYERS` (e.g. `3-6,8-11`)
+  keeps the named layers' experts on the GPU as model weights instead, cutting the pin
+  footprint to ~129 GiB and removing their PCIe traffic. The MTP head is skipped unless
+  `FREETOKEN_GLM5_MTP=1`.
 - Multimodal checkpoints are served text-only.

--- a/python/freetoken/attention/dsa.py
+++ b/python/freetoken/attention/dsa.py
@@ -61,6 +61,8 @@ class DSAMetadata(BaseAttnMetadata):
     # live lengths, device-read. None on prefill (the host loop reads the live table).
     rows:           torch.Tensor | None = None
     kvlen:          torch.Tensor | None = None
+    # k-pool: every kpool-th row (each pool's first-token physical row), position order.
+    pool_rows:      torch.Tensor | None = None
     # group leader layer -> (sel_rows, counts); only the LIVE leader is retained
     sel:            dict = field(default_factory=dict)
     # fmt: on
@@ -93,16 +95,32 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         self.dsa_enabled = isinstance(self.kvcache, DSAKVCache)
         self.index_topk = args.index_topk
         self.index_scale = args.index_head_dim**-0.5 if args.index_head_dim else 0.0
+        # GLM-5.3 k-pool: score `index_kpool`-token pools, expand winners to raw tokens and
+        # always append the in-progress tail pool. 1 = per-token scoring (GLM-5.2).
+        self.index_kpool = int(getattr(args, "index_kpool", 1))
         # layer -> group leader (most recent "full" layer); leader -> pool slot.
         # Only built when DSA serves: the dense ablation never consults indexer_types,
         # so a checkpoint with a malformed list cannot crash the ablation.
         self._leader: Dict[int, int] = {}
         self._idx_slot: Dict[int, int] = {}
         if self.dsa_enabled:
+            # Hybrid linear-attention models (GLM-5.3): only the MLA full-attention
+            # layers participate in DSA -- linear (KDA) layers own no indexer, never
+            # call mla_forward, and must not consume index slots. Non-hybrid GLM-5.2
+            # has every layer in the mla group, so this is the identity there.
+            _mla_ids = None
+            for _g in getattr(config, "attention_groups", ()) or ():
+                if getattr(_g, "mla", False):
+                    _mla_ids = frozenset(_g.layer_ids)
             lead = None
             # Capped to the SERVED layer count (dev num_layers overrides must not
             # index slots past the pool the factory sized from the same cap).
-            for lid, kind in enumerate(args.indexer_types[: config.num_layers]):
+            # Iterate the derived list (glm5 MTP appends layer 45 past num_layers);
+            # the mla-group membership filter keeps the served set exact.
+            _bound = max(config.num_layers, len(args.indexer_types)) if _mla_ids else config.num_layers
+            for lid, kind in enumerate(args.indexer_types[:_bound]):
+                if _mla_ids is not None and lid not in _mla_ids:
+                    continue
                 if kind == "full":
                     lead = lid
                     self._idx_slot[lid] = len(self._idx_slot)
@@ -173,11 +191,16 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
             # + device-read live lengths, once per step at the first layer.
             md.rows = self._decode_rows(batch).to(torch.int32)
             md.kvlen = md.kv_len_cpu.to(self.device, non_blocking=True)
+            if self.index_kpool > 1:
+                md.pool_rows = md.rows[:, :: self.index_kpool].contiguous()
         self.kvcache.store_kv(c_kv, k_rope, batch.out_loc, layer_id)
         if self.dsa_enabled and indexer_qkw is not None:
             # Scatter index keys unconditionally: short prefills serve through the
             # identity path TODAY, but their keys must exist once decode passes topk.
             self.kvcache.store_index_k(indexer_qkw[1], batch.out_loc, self._idx_slot[layer_id])
+            if self.index_kpool > 1:
+                self.kvcache.store_gate(indexer_qkw[3], batch.out_loc, self._idx_slot[layer_id])
+                self._update_pools(md, layer_id, batch, indexer_qkw[4])
 
         if md.is_decode:
             return self._decode(md, layer_id, q_nope, q_pe, indexer_qkw)
@@ -193,14 +216,46 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
             sel, cnt = rows.view(bs, 1, -1), kvlen.view(bs, 1)
         else:
             if indexer_qkw is not None:
-                q_idx, _, w = indexer_qkw
-                s = self.dsa_decode_scores(q_idx, w, self._idx_slot[layer_id], rows, kvlen)
-                k_sel = min(self.index_topk, s.shape[-1])
-                picks = self.indexer_select_decode(
-                    s.view(bs, 1, -1), valid=kvlen, topk=k_sel, offset=0
-                )[:, 0]  # [bs, K] positions, -1 sentinel
-                sel = self.dsa_map_rows(picks, rows).view(bs, 1, -1)
-                cnt = torch.clamp(kvlen, max=k_sel).to(torch.int32).view(bs, 1)
+                q_idx, w = indexer_qkw[0], indexer_qkw[2]
+                kp = self.index_kpool
+                if kp > 1:
+                    # Pool-compressed scoring: candidates are complete kpool-token pools
+                    # (pooled keys at each pool's first-token row), causal by construction
+                    # (valid = kvlen // kp counts only complete pools). Winners expand back
+                    # to raw token positions; the in-progress tail pool (< kp tokens) is
+                    # ALWAYS selected, unscored (HF index_kpool_always_select_tail).
+                    from freetoken.kernel.triton.glm_dsa_sparse import glm_dsa_decode_logits
+
+                    kv_pools = kvlen // kp
+                    sp = glm_dsa_decode_logits(
+                        q_idx, (w * self.index_scale),
+                        self.kvcache.pool_k_cache(self._idx_slot[layer_id]),
+                        md.pool_rows, kv_pools,
+                    )
+                    p_sel = min(self.index_topk // kp, sp.shape[-1])
+                    picks = self.indexer_select_decode(
+                        sp.view(bs, 1, -1), valid=kv_pools, topk=p_sel, offset=0
+                    )[:, 0]  # [bs, P] pool ids, -1 sentinel
+                    ar = torch.arange(kp, device=picks.device)
+                    tok = picks.unsqueeze(-1) * kp + ar  # [bs, P, kp]
+                    tok = torch.where(picks.unsqueeze(-1) >= 0, tok, -1).view(bs, -1)
+                    tail = (kv_pools * kp).unsqueeze(-1) + ar[: kp - 1]  # [bs, kp-1]
+                    tail = torch.where(tail < kvlen.unsqueeze(-1), tail, -1)
+                    pos = torch.cat([tail, tok], dim=-1)  # [bs, kp-1 + P*kp]
+                    sel = self.dsa_map_rows(pos, rows).view(bs, 1, -1)
+                    # -1 holes are masked inside the sparse kernel; bound by full width
+                    # (static shape -> graph-safe).
+                    cnt = torch.full(
+                        (bs, 1), pos.shape[-1], dtype=torch.int32, device=pos.device
+                    )
+                else:
+                    s = self.dsa_decode_scores(q_idx, w, self._idx_slot[layer_id], rows, kvlen)
+                    k_sel = min(self.index_topk, s.shape[-1])
+                    picks = self.indexer_select_decode(
+                        s.view(bs, 1, -1), valid=kvlen, topk=k_sel, offset=0
+                    )[:, 0]  # [bs, K] positions, -1 sentinel
+                    sel = self.dsa_map_rows(picks, rows).view(bs, 1, -1)
+                    cnt = torch.clamp(kvlen, max=k_sel).to(torch.int32).view(bs, 1)
                 # Only the live group leader's selection is ever read again.
                 md.sel.clear()
                 md.sel[layer_id] = (sel, cnt)
@@ -215,6 +270,8 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         rows: torch.Tensor, positions: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Per-request causal top-k: ([1, m, K] physical rows, [1, m] counts)."""
+        if self.index_kpool > 1:
+            return self._select_prefill_kpool(slot, q_idx, w, rows, positions)
         kv_len = rows.numel()
         k_all = self.kvcache.index_k_cache(slot).index_select(0, rows.long())
         k_sel = min(self.index_topk, kv_len)
@@ -236,6 +293,100 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         cnt = torch.clamp(positions + 1, max=k_sel).to(torch.int32)
         return sel.view(1, m, k_sel), cnt.view(1, m)
 
+    def _select_prefill_kpool(
+        self, slot: int, q_idx: torch.Tensor, w: torch.Tensor,
+        rows: torch.Tensor, positions: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Pool-compressed causal top-k for prefill: query at absolute position p scores
+        complete pools j < (p+1)//kp (indexer_select_prefill's ratio semantics == the HF
+        pool_end<=p rule), winners expand to raw tokens, and p's in-progress tail pool
+        ((p+1)%kp trailing tokens) is always appended unscored."""
+        kp = self.index_kpool
+        kv_len = rows.numel()
+        n_pools = kv_len // kp
+        pool_rows = rows[: n_pools * kp : kp]
+        k_pool = self.kvcache.pool_k_cache(slot).index_select(0, pool_rows.long())
+        p_sel = max(1, min(self.index_topk // kp, max(n_pools, 1)))
+        m = q_idx.shape[0]
+        width = (kp - 1) + p_sel * kp
+        sel = torch.empty(m, width, dtype=torch.int32, device=self.device)
+        start_pos = int(positions[0])
+        ar = torch.arange(kp, device=self.device)
+        chunk = max(16, min(_PREFILL_SCORE_CHUNK, _PREFILL_SCORE_BYTES // max(n_pools * 4, 1)))
+        for s0 in range(0, m, chunk):
+            s1 = min(s0 + chunk, m)
+            scores = self.dsa_prefill_logits(q_idx[s0:s1], k_pool, w[s0:s1])  # [c, n_pools]
+            picks = self.indexer_select_prefill(
+                scores.unsqueeze(0), start_pos=start_pos + s0, seqlen=s1 - s0,
+                ratio=kp, topk=p_sel, offset=0,
+            )[0]  # [c, p_sel] pool ids, -1 sentinel
+            tok = picks.unsqueeze(-1) * kp + ar
+            tok = torch.where(picks.unsqueeze(-1) >= 0, tok, -1).reshape(s1 - s0, -1)
+            pos_q = positions[s0:s1]
+            tail = (((pos_q + 1) // kp) * kp).unsqueeze(-1) + ar[: kp - 1]
+            tail = torch.where(tail <= pos_q.unsqueeze(-1), tail, -1)
+            pos = torch.cat([tail, tok], dim=-1)
+            sel[s0:s1] = self.dsa_map_rows(pos, rows.view(1, -1).expand(s1 - s0, -1))
+        cnt = torch.full((1, m), width, dtype=torch.int32, device=self.device)
+        return sel.view(1, m, width), cnt
+
+    def _update_pools(self, md, layer_id, batch, ape: torch.Tensor) -> None:
+        """Refresh pooled keys after this forward's index-k/gate scatter.
+
+        Pool key (HF get_pooled_states): softmax over the pool's kp tokens of
+        (gate_scores + ape) PER CHANNEL, weighted average of the raw index keys.
+        Prefill (eager): recompute every pool the new tokens touch, per request.
+        Decode (graph-captured): unconditionally recompute each request's CURRENT pool
+        from static-shaped gathers -- incomplete pools are never scored, and the
+        overwrite converges to the exact value the step the pool completes."""
+        kp = self.index_kpool
+        slot = self._idx_slot[layer_id]
+        kcache = self.kvcache.index_k_cache(slot)
+        gcache = self.kvcache.gate_cache(slot)
+        apef = ape.float().unsqueeze(0)  # [1, kp, D]
+        if md.is_decode:
+            rows, kvlen = md.rows, md.kvlen
+            bs = rows.shape[0]
+            ar = torch.arange(kp, device=rows.device)
+            pcur = torch.clamp((kvlen - 1) // kp, min=0)
+            tok = pcur.unsqueeze(-1) * kp + ar                       # [bs, kp]
+            kv_valid = kvlen
+            if getattr(md, "spec_shared_row", False):
+                # Spec verify: the bs rows are SEQUENTIAL positions of one request on a
+                # shared table row. Two rows with the same current pool scatter to the
+                # same slab slot, and inter-row scatter order is undefined -- so give
+                # every writer the max-kvlen key set (identical bytes). A pool is only
+                # ever SCORED by rows for which it is complete (kvlen_row//kp), and for
+                # those the full-key value is exact; the trailing partial pool is never
+                # scored and reconverges on the next regular decode step.
+                kv_valid = kvlen.max().expand(bs)
+            valid = tok < kv_valid.unsqueeze(-1)
+            rg = rows.gather(1, tok.clamp(max=rows.shape[1] - 1).long()).clamp(min=0)
+            kk = kcache[rg.reshape(-1).long()].view(bs, kp, -1).float()
+            gg = gcache[rg.reshape(-1).long()].view(bs, kp, -1).float()
+            logits = torch.where(valid.unsqueeze(-1), gg + apef, float("-inf"))
+            probs = torch.softmax(logits, dim=1)
+            pk = (probs * kk).sum(dim=1).to(kcache.dtype)            # [bs, D]
+            first = rows.gather(1, (pcur * kp).unsqueeze(-1).long()).squeeze(-1)
+            self.kvcache.store_pool_k(pk, first.clamp(min=0).long(), slot)
+            return
+        page_table = get_global_ctx().page_table
+        reqs = batch.padded_reqs if hasattr(batch, "padded_reqs") else batch.reqs
+        for r in reqs:
+            if r.extend_len == 0:
+                continue
+            cached = r.device_len - r.extend_len
+            p0, p1 = cached // kp, r.device_len // kp
+            if p1 <= p0:
+                continue
+            row = page_table[r.table_idx, p0 * kp : p1 * kp].long()
+            n = p1 - p0
+            kk = kcache[row].view(n, kp, -1).float()
+            gg = gcache[row].view(n, kp, -1).float()
+            probs = torch.softmax(gg + apef, dim=1)
+            pk = (probs * kk).sum(dim=1).to(kcache.dtype)
+            self.kvcache.store_pool_k(pk, row[::kp], slot)
+
     def _prefill(self, md, layer_id, q_nope, q_pe, batch, indexer_qkw) -> torch.Tensor:
         t = q_nope.shape[0]
         q_cat = torch.cat([q_nope, q_pe], dim=-1)  # [T, H, 576]
@@ -244,7 +395,7 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         qo = md.qo_indptr_cpu.tolist()
         sparse = self.dsa_enabled and int(md.kv_len_cpu.max()) > self.index_topk
         if sparse and indexer_qkw is not None:
-            q_idx, _, w = indexer_qkw
+            q_idx, w = indexer_qkw[0], indexer_qkw[2]
             md.sel.clear()  # one live group leader at a time
             md.sel[layer_id] = [
                 self._select_prefill(
@@ -283,6 +434,11 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         width = get_global_ctx().page_table.shape[1]
         self._rows_buf = torch.full((max_bs, width), -1, dtype=torch.int32, device=self.device)
         self._kvlen_buf = torch.zeros(max_bs, dtype=torch.int32, device=self.device)
+        if self.index_kpool > 1:
+            pw = (width + self.index_kpool - 1) // self.index_kpool
+            self._pool_rows_buf = torch.full(
+                (max_bs, pw), -1, dtype=torch.int32, device=self.device
+            )
 
     def _decode_rows(self, batch: Batch) -> torch.Tensor:
         """This decode step's per-request page-table rows [bs, W], gathered off the
@@ -298,6 +454,9 @@ class DSAAttnBackend(DSAIndexerMixin, BaseAttnBackend):
         self._kvlen_buf[:bs].copy_(md.kv_len_cpu.to(self.device, non_blocking=True))
         md.rows = self._rows_buf[:bs]
         md.kvlen = self._kvlen_buf[:bs]
+        if self.index_kpool > 1:
+            self._pool_rows_buf[:bs].copy_(self._rows_buf[:bs, :: self.index_kpool])
+            md.pool_rows = self._pool_rows_buf[:bs]
 
     def prepare_for_capture(self, batch: Batch) -> None:
         # The capture batch is all dummy rows with no scheduler-staged

--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -1621,6 +1621,12 @@ struct CpuMoeExecutor {
         const float glu = gate / (1.0f + std::exp(-gate * alpha));
         g_row[i] = f32_to_bf16(glu * (up + 1.0f));
       } else {
+        // Clamped swiglu (GLM-5.3 "swiglu_clamp" = silu + finite lim):
+        // silu(min(gate,lim)) * clamp(up,+-lim). lim == +inf (every other
+        // model/act): both clamps are no-ops, bitwise identical to before.
+        if (gate > lim) gate = lim;
+        if (up > lim) up = lim;
+        else if (up < -lim) up = -lim;
         g_row[i] = f32_to_bf16(act_apply(act, gate) * up);
       }
     }

--- a/python/freetoken/kernel/triton/dsv4/hc_norm.py
+++ b/python/freetoken/kernel/triton/dsv4/hc_norm.py
@@ -1,0 +1,80 @@
+"""Fused mHC pre-norm helpers (2026-08-28 tail-fusion pass).
+
+Per hc_pre call the eager chain was: big fp32 cast -> square -> mean-reduce ->
+rsqrt -> cublas gemv (dot_kernel + reduce_1Block) -> broadcast mul, i.e. ~7
+launches x 90 calls/step. Here:
+
+  * ``hc_rms_cast``  -- one kernel: bf16->fp32 copy (the gemv still needs fp32
+    input) + sum-of-squares + rsqrt(mean+eps), one CTA per token (deterministic).
+  * ``hc_mix_gemv``  -- [MIX, KDIM] fp32 gemv with the rsqrt scale folded into the
+    epilogue; one CTA per (token, row), sequential k-loop (no atomics, so
+    run-to-run deterministic like the cublas dot+reduce pair it replaces).
+
+Numerics: identical inputs/ops in fp32; only reduction order differs from ATen /
+cublas (epsilon-level). CUDA-graph safe: fixed shapes, no host sync."""
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _hc_rms_cast_kernel(
+    x_ptr, xf_ptr, rs_ptr, D, eps,
+    stride_xm, stride_fm,
+    BLOCK: tl.constexpr,
+):
+    m = tl.program_id(0)
+    acc = tl.zeros((BLOCK,), dtype=tl.float32)
+    for start in range(0, tl.cdiv(D, BLOCK)):
+        offs = start * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < D
+        v = tl.load(x_ptr + m * stride_xm + offs, mask=mask, other=0.0).to(tl.float32)
+        tl.store(xf_ptr + m * stride_fm + offs, v, mask=mask)
+        acc += v * v
+    ssq = tl.sum(acc, axis=0)
+    tl.store(rs_ptr + m, 1.0 / tl.sqrt(ssq / D + eps))
+
+
+def hc_rms_cast(x: torch.Tensor, eps: float):
+    """``x`` [M, D] (bf16/fp16/fp32) -> (``xf`` [M, D] fp32, ``rs`` [M] fp32)."""
+    M, D = x.shape
+    xf = torch.empty(M, D, dtype=torch.float32, device=x.device)
+    rs = torch.empty(M, dtype=torch.float32, device=x.device)
+    _hc_rms_cast_kernel[(M,)](
+        x, xf, rs, D, eps, x.stride(0), xf.stride(0),
+        BLOCK=1024, num_warps=4,
+    )
+    return xf, rs
+
+
+@triton.jit
+def _hc_mix_gemv_kernel(
+    xf_ptr, w_ptr, rs_ptr, out_ptr, D,
+    stride_fm, stride_wr, stride_om,
+    MIX: tl.constexpr, BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    m = pid // MIX
+    r = pid - m * MIX
+    acc = tl.zeros((BLOCK,), dtype=tl.float32)
+    for start in range(0, tl.cdiv(D, BLOCK)):
+        offs = start * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < D
+        xv = tl.load(xf_ptr + m * stride_fm + offs, mask=mask, other=0.0)
+        wv = tl.load(w_ptr + r * stride_wr + offs, mask=mask, other=0.0)
+        acc += xv * wv
+    dot = tl.sum(acc, axis=0)
+    rs = tl.load(rs_ptr + m)
+    tl.store(out_ptr + m * stride_om + r, dot * rs)
+
+
+def hc_mix_gemv(xf: torch.Tensor, w: torch.Tensor, rs: torch.Tensor) -> torch.Tensor:
+    """``out[m, r] = rs[m] * dot(w[r], xf[m])``; ``w`` [MIX, D] fp32."""
+    M, D = xf.shape
+    MIX = w.shape[0]
+    out = torch.empty(M, MIX, dtype=torch.float32, device=xf.device)
+    _hc_mix_gemv_kernel[(M * MIX,)](
+        xf, w, rs, out, D, xf.stride(0), w.stride(0), out.stride(0),
+        MIX=MIX, BLOCK=2048, num_warps=8,
+    )
+    return out

--- a/python/freetoken/kernel/triton/fused_route.py
+++ b/python/freetoken/kernel/triton/fused_route.py
@@ -1,0 +1,61 @@
+"""Fused MoE router epilogue (2026-08-28 tail-fusion pass).
+
+After the (kept, cublas) fp32 gate GEMV this replaces the eager chain
+sigmoid -> +bias -> torch.topk (gather+bitonic) -> gather -> sum -> div -> mul
+-> int32 cast (~8 launches x 42 MoE layers/step) with ONE kernel per token batch.
+
+Semantics mirror ``Glm4MoeSparseBlock`` routing with n_group<=1 exactly:
+  scores = sigmoid(logits); s4c = scores + bias; ids = top-8 of s4c (descending,
+  first-index tie-break); w = scores[ids]; w /= (sum(w)+1e-20) [if RENORM];
+  w *= scaling.  The renorm sum runs in the same descending order as the eager
+  gather->sum, so rounding matches; only sigmoid may differ from ATen by <=1 ulp.
+CUDA-graph safe: fixed shapes, no host sync, no atomics (deterministic)."""
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_route_kernel(
+    logits_ptr, bias_ptr, w_ptr, id_ptr,
+    stride_lm, scaling,
+    E: tl.constexpr, TOPK: tl.constexpr, RENORM: tl.constexpr, BLOCK: tl.constexpr,
+):
+    m = tl.program_id(0)
+    offs = tl.arange(0, BLOCK)
+    mask = offs < E
+    lg = tl.load(logits_ptr + m * stride_lm + offs, mask=mask, other=0.0).to(tl.float32)
+    sc = tl.sigmoid(lg)
+    bias = tl.load(bias_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    s4c = tl.where(mask, sc + bias, float("-inf"))
+    wsum = 0.0
+    for k in tl.static_range(TOPK):
+        idx = tl.argmax(s4c, axis=0)  # first-index tie-break, like sorted topk
+        val = tl.sum(tl.where(offs == idx, sc, 0.0), axis=0)
+        tl.store(id_ptr + m * TOPK + k, idx.to(tl.int32))
+        tl.store(w_ptr + m * TOPK + k, val)
+        s4c = tl.where(offs == idx, float("-inf"), s4c)
+        wsum += val
+    for k in tl.static_range(TOPK):
+        v = tl.load(w_ptr + m * TOPK + k)  # same-thread reload: program-ordered
+        if RENORM:
+            v = v / (wsum + 1e-20)
+        tl.store(w_ptr + m * TOPK + k, v * scaling)
+
+
+def fused_route(
+    logits: torch.Tensor,   # [M, E] fp32 (router gemv output)
+    bias: torch.Tensor,     # [E] (e_score_correction_bias; any float dtype)
+    top_k: int,
+    renorm: bool,
+    scaling: float,
+):
+    M, E = logits.shape
+    w = torch.empty(M, top_k, dtype=torch.float32, device=logits.device)
+    ids = torch.empty(M, top_k, dtype=torch.int32, device=logits.device)
+    _fused_route_kernel[(M,)](
+        logits, bias, w, ids, logits.stride(0), scaling,
+        E=E, TOPK=top_k, RENORM=renorm, BLOCK=triton.next_power_of_2(E),
+        num_warps=4,
+    )
+    return w, ids

--- a/python/freetoken/kernel/triton/glm_dsa_sparse.py
+++ b/python/freetoken/kernel/triton/glm_dsa_sparse.py
@@ -57,11 +57,12 @@ def _glm_dsa_sparse_kernel(
     offs_h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
     h_mask = offs_h < H
     offs_v = tl.arange(0, D_V)
-    offs_r = tl.arange(0, D_R)
+    offs_r = tl.arange(0, D_R) if D_R > 0 else 0  # NoPE (GLM-5.3): no rope tail
 
     q_base = q_ptr + pid_b * stride_qb + pid_m * stride_qm + offs_h[:, None] * stride_qh
     q_v = tl.load(q_base + offs_v[None, :] * stride_qd, mask=h_mask[:, None], other=0.0).to(tl.float32)
-    q_r = tl.load(q_base + (D_V + offs_r[None, :]) * stride_qd, mask=h_mask[:, None], other=0.0).to(tl.float32)
+    if D_R > 0:
+        q_r = tl.load(q_base + (D_V + offs_r[None, :]) * stride_qd, mask=h_mask[:, None], other=0.0).to(tl.float32)
 
     m_i = tl.full((BLOCK_H,), -float("inf"), dtype=tl.float32)
     l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
@@ -79,9 +80,11 @@ def _glm_dsa_sparse_kernel(
         valid = idxs >= 0
         kv_base = pool_ptr + idxs[:, None] * stride_pn
         kv_v = tl.load(kv_base + offs_v[None, :] * stride_pd, mask=valid[:, None], other=0.0).to(tl.float32)
-        kv_r = tl.load(kv_base + (D_V + offs_r[None, :]) * stride_pd, mask=valid[:, None], other=0.0).to(tl.float32)
-
-        scores = (tl.dot(q_v, tl.trans(kv_v)) + tl.dot(q_r, tl.trans(kv_r))) * scale
+        if D_R > 0:
+            kv_r = tl.load(kv_base + (D_V + offs_r[None, :]) * stride_pd, mask=valid[:, None], other=0.0).to(tl.float32)
+            scores = (tl.dot(q_v, tl.trans(kv_v)) + tl.dot(q_r, tl.trans(kv_r))) * scale
+        else:
+            scores = tl.dot(q_v, tl.trans(kv_v)) * scale
         scores = tl.where(valid[None, :], scores, -float("inf"))
 
         m_new = tl.maximum(m_i, tl.max(scores, axis=1))
@@ -221,7 +224,7 @@ def _glm_dsa_splitk_kernel(
     offs_h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
     h_mask = offs_h < H
     offs_v = tl.arange(0, D_V)
-    offs_r = tl.arange(0, D_R)
+    offs_r = tl.arange(0, D_R) if D_R > 0 else 0  # NoPE (GLM-5.3): no rope tail
 
     n_active = TOPK
     if HAS_COUNTS:
@@ -238,7 +241,8 @@ def _glm_dsa_splitk_kernel(
     if split_end > split_start:
         q_base = q_ptr + pid_b * stride_qb + pid_m * stride_qm + offs_h[:, None] * stride_qh
         q_v = tl.load(q_base + offs_v[None, :] * stride_qd, mask=h_mask[:, None], other=0.0).to(tl.float32)
-        q_r = tl.load(q_base + (D_V + offs_r[None, :]) * stride_qd, mask=h_mask[:, None], other=0.0).to(tl.float32)
+        if D_R > 0:
+            q_r = tl.load(q_base + (D_V + offs_r[None, :]) * stride_qd, mask=h_mask[:, None], other=0.0).to(tl.float32)
         idx_base = idx_ptr + pid_b * stride_ib + pid_m * stride_im
 
         for start in range(split_start, split_end, BLOCK_T):
@@ -248,9 +252,11 @@ def _glm_dsa_splitk_kernel(
             valid = idxs >= 0
             kv_base = pool_ptr + idxs[:, None] * stride_pn
             kv_v = tl.load(kv_base + offs_v[None, :] * stride_pd, mask=valid[:, None], other=0.0).to(tl.float32)
-            kv_r = tl.load(kv_base + (D_V + offs_r[None, :]) * stride_pd, mask=valid[:, None], other=0.0).to(tl.float32)
-
-            scores = (tl.dot(q_v, tl.trans(kv_v)) + tl.dot(q_r, tl.trans(kv_r))) * scale
+            if D_R > 0:
+                kv_r = tl.load(kv_base + (D_V + offs_r[None, :]) * stride_pd, mask=valid[:, None], other=0.0).to(tl.float32)
+                scores = (tl.dot(q_v, tl.trans(kv_v)) + tl.dot(q_r, tl.trans(kv_r))) * scale
+            else:
+                scores = tl.dot(q_v, tl.trans(kv_v)) * scale
             scores = tl.where(valid[None, :], scores, -float("inf"))
 
             m_new = tl.maximum(m_i, tl.max(scores, axis=1))

--- a/python/freetoken/kernel/triton/kda_gate.py
+++ b/python/freetoken/kernel/triton/kda_gate.py
@@ -1,0 +1,52 @@
+"""Fused KDA gate math: one elementwise kernel replaces the ~7-kernel fp32 chain
+(float cast, +dt_bias, exp/sigmoid/mul for g, sigmoid for beta).
+
+    g[t,h,j] = lower_bound * sigmoid(decay[h] * (raw[t, h*K+j] + dt_bias[h*K+j]))
+    beta[t,h] = sigmoid(b_raw[t,h])
+
+Same fp32 math as the eager chain (``decay = exp(A_log)`` precomputed once by the
+caller); only numerics delta is libdevice-vs-ATen sigmoid rounding (<=1 ulp).
+CUDA-graph safe: fixed shapes, no host sync."""
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _kda_gate_kernel(
+    raw_ptr, braw_ptr, dtb_ptr, decay_ptr, g_ptr, beta_ptr,
+    stride_bt,
+    lower_bound,
+    H: tl.constexpr, K: tl.constexpr,
+):
+    pid = tl.program_id(0)  # one program per (token, head)
+    t = pid // H
+    h = pid % H
+    offs = h * K + tl.arange(0, K)
+    raw = tl.load(raw_ptr + t * H * K + offs).to(tl.float32)
+    dtb = tl.load(dtb_ptr + offs)
+    dec = tl.load(decay_ptr + h)
+    g = lower_bound * tl.sigmoid(dec * (raw + dtb))
+    tl.store(g_ptr + t * H * K + offs, g)
+    braw = tl.load(braw_ptr + t * stride_bt + h).to(tl.float32)
+    tl.store(beta_ptr + t * H + h, tl.sigmoid(braw))
+
+
+def kda_gate(
+    raw: torch.Tensor,      # [total, H*K] bf16, contiguous
+    b_raw: torch.Tensor,    # [total, H] bf16 (row-strided slice ok)
+    dt_bias: torch.Tensor,  # [H*K] fp32
+    decay: torch.Tensor,    # [H] fp32 = exp(A_log)
+    lower_bound: float,
+):
+    total, qkv = raw.shape
+    H = b_raw.shape[1]
+    K = qkv // H
+    g = torch.empty(total, H, K, dtype=torch.float32, device=raw.device)
+    beta = torch.empty(total, H, dtype=torch.float32, device=raw.device)
+    _kda_gate_kernel[(total * H,)](
+        raw, b_raw, dt_bias, decay, g, beta,
+        b_raw.stride(0), lower_bound, H=H, K=K,
+        num_warps=1,
+    )
+    return g, beta

--- a/python/freetoken/kvcache/__init__.py
+++ b/python/freetoken/kvcache/__init__.py
@@ -213,6 +213,9 @@ def create_kvcache_pool(
             return DSAKVCache(
                 latent_dim=spec.head_dim,
                 num_layers=model_config.num_layers,
+                layer_ids=layer_ids,
+                index_kpool=int(getattr(
+                    getattr(model_config, "glm_dsa_args", None), "index_kpool", 1) or 1),
                 num_pages=num_pages,
                 page_size=page_size,
                 dtype=dtype,
@@ -223,6 +226,7 @@ def create_kvcache_pool(
         return MLAKVCache(
             latent_dim=spec.head_dim,
             num_layers=model_config.num_layers,
+            layer_ids=layer_ids,
             num_pages=num_pages,
             page_size=page_size,
             dtype=dtype,

--- a/python/freetoken/kvcache/dsa_pool.py
+++ b/python/freetoken/kvcache/dsa_pool.py
@@ -37,13 +37,28 @@ class MLAKVCache(BaseKVCachePool):
         page_size: int,
         dtype: torch.dtype,
         device: torch.device,
+        layer_ids=None,
     ) -> None:
         self._latent_dim = latent_dim
+        # Hybrid linear-attention models (GLM-5.3: 34 KDA + 11 MLA/DSA) back only the
+        # full-attention layers here; ``layer_ids`` remaps global layer id -> dense slab
+        # (MHAKVCache pattern), so the (majority) linear layers cost no latent slab.
+        if layer_ids is None:
+            self._layer_map = None
+        else:
+            num_layers = len(layer_ids)
+            m = [-1] * (max(layer_ids) + 1)
+            for dense, g in enumerate(layer_ids):
+                m[g] = dense
+            self._layer_map = m
         self._num_layers = num_layers
         self._page_size = page_size
         self._dtype = dtype
         self._device = device
         self._alloc(num_pages)
+
+    def _dense(self, layer_id: int) -> int:
+        return layer_id if self._layer_map is None else self._layer_map[layer_id]
 
     def _alloc(self, num_pages: int) -> None:
         self._num_pages = num_pages
@@ -56,7 +71,7 @@ class MLAKVCache(BaseKVCachePool):
     # -- views ------------------------------------------------------------------
     def k_cache(self, layer_id: int) -> torch.Tensor:
         """Paged latent view ``[num_pages, page_size, latent_dim]``."""
-        return self._kv_buffer[0, layer_id].view(self._num_pages, self._page_size, -1)
+        return self._kv_buffer[0, self._dense(layer_id)].view(self._num_pages, self._page_size, -1)
 
     def v_cache(self, layer_id: int) -> torch.Tensor:
         # MLA: K == V (single latent); same buffer, dsv4_paged_pool precedent.
@@ -64,7 +79,7 @@ class MLAKVCache(BaseKVCachePool):
 
     def latent_rows(self, layer_id: int) -> torch.Tensor:
         """Row-flat latent view ``[num_pages * page_size, latent_dim]``."""
-        return self._kv_buffer[0, layer_id].view(-1, self._latent_dim)
+        return self._kv_buffer[0, self._dense(layer_id)].view(-1, self._latent_dim)
 
     # -- writes -----------------------------------------------------------------
     def store_kv(
@@ -141,10 +156,13 @@ class DSAKVCache(MLAKVCache):
         device: torch.device,
         index_head_dim: int,
         num_index_layers: int,
+        layer_ids=None,
+        index_kpool: int = 1,
     ) -> None:
         self._index_head_dim = index_head_dim
         self._num_index_layers = num_index_layers
-        super().__init__(latent_dim, num_layers, num_pages, page_size, dtype, device)
+        self._index_kpool = index_kpool
+        super().__init__(latent_dim, num_layers, num_pages, page_size, dtype, device, layer_ids=layer_ids)
 
     def _alloc(self, num_pages: int) -> None:
         # Both slabs in one allocation step: rebuild can never leave the pool with a
@@ -159,9 +177,20 @@ class DSAKVCache(MLAKVCache):
             dtype=torch.bfloat16,
             device=self._device,
         )
+        # k-pool (GLM-5.3): raw gate-score slab (same row addressing as the key slab) and
+        # the pooled-key slab, where pool p's key is stored at the PHYSICAL ROW OF ITS FIRST
+        # TOKEN (rows[kpool*p]); scoring gathers via the strided pool-row snapshot.
+        if self._index_kpool > 1:
+            self._gate_buffer = torch.zeros_like(self._index_k_buffer)
+            self._pool_k_buffer = torch.zeros_like(self._index_k_buffer)
+        else:
+            self._gate_buffer = None
+            self._pool_k_buffer = None
 
     def rebuild(self, num_pages: int) -> None:
         self._index_k_buffer = None
+        self._gate_buffer = None
+        self._pool_k_buffer = None
         super().rebuild(num_pages)
 
     def unit_bytes(self) -> tuple[int, int]:
@@ -170,7 +199,13 @@ class DSAKVCache(MLAKVCache):
         kv, swa = super().unit_bytes()
         idx = self._index_k_buffer
         tokens = self._num_pages * self._page_size
-        return kv + int(idx.numel() * idx.element_size()) // tokens, swa
+        per = int(idx.numel() * idx.element_size()) // tokens
+        # k-pool slabs (gate + pooled keys) ride the same token budget -- count them or the
+        # sizing pass over-allocates and the alloc OOMs (caught by the dummy e2e run).
+        if self._gate_buffer is not None:
+            per += int(self._gate_buffer.numel() * self._gate_buffer.element_size()) // tokens
+            per += int(self._pool_k_buffer.numel() * self._pool_k_buffer.element_size()) // tokens
+        return kv + per, swa
 
     def index_k_cache(self, slot: int) -> torch.Tensor:
         """Row-flat index keys for a full-indexer layer slot: ``[rows, index_head_dim]``."""
@@ -178,6 +213,20 @@ class DSAKVCache(MLAKVCache):
 
     def store_index_k(self, k: torch.Tensor, out_loc: torch.Tensor, slot: int) -> None:
         self._index_k_buffer[slot][out_loc] = k
+
+    # ----- k-pool slabs (GLM-5.3; None-guarded when index_kpool == 1) -----
+    def gate_cache(self, slot: int) -> torch.Tensor:
+        return self._gate_buffer[slot]
+
+    def store_gate(self, g: torch.Tensor, out_loc: torch.Tensor, slot: int) -> None:
+        self._gate_buffer[slot][out_loc] = g
+
+    def pool_k_cache(self, slot: int) -> torch.Tensor:
+        return self._pool_k_buffer[slot]
+
+    def store_pool_k(self, k: torch.Tensor, rows: torch.Tensor, slot: int) -> None:
+        """Scatter pooled keys at the pools' first-token physical rows (int64 rows)."""
+        self._pool_k_buffer[slot][rows] = k
 
 
 __all__ = ["MLAKVCache", "DSAKVCache"]

--- a/python/freetoken/message/backend.py
+++ b/python/freetoken/message/backend.py
@@ -37,6 +37,10 @@ class UserMsg(BaseBackendMsg):
     # Optional precomputed multimodal soft-token embeddings (GPU tensor). Only used by
     # the in-process offline path; remains None for the (serialized) online path.
     mm_embeds: torch.Tensor | None = None
+    # Online vision path: per-image {"pix": fp32 bytes [P*D], "grid": [t, gh, gw]}
+    # dicts (the msgpack codec carries primitives/bytes only). The scheduler -- which
+    # owns the model/GPU -- decodes and encodes them into mm_embeds at admission.
+    mm_images: list | None = None
 
 
 @dataclass

--- a/python/freetoken/message/tokenizer.py
+++ b/python/freetoken/message/tokenizer.py
@@ -72,6 +72,10 @@ class TokenizeMsg(BaseTokenizerMsg):
     sampling_params: SamplingParams
     chat_template_kwargs: Dict[str, Any] | None = None
     tools: List[Dict[str, Any]] | None = None
+    # Preprocessed images in template order: list of (pixel_values np [P, D] fp32,
+    # grid (t, gh, gw)). The tokenize worker expands the k-th <|image|> placeholder
+    # to that image's token count and forwards the pixels on the UserMsg.
+    images: List[Any] | None = None
 
 
 @dataclass

--- a/python/freetoken/models/config.py
+++ b/python/freetoken/models/config.py
@@ -316,6 +316,8 @@ class ModelConfig:
     # n-gram embedding geometry and the QSA indexer scoring geometry the model module
     # needs. Opaque to model-agnostic engine code; None for every other model.
     qwen4_args: Any | None = None
+    # GLM-5.3-Flash (glm5_next) payload (Glm5NextArgs): hc / KDA / MLA-DSA / MoE / split.
+    glm5_args: Any | None = None
     # Generic execution-path capability flags (set by a model's parse_config) so the engine and
     # factories stay model-agnostic instead of branching on dsv4_args:
     single_stream_only: bool = False  # model runs one sequence at a time -> force bs=1
@@ -329,12 +331,22 @@ class ModelConfig:
 
     @property
     def num_moe_layers(self) -> int:
-        """Number of layers that own a sparse MoE block (and offload-cache expert slots).
+        """Number of layers served from the OFFLOAD expert cache (host banks + slots).
 
         Models with leading dense layers (``first_k_dense_replace`` > 0, e.g. GLM-4)
-        only store experts for the trailing layers; everything else has all layers MoE.
+        only store experts for the trailing layers. GLM-5.3's hotness-driven split
+        additionally keeps ``glm5_args.resident_layer_ids`` fully on the GPU as model
+        weights -- those layers own no host bank and no cache slots, so every consumer
+        of this count (bank builder, offload cache, cost estimates) excludes them.
         """
-        return self.num_layers - self.first_k_dense_replace
+        n = self.num_layers - self.first_k_dense_replace
+        g5 = getattr(self, "glm5_args", None)
+        if g5 is not None:
+            n -= sum(
+                1 for l in g5.resident_layer_ids
+                if self.first_k_dense_replace <= l < self.num_layers
+            )
+        return n
 
     @property
     def is_multimodal(self) -> bool:

--- a/python/freetoken/models/glm5_next/__init__.py
+++ b/python/freetoken/models/glm5_next/__init__.py
@@ -1,0 +1,20 @@
+"""GLM-5.3-Flash (glm5_next): hybrid KDA+MLA/DSA attention, mHC hyper-connections,
+NVFP4 experts with a VRAM/host residency split. Text-only serving.
+
+Milestone build: config parse is live; the model / weight-loader modules land next, so
+`model`-level names are imported lazily to keep `parse_config` usable on its own.
+"""
+
+from .args import Glm5NextArgs, KdaArgs, load_args
+from .config import parse_config
+from .model import Glm5NextForCausalLM
+from .weight import (
+    iter_weights,
+    load_nvfp4_expert_sources,
+    load_nvfp4_expert_sources_parallel,
+)
+
+__all__ = [
+    "Glm5NextArgs", "KdaArgs", "load_args", "parse_config", "Glm5NextForCausalLM",
+    "iter_weights", "load_nvfp4_expert_sources", "load_nvfp4_expert_sources_parallel",
+]

--- a/python/freetoken/models/glm5_next/args.py
+++ b/python/freetoken/models/glm5_next/args.py
@@ -1,0 +1,203 @@
+"""GLM-5.3-Flash (``glm5_next``) hyperparameters.
+
+GLM-5.3-Flash is a hybrid-attention MoE with manifold-constrained Hyper-Connections:
+  * 45 layers, ``layer_types`` = 34 KDA (linear_attention) + 11 MLA+DSA (deepseek_sparse).
+  * MLA is NoPE here (``qk_rope_head_dim == 0``, ``mla_use_nope``); DSA adds a Lightning
+    indexer with a k-pool compressor (``index_kpool``).
+  * KDA = gated-delta linear attention (``linear_attn_config``): 64 heads x 128 head_dim,
+    a short conv (kernel 4) and a lower-bounded forget gate.
+  * mHC (``hc_mult`` = 4 residual streams, sinkhorn iters 20) -- identical knobs to DSV4,
+    so the DSV4 hyper-connection machinery is reused verbatim.
+  * MoE: 288 routed / top-8 / 1 shared, first 3 layers dense; sigmoid noaux_tc router.
+
+Fields live under ``config.text_config`` (multimodal wrapper); we serve text-only. This
+payload is stashed on ``ModelConfig.glm_dsa_args`` (DSA/MLA dims, opaque to the engine) plus
+``ModelConfig.glm5_kda`` / hyper-connection fields carried on ModelConfig directly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Tuple
+
+
+def _parse_resident_env() -> Tuple[int, ...]:
+    """FREETOKEN_GLM5_RESIDENT_LAYERS: comma list and/or a-b ranges, e.g. "17-24" or
+    "3,17-20". Empty/unset = no resident layers (pure offload)."""
+    raw = os.environ.get("FREETOKEN_GLM5_RESIDENT_LAYERS", "").strip()
+    if not raw:
+        return ()
+    out = []
+    for part in raw.split(","):
+        part = part.strip()
+        if "-" in part:
+            a, b = part.split("-")
+            out.extend(range(int(a), int(b) + 1))
+        elif part:
+            out.append(int(part))
+    return tuple(sorted(set(out)))
+
+
+def _text(hf_config: Any) -> Any:
+    """GLM-5.3 puts the language tower under text_config; tolerate a flat config too."""
+    return getattr(hf_config, "text_config", None) or hf_config
+
+
+@dataclass(frozen=True)
+class KdaArgs:
+    """Gated-delta (KDA) linear-attention dims for the 34 linear layers."""
+    num_heads: int
+    head_dim: int
+    short_conv_kernel_size: int
+    gate_lower_bound: float
+
+
+@dataclass(frozen=True)
+class Glm5NextArgs:
+    # ---- basic ----
+    hidden_size: int
+    num_layers: int
+    num_heads: int
+    num_kv_heads: int
+    vocab_size: int
+    intermediate_size: int          # dense MLP (first_k_dense_replace layers)
+    hidden_act: str
+    norm_eps: float
+    max_position: int
+    tie_word_embeddings: bool
+    # ---- hyper-connections (mHC) -- same knobs as DSV4 ----
+    hc_mult: int
+    hc_sinkhorn_iters: int
+    hc_eps: float
+    # ---- MLA (11 full layers) ----
+    q_lora_rank: int
+    kv_lora_rank: int
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    mla_use_nope: bool
+    rope_theta: float
+    # ---- DSA indexer (Lightning + k-pool compress) ----
+    index_n_heads: int
+    index_head_dim: int
+    index_topk: int
+    index_kpool: int
+    index_kpool_always_select_tail: bool
+    index_kpool_compress: bool
+    indexer_rope_interleave: bool
+    indexer_types: Tuple[str, ...]
+    # ---- KDA (34 linear layers) ----
+    kda: KdaArgs
+    # ---- hybrid layout (explicit layer-id lists from linear_attn_config) ----
+    layer_types: Tuple[str, ...]
+    kda_layer_ids: Tuple[int, ...]
+    full_layer_ids: Tuple[int, ...]
+    # ---- MoE ----
+    n_routed_experts: int
+    num_experts_per_tok: int
+    n_shared_experts: int
+    moe_intermediate_size: int
+    first_k_dense_replace: int
+    routed_scaling_factor: float
+    n_group: int
+    topk_group: int
+    norm_topk_prob: bool
+    scoring_func: str
+    topk_method: str
+    swiglu_limit: float
+    # Hotness-driven VRAM/host split: these MoE layers keep their FULL packed expert
+    # banks on the GPU (ResidentNvfp4Experts) and are skipped by the host bank builder.
+    resident_layer_ids: Tuple[int, ...] = ()
+    # KDA fp8: quantize in_proj_qkv/o_proj of the 34 KDA layers to fp8-e4m3 per-row
+    # at load (FREETOKEN_GLM5_KDA_FP8=1). ~4.5GB less VRAM read per decode step.
+    kda_fp8: bool = False
+    # MTP self-speculative decoding: serve the checkpoint's layer-45 MTP block
+    # (FREETOKEN_GLM5_MTP=1). Its MLA/DSA attention gets its own DSA-pool slab slot.
+    mtp_enabled: bool = False
+    mtp_layer_id: int = 45
+
+    @property
+    def qk_head_dim(self) -> int:
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+    def is_kda_layer(self, layer_id: int) -> bool:
+        return layer_id in self.kda_layer_ids
+
+    def is_full_layer(self, layer_id: int) -> bool:
+        return layer_id in self.full_layer_ids
+
+    def is_dense_layer(self, layer_id: int) -> bool:
+        return layer_id < self.first_k_dense_replace
+
+
+def load_args(hf_config: Any) -> Glm5NextArgs:
+    t = _text(hf_config)
+    lac = getattr(t, "linear_attn_config", None) or {}
+    if not isinstance(lac, dict):  # transformers may wrap it in an object
+        lac = {k: getattr(lac, k) for k in ("num_heads", "head_dim", "short_conv_kernel_size",
+               "gate_lower_bound", "kda_layers", "full_attn_layers") if hasattr(lac, k)}
+    rope = getattr(t, "rope_parameters", None) or {}
+    rope_theta = float(rope.get("rope_theta", getattr(t, "rope_theta", 10000.0)))
+    layer_types = tuple(getattr(t, "layer_types", ()) or ())
+    kda_ids = tuple(lac.get("kda_layers", [])
+                    or [i for i, x in enumerate(layer_types) if x == "linear_attention"])
+    full_ids = tuple(lac.get("full_attn_layers", [])
+                     or [i for i, x in enumerate(layer_types) if x != "linear_attention"])
+    return Glm5NextArgs(
+        hidden_size=t.hidden_size,
+        num_layers=t.num_hidden_layers,
+        num_heads=t.num_attention_heads,
+        num_kv_heads=int(getattr(t, "num_key_value_heads", t.num_attention_heads)),
+        vocab_size=t.vocab_size,
+        intermediate_size=t.intermediate_size,
+        hidden_act=getattr(t, "hidden_act", "silu"),
+        norm_eps=t.rms_norm_eps,
+        max_position=int(getattr(t, "max_position_embeddings", 1048576)),
+        tie_word_embeddings=bool(getattr(t, "tie_word_embeddings", False)),
+        hc_mult=int(getattr(t, "hc_mult", 4)),
+        hc_sinkhorn_iters=int(getattr(t, "hc_sinkhorn_iters", 20)),
+        hc_eps=float(getattr(t, "hc_eps", 1e-6)),
+        q_lora_rank=int(t.q_lora_rank),
+        kv_lora_rank=int(t.kv_lora_rank),
+        qk_nope_head_dim=int(getattr(t, "qk_nope_head_dim", 0)),
+        qk_rope_head_dim=int(getattr(t, "qk_rope_head_dim", 0)),
+        v_head_dim=int(getattr(t, "v_head_dim", 0)),
+        mla_use_nope=bool(getattr(t, "mla_use_nope", False)),
+        rope_theta=rope_theta,
+        index_n_heads=int(getattr(t, "index_n_heads", 0)),
+        index_head_dim=int(getattr(t, "index_head_dim", 0)),
+        index_topk=int(getattr(t, "index_topk", 0)),
+        index_kpool=int(getattr(t, "index_kpool", 1)),
+        index_kpool_always_select_tail=bool(getattr(t, "index_kpool_always_select_tail", True)),
+        index_kpool_compress=bool(getattr(t, "index_kpool_compress", True)),
+        indexer_rope_interleave=bool(getattr(t, "indexer_rope_interleave", True)),
+        indexer_types=tuple(getattr(t, "indexer_types", ()) or ()),
+        kda=KdaArgs(
+            num_heads=int(lac.get("num_heads", t.num_attention_heads)),
+            head_dim=int(lac.get("head_dim", 128)),
+            short_conv_kernel_size=int(lac.get("short_conv_kernel_size", 4)),
+            gate_lower_bound=float(lac.get("gate_lower_bound", -5.0)),
+        ),
+        layer_types=layer_types,
+        kda_layer_ids=kda_ids,
+        full_layer_ids=full_ids,
+        n_routed_experts=int(getattr(t, "n_routed_experts", 0)),
+        num_experts_per_tok=int(t.num_experts_per_tok),
+        n_shared_experts=int(getattr(t, "n_shared_experts", 0)),
+        moe_intermediate_size=int(getattr(t, "moe_intermediate_size", 0) or t.intermediate_size),
+        first_k_dense_replace=int(getattr(t, "first_k_dense_replace", 0)),
+        routed_scaling_factor=float(getattr(t, "routed_scaling_factor", 1.0)),
+        n_group=int(getattr(t, "n_group", 1)),
+        topk_group=int(getattr(t, "topk_group", 1)),
+        norm_topk_prob=bool(getattr(t, "norm_topk_prob", True)),
+        scoring_func=str(getattr(t, "scoring_func", "sigmoid")),
+        topk_method=str(getattr(t, "topk_method", "noaux_tc")),
+        swiglu_limit=float(getattr(t, "swiglu_limit", 0.0)),
+        resident_layer_ids=_parse_resident_env(),
+        kda_fp8=os.environ.get("FREETOKEN_GLM5_KDA_FP8", "0") == "1",
+        mtp_enabled=os.environ.get("FREETOKEN_GLM5_MTP", "0") == "1",
+    )
+
+
+__all__ = ["Glm5NextArgs", "KdaArgs", "load_args"]

--- a/python/freetoken/models/glm5_next/attention.py
+++ b/python/freetoken/models/glm5_next/attention.py
@@ -1,0 +1,331 @@
+"""GLM-5.3-Flash hybrid-attention mixers.
+
+* full layers (deepseek_sparse_attention) -> glm_moe_dsa's MLA+DSA attention verbatim
+  (NoPE: qk_rope_head_dim == 0, rope guards are in glm_moe_dsa/attention.py).
+* linear layers (linear_attention) -> KDA (Kimi Delta Attention), verified against the HF
+  reference ``Glm5NextTextLinearAttention`` symbol-by-symbol:
+
+    - separate q/k/v projections (served as one merged GEMM; the loader concatenates
+      [q|k|v] in HF's own ``torch.cat`` channel order, so the depthwise conv sees the
+      exact reference channel layout);
+    - depthwise causal conv (kernel 4, no bias, silu) over the qkv concat;
+    - ForgetGate: ``g = lower_bound * sigmoid(exp(A_log) * (f_b(f_a(x)) + dt_bias))``
+      -- per-CHANNEL ([heads, head_dim]) log-space decay, computed here in fp32
+      EXACTLY as the HF reference (which also precomputes g outside its kernels);
+    - ``beta = sigmoid(b_proj(x))`` per-head, fp32 (HF does the same outside);
+    - delta rule via the upstream fla KDA kernels (``chunk_kda`` prefill,
+      ``fused_recurrent_kda`` decode) with ``use_qk_l2norm_in_kernel=True`` -- the same
+      kernels/flags the HF integration uses, fed the same precomputed ``g``/``beta``;
+    - output gate ``z = g_b(g_a(x))`` through a sigmoid-gated RMSNorm (HF RMSNormGated
+      with activation="sigmoid"), then ``o_proj``.
+
+  State lives in ``ctx.linear_state_pool`` (slot per request). The upstream fla kernels
+  take a contiguous ``initial_state`` instead of slot indices, so we gather the slots
+  before the call and scatter the final state back after. CUDA-graph hygiene: the
+  gather/scatter are ``index_select``/``index_copy_`` on a FIXED-ADDRESS index buffer
+  (``fla.cache_indices``) with capture-static shapes -- replays read the refreshed index
+  values, same contract the vendored slot-indexed kernels rely on.
+"""
+
+from __future__ import annotations
+
+import os as _os
+
+import torch
+import torch.nn.functional as F
+
+from freetoken.core import get_global_ctx
+from freetoken.kernel.causal_conv1d import causal_conv1d_decode, causal_conv1d_varlen
+from freetoken.layers import BaseOP, LinearColParallelMerged, LinearReplicated
+from freetoken.models.config import ModelConfig
+from freetoken.models.glm_moe_dsa.attention import GlmMoeDsaAttention
+from freetoken.models.qwen3_5_moe.gdn import _DepthwiseConv1d
+
+# Full (MLA + DSA) layers: ModelConfig.glm_dsa_args carries the derived GlmMoeDsaArgs.
+FullAttention = GlmMoeDsaAttention
+
+
+class _SigmoidGatedRMSNorm(BaseOP):
+    """RMSNorm(x) * sigmoid(z), fused (HF Glm5NextTextRMSNormGated, activation='sigmoid')."""
+
+    def __init__(self, dim: int, eps: float):
+        self.weight = torch.empty(dim)
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        from freetoken.kernel.fla import rms_norm_gated
+
+        return rms_norm_gated(
+            x=x, weight=self.weight, bias=None, z=z, eps=self.eps,
+            is_rms_norm=True, norm_before_gate=True, activation="sigmoid",
+        )
+
+
+class KdaAttention(BaseOP):
+    """KDA linear attention for GLM-5.3's 34 linear layers (structure == HF reference)."""
+
+    def __init__(self, config: ModelConfig, layer_id: int):
+        a = config.glm5_args
+        kda = a.kda
+        self.layer_id = layer_id
+        self.hidden_size = a.hidden_size
+        self.num_heads = kda.num_heads          # 64
+        self.head_dim = kda.head_dim            # 128
+        self.qkv_dim = self.num_heads * self.head_dim  # 8192
+        self.conv_dim = 3 * self.qkv_dim        # 24576 == pool's 2*key_dim+value_dim
+        self.conv_kernel_size = kda.short_conv_kernel_size
+        self.gate_lower_bound = kda.gate_lower_bound  # -5.0
+
+        # Merged [q|k|v] projection -- HF cat order, so conv channels match the reference.
+        # KDA fp8 (per-row): only the two big GEMMs; q/k pass the kernel's l2norm, so
+        # their quant scale error largely cancels.
+        if a.kda_fp8:
+            from freetoken.kernel.triton.fp8_pertensor_linear import (
+                Fp8PerTensorColMerged, Fp8PerTensorLinear,
+            )
+
+            self.in_proj_qkv = Fp8PerTensorColMerged(
+                self.hidden_size, [self.qkv_dim, self.qkv_dim, self.qkv_dim], has_bias=False
+            )
+        else:
+            self.in_proj_qkv = LinearColParallelMerged(
+                self.hidden_size, [self.qkv_dim, self.qkv_dim, self.qkv_dim], has_bias=False
+            )
+        self.conv1d = _DepthwiseConv1d(self.conv_dim, self.conv_kernel_size)
+
+        # ForgetGate (low-rank) + input gate + output gate (low-rank) -- bf16 GEMMs,
+        # gate math in fp32 (matches HF's .float() upcasts).
+        self.f_a_proj = LinearReplicated(self.hidden_size, self.head_dim, has_bias=False)
+        self.f_b_proj = LinearReplicated(self.head_dim, self.qkv_dim, has_bias=False)
+        self.dt_bias = torch.empty(self.qkv_dim, dtype=torch.float32)
+        self.A_log = torch.empty(self.num_heads, dtype=torch.float32)
+        self.b_proj = LinearReplicated(self.hidden_size, self.num_heads, has_bias=False)
+        self.g_a_proj = LinearReplicated(self.hidden_size, self.head_dim, has_bias=False)
+        self.g_b_proj = LinearReplicated(self.head_dim, self.qkv_dim, has_bias=False)
+        self.o_norm = _SigmoidGatedRMSNorm(self.head_dim, eps=a.norm_eps)
+        if a.kda_fp8:
+            from freetoken.kernel.triton.fp8_pertensor_linear import Fp8PerTensorLinear
+
+            self.o_proj: object = Fp8PerTensorLinear(
+                self.qkv_dim, self.hidden_size, has_bias=False
+            )
+        else:
+            self.o_proj = LinearReplicated(self.qkv_dim, self.hidden_size, has_bias=False)
+
+    # ---- gate math: EXACT HF ForgetGate (fp32) --------------------------------------
+    def _forget_gate(self, x: torch.Tensor) -> torch.Tensor:
+        """[total, hidden] -> per-channel log-decay g [total, heads, head_dim] fp32."""
+        raw = self.f_b_proj.forward(self.f_a_proj.forward(x))
+        g = raw.float() + self.dt_bias.view(1, -1)
+        g = g.view(-1, self.num_heads, self.head_dim)
+        decay = torch.exp(self.A_log.float()).view(1, self.num_heads, 1)
+        return self.gate_lower_bound * torch.sigmoid(decay * g)
+
+    # ---- fused gate path (2026-08-28): merged stage-1 GEMV + batched stage-2 bmm ----
+    # f_a/g_a/b share input x -> one [2*hd+H, hidden] GEMV; f_b/g_b -> one bmm.
+    # 5 cublas calls + ~7 fp32 elementwise per layer collapse to 3 kernels.
+    def _build_gate_merge(self) -> None:
+        w1 = torch.cat(
+            [self.f_a_proj.weight, self.g_a_proj.weight, self.b_proj.weight], 0
+        ).contiguous()                                      # [2*hd + H, hidden]
+        w2t = torch.stack(
+            [self.f_b_proj.weight, self.g_b_proj.weight]
+        ).transpose(1, 2).contiguous()                      # [2, hd, qkv]
+        decay = torch.exp(self.A_log.float()).contiguous()  # [H], cached (was per-step)
+        self._gate_merged = (w1, w2t, decay)
+
+    def _gates_fused(self, x: torch.Tensor):
+        """Same math as _forget_gate + b/g chains. Lazy build runs on the first
+        (uncaptured) forward, so CUDA-graph capture sees only fixed-shape kernels."""
+        from freetoken.kernel.triton.kda_gate import kda_gate
+
+        merged = getattr(self, "_gate_merged", None)
+        if merged is None:
+            self._build_gate_merge()
+            merged = self._gate_merged
+        w1, w2t, decay = merged
+        total = x.shape[0]
+        hd = self.head_dim
+        s1 = F.linear(x, w1)                                # [total, 2*hd + H]
+        # [2, total, hd] view over s1 cols [0:2*hd] -- no copy (strided bmm input)
+        a2 = s1.as_strided((2, total, hd), (hd, s1.stride(0), 1))
+        r2 = torch.bmm(a2, w2t)                             # [2, total, qkv]
+        g, beta = kda_gate(
+            r2[0], s1[:, 2 * hd:], self.dt_bias, decay, self.gate_lower_bound)
+        return g, beta, r2[1]
+
+    # ---- conv helpers (same pool contract as the GDN path) --------------------------
+    def _conv_weight(self) -> torch.Tensor:
+        return self.conv1d.weight.squeeze(1)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        import os as _os
+        if _os.environ.get("FREETOKEN_GLM5_STUB_KDA", "0") == "1":  # ablation timing only
+            return torch.zeros_like(hidden_states)
+        from fla.ops.kda import chunk_kda, fused_recurrent_kda
+
+        ctx = get_global_ctx()
+        batch = ctx.batch
+        pool = ctx.linear_state_pool
+        total = hidden_states.shape[0]
+        dtype = hidden_states.dtype
+
+        fla_md = batch.fla_metadata
+        if fla_md is None:
+            from freetoken.attention.linear import build_fla_metadata
+
+            fla_md = build_fla_metadata(batch, hidden_states.device)
+            batch.fla_metadata = fla_md
+
+        conv_in = self.in_proj_qkv.forward(hidden_states)  # [total, 3*qkv] = [q|k|v]
+        if _os.environ.get("FREETOKEN_KDA_FUSED_GATE", "1") == "1":
+            g, beta, z = self._gates_fused(hidden_states)  # ~12 kernels -> 3
+        else:
+            g = self._forget_gate(hidden_states)               # [total, H, K] fp32
+            beta = torch.sigmoid(self.b_proj.forward(hidden_states).float())  # [total, H]
+            z = self.g_b_proj.forward(self.g_a_proj.forward(hidden_states))   # [total, qkv]
+
+        li = pool.local_index(self.layer_id)
+        rec = pool.recurrent_states[li]  # [slots, H, K, V] fp32
+        idx = fla_md.cache_indices
+        # index_select/index_copy_ need int64; the cast kernel re-reads the (refreshed)
+        # int32 buffer on every CUDA-graph replay, so this stays graph-safe.
+        idx_l = idx.long()
+
+        if getattr(batch, "spec_stash", None) is not None:
+            # Speculative VERIFY: the batch is k+1 single-token fake reqs of ONE request
+            # at sequential positions. Run conv+delta as ONE varlen sequence (exact
+            # sequential semantics) and archive inputs + pre-states so spec_commit can
+            # re-derive the state at the accepted prefix (the fla kernels only expose
+            # the final state).
+            dev = conv_in.device
+            # Slot id via the REFRESHED device buffer (graph-safe: a captured verify
+            # graph re-reads it each replay; a host int would be baked at capture).
+            if batch.linear_table_idx is not None:
+                idx1 = batch.linear_table_idx[:1]
+            else:
+                idx1 = torch.tensor(
+                    [batch.reqs[0].table_idx], dtype=torch.int32, device=dev)
+            idx1_l = idx1.long()
+            # Constants cached per verify width: torch.tensor(list) is an UNPINNED H2D
+            # copy, illegal inside CUDA graph capture. The warm (uncaptured) forward
+            # populates the cache; the captured run hits it with zero host traffic.
+            consts = getattr(self, "_spec_consts", None)
+            if consts is None:
+                consts = self._spec_consts = {}
+            if total not in consts:
+                consts[total] = (
+                    torch.tensor([0, total], dtype=torch.int32, device=dev),
+                    torch.ones(1, dtype=torch.bool, device=dev),
+                )
+            cu, has_init = consts[total]
+            conv_before = pool.conv_states[li].index_select(0, idx1_l).clone()
+            rec_before = rec.index_select(0, idx1_l)  # a copy
+            x_c = conv_in.transpose(0, 1).contiguous()
+            mixed = causal_conv1d_varlen(
+                x_c, self._conv_weight(), pool.conv_states[li], cu, idx1, has_init,
+            ).transpose(0, 1)
+            qf, kf, vf = torch.split(mixed, [self.qkv_dim] * 3, dim=-1)
+            q = qf.reshape(1, total, self.num_heads, self.head_dim).to(dtype)
+            k = kf.reshape(1, total, self.num_heads, self.head_dim).to(dtype)
+            v = vf.reshape(1, total, self.num_heads, self.head_dim).to(dtype)
+            gv = g.view(1, total, self.num_heads, self.head_dim)
+            bv = beta.view(1, total, self.num_heads)
+            # fused_recurrent (not chunk): the SAME sequential-scan kernel the decode
+            # path uses, so verify outputs / spec_commit / plain decode stay bit-aligned.
+            core, state = fused_recurrent_kda(
+                q=q, k=k, v=v, g=gv, beta=bv,
+                scale=self.head_dim ** -0.5,
+                initial_state=rec_before.clone(), output_final_state=True,
+                use_qk_l2norm_in_kernel=True, cu_seqlens=cu,
+            )
+            rec.index_copy_(0, idx1_l, state.to(rec.dtype))
+            batch.spec_stash[self.layer_id] = dict(
+                q=q, k=k, v=v, g=gv, beta=bv,
+                rec_before=rec_before, conv_before=conv_before, conv_in=conv_in,
+            )
+        elif batch.is_decode:
+            mixed = causal_conv1d_decode(conv_in, pool.conv_states[li], self._conv_weight(), idx)
+            B = mixed.shape[0]
+            qf, kf, vf = torch.split(mixed, [self.qkv_dim] * 3, dim=-1)
+            q = qf.reshape(1, B, self.num_heads, self.head_dim).to(dtype)
+            k = kf.reshape(1, B, self.num_heads, self.head_dim).to(dtype)
+            v = vf.reshape(1, B, self.num_heads, self.head_dim).to(dtype)
+            state = rec.index_select(0, idx_l)  # gather (fixed-address idx buffer: graph-safe)
+            core, state = fused_recurrent_kda(
+                q=q, k=k, v=v,
+                g=g.view(1, B, self.num_heads, self.head_dim),
+                beta=beta.view(1, B, self.num_heads),
+                scale=self.head_dim ** -0.5,
+                initial_state=state, output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                # varlen: B one-token sequences (cu_seqlens = arange(B+1)); without this the
+                # kernel would treat the batch as ONE sequence of B timesteps and return a
+                # single merged state (caught by the bs=2 graph-capture regression).
+                cu_seqlens=fla_md.cu_seqlens,
+            )
+            rec.index_copy_(0, idx_l, state.to(rec.dtype))  # scatter back
+        else:
+            if fla_md.fresh_state_indices is not None:
+                rec.index_fill_(0, fla_md.fresh_state_indices, 0.0)
+            x_c = conv_in.transpose(0, 1).contiguous()
+            mixed = causal_conv1d_varlen(
+                x_c, self._conv_weight(), pool.conv_states[li],
+                fla_md.cu_seqlens, idx, fla_md.has_initial_state,
+            ).transpose(0, 1)
+            qf, kf, vf = torch.split(mixed, [self.qkv_dim] * 3, dim=-1)
+            q = qf.reshape(1, total, self.num_heads, self.head_dim).to(dtype)
+            k = kf.reshape(1, total, self.num_heads, self.head_dim).to(dtype)
+            v = vf.reshape(1, total, self.num_heads, self.head_dim).to(dtype)
+            state = rec.index_select(0, idx_l)
+            core, state = chunk_kda(
+                q=q, k=k, v=v,
+                g=g.view(1, total, self.num_heads, self.head_dim),
+                beta=beta.view(1, total, self.num_heads),
+                scale=self.head_dim ** -0.5,
+                initial_state=state, output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=fla_md.cu_seqlens,
+            )
+            rec.index_copy_(0, idx_l, state.to(rec.dtype))
+
+        core = core.reshape(-1, self.head_dim)
+        z = z.reshape(-1, self.head_dim)
+        out = self.o_norm.forward(core, z).reshape(total, -1)
+        return self.o_proj.forward(out.to(dtype))
+
+    @torch.inference_mode()
+    def spec_restore(self, st: dict, slot: int) -> None:
+        """Roll this layer back to the archived pre-verify state (KL replay mode)."""
+        pool = get_global_ctx().linear_state_pool
+        li = pool.local_index(self.layer_id)
+        pool.recurrent_states[li][slot] = st["rec_before"][0]
+        pool.conv_states[li][slot] = st["conv_before"][0]
+
+    @torch.inference_mode()
+    def spec_commit(self, st: dict, keep: int, slot: int) -> None:
+        """Re-commit recurrent+conv state at the accepted prefix (``keep`` of the
+        archived verify tokens), from the archived pre-verify state. Post-conv
+        q/k/v of accepted tokens are causal (independent of rejected ones), so a
+        single fused_recurrent over the archive is exact."""
+        from fla.ops.kda import fused_recurrent_kda
+
+        ctx = get_global_ctx()
+        pool = ctx.linear_state_pool
+        li = pool.local_index(self.layer_id)
+        cu = torch.tensor([0, keep], dtype=torch.int32, device=st["q"].device)
+        _, state = fused_recurrent_kda(
+            q=st["q"][:, :keep].contiguous(), k=st["k"][:, :keep].contiguous(),
+            v=st["v"][:, :keep].contiguous(),
+            g=st["g"][:, :keep].contiguous(), beta=st["beta"][:, :keep].contiguous(),
+            scale=self.head_dim ** -0.5,
+            initial_state=st["rec_before"].clone(), output_final_state=True,
+            use_qk_l2norm_in_kernel=True, cu_seqlens=cu,
+        )
+        rec = pool.recurrent_states[li]
+        rec[slot] = state[0].to(rec.dtype)
+        win = torch.cat([st["conv_before"][0], st["conv_in"][:keep].t()], dim=1)
+        pool.conv_states[li][slot] = win[:, -(self.conv_kernel_size - 1):]
+
+
+__all__ = ["FullAttention", "KdaAttention"]

--- a/python/freetoken/models/glm5_next/config.py
+++ b/python/freetoken/models/glm5_next/config.py
@@ -37,6 +37,7 @@ from .args import Glm5NextArgs, load_args
 # Non-expert FP8: default OFF (bf16 quality baseline). Turn on after the bf16 run is the A/B
 # reference. lm_head stays bf16 even when MLP_FP8 is on (logits / rare-word sensitivity).
 _ATTN_FP8 = os.getenv("FREETOKEN_GLM5_ATTN_FP8", "0") != "0"
+_VISION = os.getenv("FREETOKEN_GLM5_VISION", "0") != "0"
 _MLP_FP8 = os.getenv("FREETOKEN_GLM5_MLP_FP8", "0") != "0"
 _LMHEAD_FP8 = os.getenv("FREETOKEN_GLM5_LMHEAD_FP8", "0") != "0"
 
@@ -64,6 +65,19 @@ def _derive_dsa_args(a: Glm5NextArgs) -> GlmMoeDsaArgs:
         index_kpool_always_select_tail=a.index_kpool_always_select_tail,
     )
 
+
+
+def _vision_cfg_dict(hf_config) -> dict | None:
+    """Raw vision_config as a plain dict (the tower port indexes by key). Env-gated:
+    default OFF keeps the text-only boot byte-identical."""
+    if not _VISION:
+        return None
+    vc = getattr(hf_config, "vision_config", None)
+    if vc is None or isinstance(vc, dict):
+        return vc
+    if hasattr(vc, "to_dict"):
+        return vc.to_dict()
+    return dict(vars(vc))
 
 def parse_config(hf_config: Any) -> ModelConfig:
     a = load_args(hf_config)
@@ -159,7 +173,7 @@ def parse_config(hf_config: Any) -> ModelConfig:
         attn_sm_scale=a.qk_head_dim**-0.5,
         swiglu_limit=(a.swiglu_limit or None),
         has_attn_bias=False,
-        vision_config=None,  # text-only
+        vision_config=_vision_cfg_dict(hf_config),
         image_token_id=getattr(hf_config, "image_token_id", None),
         attention_groups=groups,
         attn_quant="fp8_pertensor" if _ATTN_FP8 else "none",

--- a/python/freetoken/models/glm5_next/config.py
+++ b/python/freetoken/models/glm5_next/config.py
@@ -1,0 +1,173 @@
+"""Engine-facing config for GLM-5.3-Flash (``glm5_next``).
+
+Hybrid attention resolved into two groups:
+  * full layers (``full_attn_layers``) -> MLA + DSA. We derive a ``GlmMoeDsaArgs`` and put it
+    on ``ModelConfig.glm_dsa_args`` so the glm_moe_dsa pool / KV cost model / MLA-DSA attention
+    serve them UNCHANGED. GLM-5.3 MLA is NoPE (``qk_rope_head_dim == 0``): the latent row is
+    just ``kv_lora_rank`` wide and the rope is a no-op.
+  * linear layers (``kda_layers``) -> KDA gated-delta (``LinearGatedDeltaGroupConfig``, the
+    same linear_state pool the qwen3.5 GDN path uses; the KDA-specific gating is applied in
+    the model module, not the pool).
+
+The mHC (hyper-connection) + KDA + VRAM/host split payload rides on the new
+``ModelConfig.glm5_args`` (Glm5NextArgs).
+
+Precision (quality-first): the first milestone keeps every resident (non-expert) weight in
+BF16 for a clean quality baseline. FREETOKEN_GLM5_ATTN_FP8 / _MLP_FP8 turn on the non-expert
+FP8 optimization later; lm_head and the MLA-latent projections deliberately stay BF16 per the
+sensitivity analysis, so they have their own switch (default off).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from freetoken.models.config import (
+    FullAttentionGroupConfig,
+    LinearGatedDeltaGroupConfig,
+    ModelConfig,
+    RotaryConfig,
+    detect_expert_quant,
+)
+from freetoken.models.glm_moe_dsa.args import GlmMoeDsaArgs
+
+from .args import Glm5NextArgs, load_args
+
+# Non-expert FP8: default OFF (bf16 quality baseline). Turn on after the bf16 run is the A/B
+# reference. lm_head stays bf16 even when MLP_FP8 is on (logits / rare-word sensitivity).
+_ATTN_FP8 = os.getenv("FREETOKEN_GLM5_ATTN_FP8", "0") != "0"
+_MLP_FP8 = os.getenv("FREETOKEN_GLM5_MLP_FP8", "0") != "0"
+_LMHEAD_FP8 = os.getenv("FREETOKEN_GLM5_LMHEAD_FP8", "0") != "0"
+
+
+def _derive_dsa_args(a: Glm5NextArgs) -> GlmMoeDsaArgs:
+    """GlmMoeDsaArgs for the full MLA+DSA layers -- reuses the glm_moe_dsa machinery verbatim."""
+    return GlmMoeDsaArgs(
+        hidden_size=a.hidden_size,
+        num_heads=a.num_heads,
+        q_lora_rank=a.q_lora_rank,
+        kv_lora_rank=a.kv_lora_rank,
+        qk_nope_head_dim=a.qk_nope_head_dim,
+        qk_rope_head_dim=a.qk_rope_head_dim,
+        v_head_dim=a.v_head_dim,
+        norm_eps=a.norm_eps,
+        rope_theta=a.rope_theta,
+        rope_interleave=True,
+        indexer_rope_interleave=a.indexer_rope_interleave,
+        max_position=a.max_position,
+        index_n_heads=a.index_n_heads,
+        index_head_dim=a.index_head_dim,
+        index_topk=a.index_topk,
+        indexer_types=a.indexer_types,
+        index_kpool=a.index_kpool,
+        index_kpool_always_select_tail=a.index_kpool_always_select_tail,
+    )
+
+
+def parse_config(hf_config: Any) -> ModelConfig:
+    a = load_args(hf_config)
+
+    # Dev cap (FREETOKEN_GLM5_MAX_LAYERS=5 -> 3 dense + 2 MoE) to exercise the forward path /
+    # KV / offload without pinning the full 163 GiB of experts. Unset in normal use.
+    num_layers = a.num_layers
+    cap = os.environ.get("FREETOKEN_GLM5_MAX_LAYERS")
+    if cap:
+        num_layers = min(num_layers, int(cap))
+
+    dsa_args = _derive_dsa_args(a)
+    if a.mtp_enabled:
+        import dataclasses as _dc
+
+        dsa_args = _dc.replace(dsa_args, indexer_types=a.indexer_types + ("full",))
+    latent_dim = a.kv_lora_rank + a.qk_rope_head_dim  # 512 (NoPE: qk_rope_head_dim == 0)
+    dsa_on = (
+        a.index_topk > 0 and a.index_head_dim > 0 and os.getenv("FREETOKEN_GLM5_DSA", "1") != "0"
+    )
+
+    full_ids = tuple(i for i in a.full_layer_ids if i < num_layers)
+    kda_ids = tuple(i for i in a.kda_layer_ids if i < num_layers)
+    # MTP layer 45: one more MLA/DSA layer sharing the paged latent/index slabs (its own
+    # dense slab row via the layer_ids remap). Only when serving the full stack.
+    mtp_on = a.mtp_enabled and num_layers == a.num_layers
+    if mtp_on:
+        full_ids = full_ids + (a.mtp_layer_id,)
+
+    full_rotary = RotaryConfig(
+        head_dim=a.qk_head_dim,
+        rotary_dim=a.qk_rope_head_dim,
+        max_position=a.max_position,
+        base=a.rope_theta,
+        scaling=None,
+    )
+    full_group = FullAttentionGroupConfig(
+        name="full",
+        layer_ids=full_ids,
+        num_kv_heads=1,  # single shared MLA latent
+        head_dim=latent_dim,
+        rotary_config=full_rotary,
+        mla=True,
+        index_head_dim=a.index_head_dim if dsa_on else 0,
+        num_index_layers=(
+            sum(1 for i in full_ids if dsa_args.indexer_types[i] == "full")
+            if dsa_on
+            else 0
+        ),
+    )
+    linear_group = LinearGatedDeltaGroupConfig(
+        name="linear",
+        layer_ids=kda_ids,
+        num_key_heads=a.kda.num_heads,
+        num_value_heads=a.kda.num_heads,
+        key_head_dim=a.kda.head_dim,
+        value_head_dim=a.kda.head_dim,
+        conv_kernel_dim=a.kda.short_conv_kernel_size,
+        output_gate=True,
+    )
+    groups = tuple(
+        sorted(
+            (full_group, linear_group),
+            key=lambda g: g.layer_ids[0] if g.layer_ids else 1 << 30,
+        )
+    )
+
+    return ModelConfig(
+        num_layers=num_layers,
+        num_qo_heads=a.num_heads,
+        num_kv_heads=1,
+        head_dim=latent_dim,
+        hidden_size=a.hidden_size,
+        vocab_size=a.vocab_size,
+        intermediate_size=a.intermediate_size,
+        rms_norm_eps=a.norm_eps,
+        rotary_config=full_rotary,
+        hidden_act=a.hidden_act,
+        tie_word_embeddings=a.tie_word_embeddings,
+        num_experts=a.n_routed_experts,
+        num_experts_per_tok=a.num_experts_per_tok,
+        moe_intermediate_size=a.moe_intermediate_size,
+        norm_topk_prob=a.norm_topk_prob,
+        model_type=getattr(hf_config, "model_type", "glm5_next"),
+        architectures=getattr(hf_config, "architectures", ["Glm5NextForConditionalGeneration"]),
+        moe_enabled=True,
+        expert_quant=detect_expert_quant(hf_config) or "nvfp4",
+        first_k_dense_replace=a.first_k_dense_replace,
+        n_shared_experts=a.n_shared_experts,
+        routed_scaling_factor=a.routed_scaling_factor,
+        n_group=a.n_group,
+        topk_group=a.topk_group,
+        attn_sm_scale=a.qk_head_dim**-0.5,
+        swiglu_limit=(a.swiglu_limit or None),
+        has_attn_bias=False,
+        vision_config=None,  # text-only
+        image_token_id=getattr(hf_config, "image_token_id", None),
+        attention_groups=groups,
+        attn_quant="fp8_pertensor" if _ATTN_FP8 else "none",
+        dense_quant="fp8_pertensor" if _MLP_FP8 else "none",
+        lm_head_quant="fp8_pertensor" if _LMHEAD_FP8 else "none",
+        glm_dsa_args=dsa_args,
+        glm5_args=a,
+    )
+
+
+__all__ = ["parse_config"]

--- a/python/freetoken/models/glm5_next/experts_resident.py
+++ b/python/freetoken/models/glm5_next/experts_resident.py
@@ -1,0 +1,75 @@
+"""GPU-resident NVFP4 routed experts for GLM-5.3's hotness-driven VRAM/host split.
+
+A resident layer keeps its FULL packed expert banks on the GPU (no host pin, no
+offload cache slots, no PCIe on miss) and computes through the same inline-dequant
+Triton kernels the offload path uses for materialized full-layer views -- raw expert
+ids, position == expert id. Which layers are resident is chosen by measured fetch
+hotness (FREETOKEN_GLM5_RESIDENT_LAYERS); the host banks for these layers are never
+built (weight.py's spec skips them), which is what makes the 45-layer model fit in
+host RAM.
+"""
+
+from __future__ import annotations
+
+import torch
+from freetoken.core import get_global_ctx
+from freetoken.layers import BaseOP
+from freetoken.models.config import ModelConfig
+
+FP8 = torch.float8_e4m3fn
+
+
+class ResidentNvfp4Experts(BaseOP):
+    """Same ``routed_forward`` contract as OffloadMoELayer, minus the cache."""
+
+    def __init__(self, config: ModelConfig, activation: str, layer_id: int = -1):
+        self.layer_id = layer_id
+        e = config.num_experts
+        h = config.hidden_size
+        i = config.moe_intermediate_size
+        self.num_experts = e
+        self.activation = activation
+        self.apply_router_weight_on_input = False
+        self.hidden_act_alpha = config.hidden_act_alpha
+        self.swiglu_limit = config.swiglu_limit
+        # The six native ModelOpt banks (position == expert id), loaded by weight.py.
+        self.gate_up_packed = torch.empty(e, 2 * i, h // 2, dtype=torch.uint8)
+        self.gate_up_scale = torch.empty(e, 2 * i, h // 16, dtype=FP8)
+        self.gate_up_global = torch.empty(e, 2 * i, dtype=torch.float16)
+        self.down_packed = torch.empty(e, h, i // 2, dtype=torch.uint8)
+        self.down_scale = torch.empty(e, h, i // 16, dtype=FP8)
+        self.down_global = torch.empty(e, h, dtype=torch.float16)
+
+    def _views(self):
+        return (
+            self.gate_up_packed, self.gate_up_scale, self.gate_up_global,
+            self.down_packed, self.down_scale, self.down_global,
+        )
+
+    def routed_forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        act_limit = self.swiglu_limit
+        act_limit = float("inf") if act_limit is None else float(act_limit)
+        if get_global_ctx().batch.is_prefill:
+            from freetoken.moe.fused_nvfp4 import fused_experts_nvfp4
+
+            return fused_experts_nvfp4(
+                hidden_states, *self._views(), topk_weights, topk_ids,
+                self.num_experts, self.activation,
+                self.apply_router_weight_on_input, self.hidden_act_alpha, act_limit,
+            )
+        from freetoken.moe.fused_nvfp4 import fused_experts_decode_nvfp4_marlin
+
+        # Marlin-style GEMV path: CUDA-graph safe (fixed shapes, no host sync).
+        return fused_experts_decode_nvfp4_marlin(
+            hidden_states, *self._views(), topk_weights, topk_ids,
+            self.activation, self.apply_router_weight_on_input,
+            self.hidden_act_alpha, act_limit,
+        )
+
+
+__all__ = ["ResidentNvfp4Experts"]

--- a/python/freetoken/models/glm5_next/image_process.py
+++ b/python/freetoken/models/glm5_next/image_process.py
@@ -1,0 +1,268 @@
+"""Server-side image preprocessing for GLM-5.3-Flash vision.
+
+Vendored port of HF ``Glm5NextImageProcessorPil`` (transformers 5.16.1): the runtime
+env pins transformers 5.15.1, which has no glm5_next classes, and swapping the whole
+package under a serving stack for one preprocessing routine is not worth the risk.
+Constants mirror the checkpoint's processor_config.json.
+
+Pipeline per image (PIL in): smart_resize -> BICUBIC resize to the content box ->
+zero-pad to the aligned canvas -> /255 -> CLIP normalize -> patchify (merge-block-major
+patch order, per-patch feature layout [C][T][ph][pw] -- exactly what the vision tower's
+Conv3d view expects). Output: pixel_values [P, 3*2*14*14] fp32 + grid (1, gh, gw)."""
+from __future__ import annotations
+
+import math
+import os
+
+import numpy as np
+
+PATCH = 14
+MERGE = 2
+TEMPORAL = 2
+MIN_TOKENS = 16
+# Patch budget per image (HF default 8000 patches = 2000 LM tokens after the 2x2
+# merge). Lower it to trade large-image fidelity for prompt length / encode time.
+MAX_TOKENS = int(os.getenv("FREETOKEN_GLM5_MAX_IMAGE_TOKENS", "8000"))
+IMAGE_TOKEN = "<|image|>"
+_MEAN = np.array([0.48145466, 0.4578275, 0.40821073], dtype=np.float32).reshape(3, 1, 1)
+_STD = np.array([0.26862954, 0.26130258, 0.27577711], dtype=np.float32).reshape(3, 1, 1)
+_MAX_BYTES = 30 * 1024 * 1024
+
+
+def smart_resize(num_frames, height, width, temporal_factor=2, factor=28,
+                 min_pixels=16, max_pixels=8000):
+    """Aligned canvas within the spatiotemporal budget (verbatim HF port)."""
+    pixels_per_token = temporal_factor * factor**2
+    min_pixels *= pixels_per_token
+    max_pixels *= pixels_per_token
+
+    def align(value, f):
+        return math.ceil(value / f) * f
+
+    def fit_within_budget(aligned_frames):
+        minimum_pixels = aligned_frames * factor**2
+        if max_pixels < minimum_pixels:
+            raise ValueError(f"max_pixels={max_pixels} too small for one aligned patch")
+        low, high = 1, height
+        best_height, best_width = factor, factor
+        while low <= high:
+            content_height = (low + high) // 2
+            content_width = max(1, math.floor(width * content_height / height))
+            candidate_height = align(content_height, factor)
+            candidate_width = align(content_width, factor)
+            if aligned_frames * candidate_height * candidate_width <= max_pixels:
+                best_height, best_width = candidate_height, candidate_width
+                low = content_height + 1
+            else:
+                high = content_height - 1
+        return best_height, best_width
+
+    aligned_frames = max(temporal_factor, round(num_frames / temporal_factor) * temporal_factor)
+    aligned_height = align(height, factor)
+    aligned_width = align(width, factor)
+    aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+    if aligned_pixel_budget < min_pixels:
+        scale = math.sqrt(min_pixels / (num_frames * height * width))
+        aligned_height = align(max(1, math.ceil(height * scale)), factor)
+        aligned_width = align(max(1, math.ceil(width * scale)), factor)
+        aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+    if aligned_pixel_budget > max_pixels:
+        aligned_height, aligned_width = fit_within_budget(aligned_frames)
+    return aligned_height, aligned_width
+
+
+def _patchify(image: np.ndarray) -> tuple[np.ndarray, int, int]:
+    """(C, H, W) fp32 -> ([gh*gw, C*T*P*P] block-major, gh, gw) (verbatim HF port)."""
+    image = np.asarray(image, dtype=np.float32)
+    channel, resized_height, resized_width = image.shape
+    grid_h, grid_w = resized_height // PATCH, resized_width // PATCH
+    patches = image.reshape(
+        channel, grid_h // MERGE, MERGE, PATCH, grid_w // MERGE, MERGE, PATCH
+    )
+    patches = np.transpose(patches, (1, 4, 2, 5, 0, 3, 6))
+    patches = np.broadcast_to(
+        patches[:, :, :, :, :, None, :, :],
+        (*patches.shape[:5], TEMPORAL, *patches.shape[5:]),
+    )
+    flat = patches.reshape(grid_h * grid_w, channel * TEMPORAL * PATCH * PATCH)
+    return np.ascontiguousarray(flat), grid_h, grid_w
+
+
+def preprocess_image(img) -> tuple[np.ndarray, tuple[int, int, int]]:
+    from PIL import Image
+
+    img = img.convert("RGB")
+    width, height = img.size
+    factor = PATCH * MERGE
+    target_h, target_w = smart_resize(
+        TEMPORAL, height, width, temporal_factor=TEMPORAL, factor=factor,
+        min_pixels=MIN_TOKENS, max_pixels=MAX_TOKENS,
+    )
+    pixels_per_token = TEMPORAL * factor**2
+    scale = min(target_h / height, target_w / width)
+    if TEMPORAL * height * width >= pixels_per_token * MIN_TOKENS:
+        scale = min(1.0, scale)  # never upscale an image already over the minimum
+    content_h = max(1, min(target_h, math.floor(height * scale)))
+    content_w = max(1, min(target_w, math.floor(width * scale)))
+    if (content_h, content_w) != (height, width):
+        img = img.resize((content_w, content_h), Image.BICUBIC)
+    arr = np.asarray(img, dtype=np.uint8).transpose(2, 0, 1)  # CHW
+    arr = np.pad(arr, ((0, 0), (0, target_h - content_h), (0, target_w - content_w)))
+    x = arr.astype(np.float32) / 255.0
+    x = (x - _MEAN) / _STD
+    flat, gh, gw = _patchify(x)
+    return flat, (1, gh, gw)
+
+
+def decode_image_part(image_url):
+    """OpenAI image_url payload (str or {'url': ...}; data URI or http(s)) -> PIL image."""
+    import base64
+    import io
+    import urllib.request
+
+    from PIL import Image
+
+    url = image_url.get("url") if isinstance(image_url, dict) else image_url
+    if not isinstance(url, str) or not url:
+        raise ValueError("image_url must be a non-empty string or {'url': ...}")
+    if url.startswith("data:"):
+        _, _, b64 = url.partition(",")
+        raw = base64.b64decode(b64)
+    elif url.startswith(("http://", "https://")):
+        req = urllib.request.Request(url, headers={"User-Agent": "freetoken-vision"})
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read(_MAX_BYTES + 1)
+    else:
+        raise ValueError("image_url must be a data: URI or http(s) URL")
+    if len(raw) > _MAX_BYTES:
+        raise ValueError("image too large (>30MB)")
+    return Image.open(io.BytesIO(raw))
+
+
+
+
+
+# ---------------------------------------------------------------------------------
+# Video: sampled frames -> patch grid (t, gh, gw). Mirrors HF Glm5NextVideoProcessor
+# (same smart_resize with a frame-count-aware budget, same content-box + zero-pad,
+# same paired-frame temporal patchify); resize uses PIL bicubic like our image path
+# (HF's video backend is torchvision -- visually identical, not bitwise).
+# ---------------------------------------------------------------------------------
+VIDEO_FPS = float(os.getenv("FREETOKEN_GLM5_VIDEO_FPS", "2"))
+# Patch budget for the WHOLE clip (HF default 240000 -> 60000 LM tokens, far beyond
+# what a PCIe-offload box should prefill). 8000 patches = 2000 LM tokens.
+MAX_VIDEO_TOKENS = int(os.getenv("FREETOKEN_GLM5_MAX_VIDEO_TOKENS", "8000"))
+MAX_VIDEO_FRAMES = int(os.getenv("FREETOKEN_GLM5_MAX_VIDEO_FRAMES", "64"))
+_MAX_VIDEO_BYTES = 128 * 1024 * 1024
+
+
+def sample_frame_indices(total_frames: int, native_fps: float, duration: float):
+    """Frame indices at FREETOKEN_GLM5_VIDEO_FPS spacing, even count (HF sampler)."""
+    max_seconds = int(duration) if duration else max(1, round(total_frames / max(native_fps, 1e-6)))
+    extract_t = min(int(max(duration, 1e-6) * VIDEO_FPS) or 2, MAX_VIDEO_FRAMES)
+    timestamps = [i / max(native_fps, 1e-6) for i in range(total_frames)]
+    if total_frames < extract_t:
+        idx = np.linspace(0, total_frames - 1, extract_t, dtype=int).tolist()
+    else:
+        idx = []
+        current = 0.0
+        inv = 1.0 / VIDEO_FPS
+        for i in range(total_frames):
+            if timestamps[i] >= current:
+                current += inv
+                idx.append(i)
+                if current >= max_seconds:
+                    break
+        if len(idx) < extract_t:
+            a, b = (idx[0], idx[-1]) if idx else (0, max(total_frames - 1, 0))
+            idx = np.linspace(a, b, extract_t, dtype=int).tolist()
+        elif len(idx) > extract_t:
+            idx = np.linspace(0, total_frames - 1, extract_t, dtype=int).tolist()
+    seen, uniq = set(), []
+    for i in idx:
+        if i not in seen:
+            seen.add(i); uniq.append(i)
+    if len(uniq) & 1:
+        uniq.append(uniq[-1])
+    ts = [timestamps[i] for i in uniq]
+    return uniq, ts
+
+
+def preprocess_video(frames, timestamps):
+    """frames: even-length list of PIL images (same size). Returns
+    (pixel_values [t*gh*gw, D] fp32, grid (t, gh, gw), unit_timestamps [t])."""
+    from PIL import Image
+
+    T = len(frames)
+    assert T >= 2 and T % 2 == 0, "sampled frame count must be even"
+    frames = [f.convert("RGB") for f in frames]
+    width, height = frames[0].size
+    factor = PATCH * MERGE
+    target_h, target_w = smart_resize(
+        T, height, width, temporal_factor=TEMPORAL, factor=factor,
+        min_pixels=MIN_TOKENS, max_pixels=MAX_VIDEO_TOKENS,
+    )
+    pixels_per_token = TEMPORAL * factor**2
+    scale = min(target_h / height, target_w / width)
+    if T * height * width >= pixels_per_token * MIN_TOKENS:
+        scale = min(1.0, scale)
+    content_h = max(1, min(target_h, math.floor(height * scale)))
+    content_w = max(1, min(target_w, math.floor(width * scale)))
+    chw = []
+    for f in frames:
+        if (content_h, content_w) != (height, width):
+            f = f.resize((content_w, content_h), Image.BICUBIC)
+        a = np.asarray(f, dtype=np.uint8).transpose(2, 0, 1)
+        a = np.pad(a, ((0, 0), (0, target_h - content_h), (0, target_w - content_w)))
+        chw.append(a)
+    vid = np.stack(chw).astype(np.float32) / 255.0          # [T, C, H, W]
+    vid = (vid - _MEAN[None]) / _STD[None]
+    grid_t, gh, gw = T // TEMPORAL, target_h // PATCH, target_w // PATCH
+    x = vid.reshape(grid_t, TEMPORAL, 3, gh // MERGE, MERGE, PATCH, gw // MERGE, MERGE, PATCH)
+    x = np.transpose(x, (0, 3, 6, 4, 7, 2, 1, 5, 8))        # unit, block-major, m, m, C, T, ph, pw
+    flat = np.ascontiguousarray(
+        x.reshape(grid_t * gh * gw, 3 * TEMPORAL * PATCH * PATCH)
+    )
+    unit_ts = [float(timestamps[min(k * TEMPORAL, T - 1)]) for k in range(grid_t)]
+    return flat, (grid_t, gh, gw), unit_ts
+
+
+def decode_video_part(video_url):
+    """OpenAI-style video_url payload -> (frames list of PIL, unit timestamps).
+    data: URI (base64 mp4/webm) or http(s) URL; decoded via PyAV."""
+    import base64
+    import io
+    import tempfile
+    import urllib.request
+
+    import av
+    from PIL import Image
+
+    url = video_url.get("url") if isinstance(video_url, dict) else video_url
+    if not isinstance(url, str) or not url:
+        raise ValueError("video_url must be a non-empty string or {'url': ...}")
+    if url.startswith("data:"):
+        _, _, b64 = url.partition(",")
+        raw = base64.b64decode(b64)
+    elif url.startswith(("http://", "https://")):
+        req = urllib.request.Request(url, headers={"User-Agent": "freetoken-vision"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read(_MAX_VIDEO_BYTES + 1)
+    else:
+        raise ValueError("video_url must be a data: URI or http(s) URL")
+    if len(raw) > _MAX_VIDEO_BYTES:
+        raise ValueError("video too large (>128MB)")
+
+    with av.open(io.BytesIO(raw)) as container:
+        stream = container.streams.video[0]
+        native_fps = float(stream.average_rate or 24.0)
+        decoded = [f for f in container.decode(stream)]
+    total = len(decoded)
+    if total == 0:
+        raise ValueError("could not decode any video frames")
+    duration = total / max(native_fps, 1e-6)
+    idx, ts = sample_frame_indices(total, native_fps, duration)
+    frames = [Image.fromarray(decoded[i].to_ndarray(format="rgb24")) for i in idx]
+    return frames, ts
+
+__all__ = ["preprocess_image", "decode_image_part", "preprocess_video", "decode_video_part", "smart_resize", "IMAGE_TOKEN", "MERGE"]

--- a/python/freetoken/models/glm5_next/mlp.py
+++ b/python/freetoken/models/glm5_next/mlp.py
@@ -1,0 +1,29 @@
+"""Clamped-SwiGLU MLP for GLM-5.3's dense layers and shared experts.
+
+HF reference (Glm5NextTextMLP / shared experts): ``silu(clamp(gate, max=limit)) *
+clamp(up, -limit, limit)``. Serves through the dsv4 fused kernel, which is bit-exact
+to that formula (verified). Weight names match GlmDsaGatedMLP (gate/up/down_proj).
+"""
+
+from __future__ import annotations
+
+import torch
+from freetoken.kernel.triton.dsv4.swiglu import fused_swiglu
+from freetoken.models.glm_moe_dsa.mlp import GlmDsaGatedMLP
+from freetoken.utils import nvtx_annotate
+
+
+class Glm5ClampedMLP(GlmDsaGatedMLP):
+    def __init__(self, hidden_size: int, intermediate_size: int, quant: str = "none",
+                 limit: float = 10.0):
+        super().__init__(hidden_size, intermediate_size, quant=quant)
+        self.__dict__["_limit"] = float(limit)  # plain attr, excluded from state_dict walk
+
+    @nvtx_annotate("MLP")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate = self.gate_proj.forward(x)
+        up = self.up_proj.forward(x)
+        return self.down_proj.forward(fused_swiglu(gate, up, self._limit, x.dtype))
+
+
+__all__ = ["Glm5ClampedMLP"]

--- a/python/freetoken/models/glm5_next/model.py
+++ b/python/freetoken/models/glm5_next/model.py
@@ -1,0 +1,242 @@
+"""GLM-5.3-Flash (glm5_next) model: DSV4-style manifold-constrained Hyper-Connections (mHC,
+4 residual streams) wrapping a hybrid per-layer mixer -- KDA linear attention (linear layers)
+or MLA+DSA (full layers) -- plus a GLM MoE / dense MLP feed-forward.
+
+Reuse map:
+  * mHC (hc_pre / hc_post / hc_head + sinkhorn) -> DSV4 kernels verbatim; hc_mult == 4.
+  * full-layer mixer -> glm_moe_dsa GlmMoeDsaAttention (via FullAttention).
+  * linear-layer mixer -> KdaAttention (attention.py).
+  * MoE / dense MLP / FP8 lm_head -> glm_moe_dsa GlmMoeDsaSparseBlock / GlmDsaGatedMLP / GlmFp8LMHead.
+
+Hidden state carries the 4 residual streams as ``[total_tokens, hc_mult, dim]`` (ragged-flat,
+matching the glm_moe_dsa/KDA mixers which consume ``[total, dim]``). hc_pre collapses the
+streams to ``[total, dim]`` for the mixer; hc_post expands back. FIRST PASS: the ragged-flat
+shape handling is verified by a dummy-weight forward before real weights.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from freetoken.core import get_global_ctx
+from freetoken.kernel.triton.dsv4.hc import hc_post_combine, hc_pre_combine
+from freetoken.kernel.triton.dsv4.hc_norm import hc_mix_gemv, hc_rms_cast
+from freetoken.kernel.triton.dsv4.sinkhorn import hc_split_sinkhorn
+from freetoken.layers import (
+    BaseOP,
+    OPList,
+    ParallelLMHead,
+    RMSNorm,
+    VocabParallelEmbedding,
+)
+from freetoken.models.blocks import BaseLLMModel
+from freetoken.models.config import ModelConfig
+from freetoken.models.glm_moe_dsa.model import GlmFp8LMHead
+
+from .mlp import Glm5ClampedMLP
+from .moe import Glm5SparseBlock
+
+from .attention import FullAttention, KdaAttention
+
+
+class Glm5DecoderLayer(BaseOP):
+    """mHC block: hc_pre -> norm -> mixer -> hc_post ; hc_pre -> norm -> ffn -> hc_post.
+    ``mixer`` is KDA (linear layers) or MLA+DSA (full); ``ffn`` is MoE or dense MLP."""
+
+    def __init__(self, config: ModelConfig, layer_id: int):
+        a = config.glm5_args
+        self.dim = config.hidden_size
+        self.norm_eps = config.rms_norm_eps
+        self.layer_id = layer_id
+
+        if a.is_kda_layer(layer_id):
+            self.self_attn: BaseOP = KdaAttention(config, layer_id)
+        else:
+            self.self_attn = FullAttention(config, layer_id)
+
+        if a.is_dense_layer(layer_id):
+            self.mlp: BaseOP = Glm5ClampedMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                quant=config.dense_quant,
+                limit=float(config.swiglu_limit or 10.0),
+            )
+        else:
+            self.mlp = Glm5SparseBlock(config, layer_id)
+
+        # Attribute names match the checkpoint layout (weight.py yields these paths).
+        self.input_layernorm = RMSNorm(size=self.dim, eps=self.norm_eps)
+        self.post_attention_layernorm = RMSNorm(size=self.dim, eps=self.norm_eps)
+
+        # Hyper-connection mix (DSV4 layout): hc_mult == a.hc_mult (4).
+        self.hc_mult = hc = a.hc_mult
+        self.hc_sinkhorn_iters = a.hc_sinkhorn_iters
+        self.hc_eps = a.hc_eps
+        mix_hc = (2 + hc) * hc
+        hc_dim = hc * self.dim
+        self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32), requires_grad=False)
+        self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32), requires_grad=False)
+        self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32), requires_grad=False)
+        self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32), requires_grad=False)
+        self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32), requires_grad=False)
+        self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32), requires_grad=False)
+
+    def hc_pre(self, x, hc_fn, hc_scale, hc_base):
+        # x: [total, hc_mult, dim] -> collapsed y: [total, dim] for the mixer.
+        total = x.shape[0]
+        dtype = x.dtype
+        # tail-fusion (2026-08-28): cast+square+mean+rsqrt -> one kernel; gemv with
+        # rsqrt epilogue -> one kernel; pre_combine upcasts bf16 in-register (the
+        # eager chain was ~7 launches + two 64KB-per-token fp32 casts per call).
+        xf, rs = hc_rms_cast(x.reshape(total, self.hc_mult * self.dim), self.norm_eps)
+        mixes = hc_mix_gemv(xf, hc_fn, rs)
+        pre, post, comb = hc_split_sinkhorn(
+            mixes, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.hc_eps
+        )
+        y = hc_pre_combine(x.reshape(total, self.hc_mult, self.dim), pre, dtype)
+        return y.reshape(total, self.dim), post, comb
+
+    def hc_post(self, x, residual, post, comb):
+        # x: [total, dim] (mixer out); residual: [total, hc_mult, dim] -> [total, hc_mult, dim].
+        total = residual.shape[0]
+        y = hc_post_combine(
+            x.reshape(total, self.dim), residual.reshape(total, self.hc_mult, self.dim), post, comb
+        )
+        return y.reshape(total, self.hc_mult, self.dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        import os as _os
+        _stub = _os.environ.get("FREETOKEN_GLM5_STUB_MHC", "0")
+        if _stub in ("1", "2", "3"):  # ablation timing only
+            # "2": compute hc, discard.  "3": REAL hc_pre feeds the sublayer, simple add out.
+            if _stub == "3":
+                y, _, _ = self.hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+            else:
+                if _stub == "2":
+                    self.hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+                y = self.input_layernorm.forward(x[:, 0])
+            if _stub == "3":
+                y = self.input_layernorm.forward(y)
+            y = self.self_attn.forward(y)
+            x = x + y.unsqueeze(1)
+            if _stub == "3":
+                y, _, _ = self.hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+                y = self.post_attention_layernorm.forward(y)
+            else:
+                if _stub == "2":
+                    self.hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+                y = self.post_attention_layernorm.forward(x[:, 0])
+            y = self.mlp.forward(y)
+            return x + y.unsqueeze(1)
+        residual = x
+        y, post, comb = self.hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        y = self.input_layernorm.forward(y)
+        y = self.self_attn.forward(y)
+        x = self.hc_post(y, residual, post, comb)
+
+        residual = x
+        y, post, comb = self.hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        y = self.post_attention_layernorm.forward(y)
+        y = self.mlp.forward(y)
+        x = self.hc_post(y, residual, post, comb)
+        return x
+
+
+class Glm5Model(BaseOP):
+    def __init__(self, config: ModelConfig):
+        a = config.glm5_args
+        self.dim = config.hidden_size
+        self.norm_eps = config.rms_norm_eps
+        self.hc_mult = a.hc_mult
+        self.hc_eps = a.hc_eps
+        self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size)
+        self.layers = OPList([Glm5DecoderLayer(config, i) for i in range(config.num_layers)])
+        self.norm = RMSNorm(size=self.dim, eps=self.norm_eps)
+
+    def hc_head(self, x: torch.Tensor) -> torch.Tensor:
+        # GLM-5.3 collapses the final residual streams with an UNWEIGHTED MEAN -- verified
+        # against HF Glm5NextTextHyperHead ("Unlike DeepSeek-V4, this is an unweighted
+        # mean"); there are no hc_head weights in the checkpoint.
+        return x.mean(dim=1)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        h = self.embed_tokens.forward(input_ids)  # [total, dim]
+        h = h.unsqueeze(1).repeat(1, self.hc_mult, 1)  # [total, hc_mult, dim]
+        for layer in self.layers.op_list:
+            h = layer.forward(h)
+        h = self.hc_head(h)  # [total, dim]
+        # Stash for the MTP block: DeepSeek-style drafting consumes the collapsed hidden
+        # BEFORE the final norm (a ref, not a copy; None-cost when MTP is off).
+        self.last_pre_norm = h
+        # RMSNorm.forward returns a single tensor (no residual fusion here -- mHC already
+        # carried the residual through hc_post). Call it exactly once (graph-safe, no dup work).
+        return self.norm.forward(h)
+
+
+class Glm5NextForCausalLM(BaseLLMModel):
+    def __init__(self, config: ModelConfig):
+        self.config = config
+        self.model = Glm5Model(config)
+        if config.glm5_args.mtp_enabled:
+            from .mtp import Glm5MtpBlock
+
+            self.mtp = Glm5MtpBlock(config)
+        if config.lm_head_quant == "fp8_pertensor" and not config.tie_word_embeddings:
+            self.lm_head: BaseOP = GlmFp8LMHead(
+                num_embeddings=config.vocab_size, embedding_dim=config.hidden_size
+            )
+        else:
+            self.lm_head = ParallelLMHead(
+                num_embeddings=config.vocab_size,
+                embedding_dim=config.hidden_size,
+                tie_word_embeddings=config.tie_word_embeddings,
+                tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
+            )
+        super().__init__()
+
+    def prepare_for_runtime(self) -> None:
+        for layer in self.model.layers.op_list:
+            if hasattr(layer.self_attn, "prepare_for_runtime"):
+                layer.self_attn.prepare_for_runtime()
+        torch.cuda.empty_cache()
+
+    def forward(self) -> torch.Tensor:
+        batch = get_global_ctx().batch
+        output = self.model.forward(batch.input_ids)
+        logits = self.lm_head.forward(output)
+        # ---- MTP acceptance probe (measurement only; eager decode, bs==1) ----
+        # Compares last step's draft against this step's main-model argmax and drafts the
+        # next token. Requires --cuda-graph-max-bs 0 (host-side counters do not replay).
+        import os as _os
+
+        if (
+            _os.environ.get("FREETOKEN_GLM5_MTP_PROBE", "0") == "1"
+            and getattr(self, "mtp", None) is not None
+            and batch.is_decode
+            and logits.shape[0] == 1
+            and not torch.cuda.is_current_stream_capturing()
+        ):
+            nxt = logits.argmax(dim=-1)  # greedy t_{p+2} truth (temperature-0 runs)
+            prev = getattr(self, "_probe_draft", None)
+            if prev is not None:
+                self._probe_total = getattr(self, "_probe_total", 0) + 1
+                self._probe_agree = getattr(self, "_probe_agree", 0) + int(
+                    (prev == nxt).item()
+                )
+                if self._probe_total % 50 == 0:
+                    print(
+                        f"[mtp-probe] accept={self._probe_agree}/{self._probe_total}"
+                        f" = {self._probe_agree/self._probe_total:.3f}",
+                        flush=True,
+                    )
+            emb = self.model.embed_tokens.weight[nxt]
+            d_logits = self.mtp.draft_logits(
+                self.model.last_pre_norm, emb, self.lm_head
+            )
+            self._probe_draft = d_logits.argmax(dim=-1)
+        return logits
+
+
+__all__ = ["Glm5NextForCausalLM", "Glm5Model", "Glm5DecoderLayer"]

--- a/python/freetoken/models/glm5_next/model.py
+++ b/python/freetoken/models/glm5_next/model.py
@@ -152,6 +152,7 @@ class Glm5Model(BaseOP):
         self.hc_mult = a.hc_mult
         self.hc_eps = a.hc_eps
         self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size)
+        self._image_token_id = config.image_token_id
         self.layers = OPList([Glm5DecoderLayer(config, i) for i in range(config.num_layers)])
         self.norm = RMSNorm(size=self.dim, eps=self.norm_eps)
 
@@ -163,6 +164,19 @@ class Glm5Model(BaseOP):
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         h = self.embed_tokens.forward(input_ids)  # [total, dim]
+        # Multimodal splice (gemma4 pattern): rows at image_token_id placeholders are
+        # replaced by the vision features BEFORE the residual streams fan out. Only
+        # prefill batches ever carry mm_embeds; decode (and graph capture) skip the
+        # branch at Python level.
+        mm_embeds = getattr(get_global_ctx().batch, "mm_embeds", None)
+        if mm_embeds is not None and self._image_token_id is not None:
+            mask = input_ids == self._image_token_id
+            n_slots = int(mask.sum())
+            assert n_slots == mm_embeds.shape[0], (
+                f"image-token slots ({n_slots}) != vision features ({mm_embeds.shape[0]})"
+            )
+            if n_slots:
+                h = h.masked_scatter(mask.unsqueeze(-1), mm_embeds.to(h.dtype))
         h = h.unsqueeze(1).repeat(1, self.hc_mult, 1)  # [total, hc_mult, dim]
         for layer in self.layers.op_list:
             h = layer.forward(h)
@@ -179,6 +193,10 @@ class Glm5NextForCausalLM(BaseLLMModel):
     def __init__(self, config: ModelConfig):
         self.config = config
         self.model = Glm5Model(config)
+        if config.is_multimodal:
+            from .vision import Glm5Vision
+
+            self.visual = Glm5Vision(config.vision_config)
         if config.glm5_args.mtp_enabled:
             from .mtp import Glm5MtpBlock
 
@@ -195,6 +213,17 @@ class Glm5NextForCausalLM(BaseLLMModel):
                 tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
             )
         super().__init__()
+
+    def encode_images(
+        self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        """Vision tower forward. ``grid_thw`` [num_images, 3] rides in the generic
+        ``image_position_ids`` slot of the mm contract (LLM.encode_images passes both
+        args positionally). Returns ``[num_image_tokens, out_hidden]`` bf16."""
+        assert hasattr(self, "visual"), (
+            "vision tower not loaded -- boot with FREETOKEN_GLM5_VISION=1"
+        )
+        return self.visual.forward(pixel_values, grid_thw.to(torch.long))
 
     def prepare_for_runtime(self) -> None:
         for layer in self.model.layers.op_list:

--- a/python/freetoken/models/glm5_next/moe.py
+++ b/python/freetoken/models/glm5_next/moe.py
@@ -1,0 +1,48 @@
+"""GLM-5.3 sparse MoE block: glm_moe_dsa's router/experts (activation resolved to
+swiglu_clamp via config.swiglu_limit) with the SHARED expert also clamped."""
+
+from __future__ import annotations
+
+from freetoken.layers.moe import make_moe_layer
+from freetoken.models.config import ModelConfig
+from freetoken.models.glm_moe_dsa.moe import GlmMoeDsaSparseBlock
+
+from .experts_resident import ResidentNvfp4Experts
+from .mlp import Glm5ClampedMLP
+
+
+def offload_moe_layers(config: ModelConfig):
+    """MoE layers served from the offload cache (non-resident), in order. The host
+    bank builder (weight.py) and the per-layer bank ids below share this list, so the
+    two can never disagree."""
+    res = frozenset(config.glm5_args.resident_layer_ids)
+    return [
+        l for l in range(config.first_k_dense_replace, config.num_layers) if l not in res
+    ]
+
+
+class Glm5SparseBlock(GlmMoeDsaSparseBlock):
+    def _make_experts(self, config: ModelConfig, layer_id: int):
+        activation = "swiglu_clamp" if getattr(config, "swiglu_limit", None) else "silu"
+        if layer_id in config.glm5_args.resident_layer_ids:
+            return ResidentNvfp4Experts(config, activation, layer_id=layer_id)
+        # Offload bank ids are dense over the NON-resident MoE layers.
+        return make_moe_layer(
+            config,
+            layer_id=offload_moe_layers(config).index(layer_id),
+            renormalize=config.norm_topk_prob,
+            activation=activation,
+        )
+
+    def __init__(self, config: ModelConfig, layer_id: int):
+        super().__init__(config, layer_id)
+        # Same attribute name/weights; only the activation gains the HF clamp.
+        self.shared_experts = Glm5ClampedMLP(
+            config.hidden_size,
+            config.moe_intermediate_size * max(1, config.n_shared_experts),
+            quant=config.dense_quant,
+            limit=float(config.swiglu_limit or 10.0),
+        )
+
+
+__all__ = ["Glm5SparseBlock"]

--- a/python/freetoken/models/glm5_next/mtp.py
+++ b/python/freetoken/models/glm5_next/mtp.py
@@ -1,0 +1,81 @@
+"""GLM-5.3-Flash MTP (multi-token prediction) block -- the checkpoint's layer 45.
+
+DeepSeek-style draft: ``x = eh_proj([enorm(embed(t_next)) ; hnorm(h_main)])`` runs through
+ONE decoder block and predicts the token after ``t_next`` through ``shared_head.norm`` +
+the shared ``lm_head``. CHECKPOINT FACT: layer 45 ships NO hc_* weights -- the MTP block
+is a PLAIN pre-norm residual block (single stream), unlike the mHC main stack. Its MLA/DSA
+attention appends to its OWN slab row in the shared paged pool (layer 45 was added to the
+full attention group) at the same positions/page rows as the main stack.
+
+The MTP MoE experts (288, ~3.9G) must be VRAM-resident (add 45 to
+FREETOKEN_GLM5_RESIDENT_LAYERS): the offload bank layout only covers layers < 45.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from freetoken.layers import BaseOP, LinearReplicated, RMSNorm
+from freetoken.models.config import ModelConfig
+
+
+class _SharedHead(BaseOP):
+    def __init__(self, dim: int, eps: float):
+        self.norm = RMSNorm(size=dim, eps=eps)
+
+
+class _MtpLayer(BaseOP):
+    """Plain pre-norm residual decoder block (no mHC -- layer 45 has no hc weights)."""
+
+    def __init__(self, config: ModelConfig, layer_id: int):
+        from .attention import FullAttention
+        from .moe import Glm5SparseBlock
+
+        self.self_attn = FullAttention(config, layer_id)
+        self.mlp = Glm5SparseBlock(config, layer_id)
+        self.input_layernorm = RMSNorm(size=config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            size=config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.self_attn.forward(self.input_layernorm.forward(x))
+        return x + self.mlp.forward(self.post_attention_layernorm.forward(x))
+
+
+class Glm5MtpBlock(BaseOP):
+    def __init__(self, config: ModelConfig):
+        a = config.glm5_args
+        assert a.mtp_layer_id in a.resident_layer_ids, (
+            "MTP needs its experts VRAM-resident: add 45 to FREETOKEN_GLM5_RESIDENT_LAYERS"
+        )
+        d = config.hidden_size
+        self.enorm = RMSNorm(size=d, eps=a.norm_eps)
+        self.hnorm = RMSNorm(size=d, eps=a.norm_eps)
+        self.eh_proj = LinearReplicated(2 * d, d, has_bias=False)
+        self.layer = _MtpLayer(config, a.mtp_layer_id)
+        self.shared_head = _SharedHead(d, a.norm_eps)
+
+    def draft_logits(
+        self, h_pre_norm: torch.Tensor, tok_embed: torch.Tensor, lm_head
+    ) -> torch.Tensor:
+        """One draft step: ``h_pre_norm`` [T, D] (main stack's collapsed pre-final-norm
+        hidden at these positions), ``tok_embed`` [T, D] (embedding of the token the main
+        model just emitted there). Returns logits [T, V] predicting the FOLLOWING token.
+        Runs under the CURRENT batch ctx (same positions/out_loc -> layer-45 slab)."""
+        return self.draft_step(h_pre_norm, tok_embed, lm_head)[0]
+
+    def draft_step(
+        self, h_pre_norm: torch.Tensor, tok_embed: torch.Tensor, lm_head
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """draft_logits plus the block's output hidden [T, D] (pre shared-head norm) --
+        the ``h`` input of the NEXT chained draft (DeepSeek-style depth-1 chaining)."""
+        x = torch.cat(
+            [self.enorm.forward(tok_embed), self.hnorm.forward(h_pre_norm)], dim=-1
+        )
+        x = self.eh_proj.forward(x)
+        x = self.layer.forward(x)
+        return lm_head.forward(self.shared_head.norm.forward(x)), x
+
+
+__all__ = ["Glm5MtpBlock"]

--- a/python/freetoken/models/glm5_next/spec.py
+++ b/python/freetoken/models/glm5_next/spec.py
@@ -1,0 +1,432 @@
+"""GLM-5.3-Flash MTP self-speculative decoding (engine-side state machine).
+
+One request, greedy, bs==1. Round layout (steady state, all inside one scheduler
+"decode step" at position p = device_len-1, input token x_p):
+
+  carry-in : d1 = draft of x_{p+1} (from last round's refresh), h_mtp = MTP hidden
+             at position p-1, main-stack KV/state committed through position p-1.
+  chain    : drafts d2..dk -- MTP-only forwards at positions p..p+k-2, each feeding
+             the previous MTP hidden (DeepSeek-style depth-1 chaining, approximate).
+  verify   : ONE main-model forward of k+1 SINGLE-TOKEN fake reqs at positions
+             p..p+k with inputs [x_p, d1..dk]. The prefill/extend path gives exact
+             per-position causal attention; lm_head's per-request last-index gather
+             returns all k+1 logits rows. KDA layers run a dedicated one-sequence
+             branch that archives inputs + pre-states (batch.spec_stash).
+  accept   : m = longest prefix with verify-argmax == draft; emit m+1 tokens
+             (d1..dm + bonus). The step returns the first; the rest go to a token
+             cache the next m scheduler steps pop without any forward.
+  commit   : KDA state re-run over the accepted m+1 tokens from the archived
+             pre-state (kernels only expose the final state). Everything else is
+             append-only: rejected positions are plain overwrites next round.
+  refresh  : MTP-only span forward over positions p..p+m with EXACT inputs
+             (verify hiddens + emitted tokens) -- overwrites the chain's approximate
+             layer-45 KV and its last logits row IS the next round's d1.
+
+Fallbacks are free: any gate failure (bs>1, sampling, horizon missing) runs the
+normal path; stale spec state is dropped by the (uid, device_len) key; junk KV
+beyond the accepted point is overwritten before it can ever be attended (stores
+happen before attention in mla_forward, one position at a time).
+
+Known v1 gap: MTP layer-45 KV at PROMPT positions is never written (the prefill
+runs only the main stack), so drafts attend junk there -- the measured 0.78
+acceptance already includes this handicap. A prompt-time MTP pass is a later
+quality upgrade, not a correctness issue (verify guarantees exactness).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import Counter
+from typing import List
+
+import torch
+
+from freetoken.core import Batch
+
+
+class _FakeReq:
+    """Just enough of Req for prepare_metadata / build_fla_metadata / MoE prefill."""
+
+    __slots__ = ("table_idx", "cached_len", "device_len", "linear_slot_idx",
+                 "mamba_ping_pong", "mm_embeds")
+
+    def __init__(self, table_idx: int, cached_len: int, device_len: int):
+        self.table_idx = table_idx
+        self.cached_len = cached_len
+        self.device_len = device_len
+        self.linear_slot_idx = None
+        self.mamba_ping_pong = None
+        self.mm_embeds = None
+
+    @property
+    def extend_len(self) -> int:
+        return self.device_len - self.cached_len
+
+
+class Glm5MtpSpec:
+    def __init__(self, engine, k: int):
+        self.eng = engine
+        self.k = k
+        self.log = os.environ.get("FREETOKEN_GLM5_SPEC_LOG", "0") == "1"
+        # KL measurement mode: after each verify, roll KDA state back and REPLAY the
+        # accepted prefix through the real single-token decode path, reporting
+        # KL(sequential || verify) per position + argmax agreement. The replay's final
+        # state then IS the committed state (spec_commit is skipped). ~3x slower;
+        # measurement only. Note the replay attends verify-written KV (1-ulp GEMM
+        # noise on stores), which is exactly the operative continuation question.
+        self.kl_mode = os.environ.get("FREETOKEN_GLM5_SPEC_KL", "0") == "1"
+        self.kl_sum = 0.0
+        self.kl_max = 0.0
+        self.kl_n = 0
+        self.kl_disagree = 0
+        # single-slot spec state, keyed by (uid, device_len)
+        self.uid: int | None = None
+        self.expect_dl = -1
+        self.d1: torch.Tensor | None = None      # [1] draft of the next token
+        self.h_mtp: torch.Tensor | None = None   # [1, D] MTP hidden at the draft position
+        self.cache_gpu: torch.Tensor | None = None  # [n] int32 pending tokens
+        self.cache_pos = 0
+        self.cache_len = 0
+        self._pending = False
+        self.stats = Counter()
+        self.m_hist = Counter()
+        self._round_t = 0.0
+        self._ph = [0.0, 0.0, 0.0, 0.0]  # chain / verify / commit / refresh (cuda-synced)
+        self._kda_layers = [
+            layer.self_attn
+            for layer in engine.model.model.layers.op_list
+            if type(layer.self_attn).__name__ == "KdaAttention"
+        ]
+        # ---- captured verify graph (Phase B). Lazily captured at the first eligible
+        # round when the engine serves with CUDA graphs (their attn staging buffers and
+        # memory pool are reused). Eager verify remains the fallback (KL mode, graphs
+        # off, capture failure).
+        self._vg = None           # torch.cuda.CUDAGraph once captured
+        self._vg_state = None     # dict of static buffers/batch/stash
+        self._vg_failed = self.kl_mode  # KL replay compares against EAGER verify
+
+    # ------------------------------------------------------------------ fake batches
+    def _fake_batch(self, table_idx: int, start: int, toks: torch.Tensor,
+                    span: bool = False) -> Batch:
+        """Fabricated batch at positions [start, start+n).
+
+        ``span`` (MTP chain/refresh): ONE request of n tokens on the prefill path --
+        exact causal extend semantics, and only the last logits row is gathered.
+        Verify (span=False): n single-token fake reqs on the DECODE path -- per-row
+        staggered kvlen gives exact causal attention, lm_head returns every row, and
+        crucially MoE takes the decode fetch (union of activated experts through the
+        LRU cache). The prefill MoE path STREAMS WHOLE LAYERS from host (~130GB for
+        the 39 offload layers) and costs seconds per verify."""
+        eng = self.eng
+        n = toks.numel()
+        if span:
+            reqs: List[_FakeReq] = [_FakeReq(table_idx, start, start + n)]
+            b = Batch(reqs=reqs, phase="prefill")
+        else:
+            reqs = [_FakeReq(table_idx, start + i, start + i + 1) for i in range(n)]
+            b = Batch(reqs=reqs, phase="decode")
+        b.padded_reqs = b.reqs
+        b.input_ids = toks
+        b.positions = torch.arange(start, start + n, dtype=torch.int32, device=eng.device)
+        b.out_loc = eng.page_table[table_idx, start:start + n].clone()
+        if not span:
+            b.active_table_idx = torch.full(
+                (n,), table_idx, dtype=torch.int64, device=eng.device)
+            b.linear_table_idx = torch.full(
+                (n,), table_idx, dtype=torch.int32, device=eng.device)
+        eng.attn_backend.prepare_metadata(b)
+        if not span:
+            # decode _update_pools: rows share ONE table row -- make same-pool writers
+            # produce identical bytes (see DSAAttnBackend._update_pools).
+            b.attn_metadata.spec_shared_row = True
+        return b
+
+    def _fake_decode_batch(self, table_idx: int, pos: int, tok: torch.Tensor) -> Batch:
+        """Fabricated single-token DECODE batch at ``pos`` (KL replay only)."""
+        eng = self.eng
+        b = Batch(reqs=[_FakeReq(table_idx, pos, pos + 1)], phase="decode")
+        b.padded_reqs = b.reqs
+        b.input_ids = tok
+        b.positions = torch.tensor([pos], dtype=torch.int32, device=eng.device)
+        b.out_loc = eng.page_table[table_idx, pos:pos + 1].clone()
+        b.active_table_idx = torch.tensor([table_idx], dtype=torch.int64, device=eng.device)
+        b.linear_table_idx = torch.tensor([table_idx], dtype=torch.int32, device=eng.device)
+        eng.attn_backend.prepare_metadata(b)
+        return b
+
+    # ------------------------------------------------------------------ entry points
+    def try_step(self, batch: Batch):
+        if not batch.is_decode or batch.size != 1:
+            return None
+        req = batch.reqs[0]
+        # Effective greediness: temperature<=0 samples argmax REGARDLESS of top_p/top_k
+        # (Sampler: greedy path, and even the 1e-6-clamped path degenerates to argmax).
+        # SamplingParams.is_greedy is stricter (requires top_p==1.0) and the server's
+        # --sampling-defaults model merges top_p=0.95 into temp=0 requests -- that gate
+        # would disable spec for every normal client call.
+        sp = req.sampling_params
+        if req.aborted or not (sp.temperature <= 0.0 or sp.top_k == 1) or not req.can_decode:
+            return None
+        keyed = req.uid == self.uid and req.device_len == self.expect_dl
+        if keyed and self.cache_pos < self.cache_len:
+            return self._pop(req)
+        if (
+            keyed
+            and self.d1 is not None
+            and self.cache_pos >= self.cache_len
+            and req.spec_alloc_len >= req.device_len + self.k
+            and req.device_len + self.k <= self.eng.max_seq_len
+        ):
+            return self._round(batch, req)
+        self._pending = True  # bootstrap on the normal forward that follows
+        return None
+
+    def wants_eager(self, batch: Batch) -> bool:
+        """Bootstrap steps must run the model EAGERLY: model.last_pre_norm under a
+        graph replay points at whichever graph was captured LAST (the verify graph,
+        once it exists), not this batch's buffer. One eager step per request."""
+        return self._pending
+
+    def after_main(self, batch: Batch, next_tokens_gpu: torch.Tensor) -> None:
+        """Bootstrap: after a normal decode forward, draft d1 under the live batch
+        ctx (probe pattern: same positions/out_loc -> layer-45 KV at position p)."""
+        if not self._pending:
+            return
+        self._pending = False
+        if not batch.is_decode:
+            return
+        eng, model = self.eng, self.eng.model
+        req = batch.reqs[0]
+        h = model.model.last_pre_norm[:1]
+        t1 = next_tokens_gpu[:1].long()
+        with eng.ctx.forward_batch(batch):
+            logits, x = model.mtp.draft_step(
+                h, model.model.embed_tokens.weight[t1], model.lm_head
+            )
+        self.d1 = logits.argmax(dim=-1)
+        self.h_mtp = x[-1:]
+        self.uid = req.uid
+        self.expect_dl = req.device_len  # complete_one already advanced it
+        self.cache_pos = self.cache_len = 0
+        self.stats["bootstrap"] += 1
+
+    # ------------------------------------------------------------------ internals
+    def _pop(self, req):
+        from freetoken.engine.engine import ForwardOutput
+
+        tok = self.cache_gpu[self.cache_pos:self.cache_pos + 1]
+        self.cache_pos += 1
+        self.expect_dl += 1
+        req.complete_one()
+        cpu = tok.to("cpu", non_blocking=True)
+        ev = torch.cuda.Event()
+        ev.record(self.eng.stream)
+        self.stats["pop"] += 1
+        return ForwardOutput(tok, cpu, ev)
+
+    def _round(self, batch: Batch, req):
+        from freetoken.engine.engine import ForwardOutput
+
+        eng, model, k = self.eng, self.eng.model, self.k
+        t0 = time.monotonic()
+        p = req.device_len - 1
+        x_p = batch.input_ids[:1].to(torch.int32)
+        emb_w = model.model.embed_tokens.weight
+
+        def _tick(i0):
+            torch.cuda.synchronize()
+            t = time.monotonic()
+            if i0 >= 0:
+                self._ph[i0] += t - _tick.last
+            _tick.last = t
+        _tick(-1)
+
+        # -- draft chain: d1 carried; d2..dk via MTP at positions p..p+k-2
+        drafts = [self.d1]
+        h = self.h_mtp
+        for j in range(2, k + 1):
+            prev = drafts[-1]
+            fb = self._fake_batch(req.table_idx, p + j - 2, prev.to(torch.int32), span=True)
+            with eng.ctx.forward_batch(fb):
+                lg, h = model.mtp.draft_step(h, emb_w[prev], model.lm_head)
+            drafts.append(lg.argmax(dim=-1))
+
+        _tick(0)
+        # -- verify: one main-model forward, k+1 single-token fake reqs
+        d_t = torch.cat(drafts)  # [k] int64
+        toks = torch.cat([x_p, d_t.to(torch.int32)])
+        if self._vg is None and not self._vg_failed:
+            self._try_capture_verify(req, p, toks)
+        if self._vg is not None:
+            vb, vlogits, h_v = self._replay_verify(req, p, toks)
+        else:
+            vb = self._fake_batch(req.table_idx, p, toks)
+            vb.spec_stash = {}
+            with eng.ctx.forward_batch(vb):
+                vlogits = model.forward()  # [k+1, V]
+            h_v = model.model.last_pre_norm  # [k+1, D]
+        greedy = vlogits.argmax(dim=-1)  # [k+1]
+
+        _tick(1)
+        # -- accept: longest draft prefix + bonus (one host sync for m)
+        matched = torch.cumprod((greedy[:k] == d_t).int(), 0)
+        m = int(matched.sum().item())
+        # never emit past the output budget (scheduler finishes the req at remain 0)
+        m = min(m, req.remain_len - 1)
+        emitted = torch.cat([d_t[:m], greedy[m:m + 1]])  # [m+1]
+
+        # -- KDA state commit at the accepted prefix
+        if self.kl_mode:
+            self._kl_replay(req, vb, vlogits, toks, emitted, p, m)
+        elif m < k:
+            for attn in self._kda_layers:
+                attn.spec_commit(vb.spec_stash[attn.layer_id], m + 1, req.table_idx)
+
+        _tick(2)
+        # -- MTP refresh over accepted positions p..p+m: exact layer-45 KV + next d1
+        rb = self._fake_batch(req.table_idx, p, emitted.to(torch.int32), span=True)
+        with eng.ctx.forward_batch(rb):
+            rlg, x = model.mtp.draft_step(h_v[:m + 1], emb_w[emitted], model.lm_head)
+        self.d1 = rlg.argmax(dim=-1)
+        self.h_mtp = x[-1:]
+
+        _tick(3)
+        # -- bookkeeping: emit first token now, cache the rest
+        req.complete_one()
+        self.cache_gpu = emitted[1:].to(torch.int32)
+        self.cache_pos, self.cache_len = 0, m
+        self.expect_dl = req.device_len
+
+        self.stats["round"] += 1
+        self.stats["accepted"] += m
+        self.m_hist[m] += 1
+        self._round_t += time.monotonic() - t0
+        if self.log and (self.stats["round"] % 25 == 0 or self.stats["round"] == 1):
+            r = self.stats["round"]
+            print(
+                f"[mtp-spec] rounds={r} tok/round={(self.stats['accepted'] + r) / r:.2f}"
+                f" m_hist={dict(sorted(self.m_hist.items()))}"
+                f" ms/round={1000 * self._round_t / r:.1f}"
+                f" phases(chain/verify/commit/refresh)ms="
+                f"{'/'.join(f'{1000 * x / r:.0f}' for x in self._ph)}"
+                f" pops={self.stats['pop']} boots={self.stats['bootstrap']}",
+                flush=True,
+            )
+
+        if self.kl_mode and self.log and self.stats["round"] % 25 == 0 and self.kl_n:
+            print(
+                f"[mtp-spec-kl] n={self.kl_n} kl_mean={self.kl_sum / self.kl_n:.3e}"
+                f" kl_max={self.kl_max:.3e} argmax_disagree={self.kl_disagree}",
+                flush=True,
+            )
+        out = emitted[:1].to(torch.int32)
+        cpu = out.to("cpu", non_blocking=True)
+        ev = torch.cuda.Event()
+        ev.record(eng.stream)
+        return ForwardOutput(out, cpu, ev)
+
+
+    # ------------------------------------------------------------------ verify graph
+    def _try_capture_verify(self, req, p: int, toks: torch.Tensor) -> None:
+        """Capture the verify forward as a standalone CUDA graph (once per boot).
+        Reuses the engine graphs' attention staging buffers (init_capture_graph) and
+        memory pool. On any precondition failure, marks eager-forever."""
+        eng = self.eng
+        runner = eng.graph_runner
+        n = self.k + 1
+        if not runner.graph_map or getattr(eng.attn_backend, "_rows_buf", None) is None                 or runner.max_graph_bs < n:
+            self._vg_failed = True
+            return
+        try:
+            dev = eng.device
+            st: dict = {}
+            st["input_ids"] = torch.zeros(n, dtype=torch.int32, device=dev)
+            st["positions"] = torch.zeros(n, dtype=torch.int32, device=dev)
+            st["out_loc"] = torch.zeros(n, dtype=torch.int32, device=dev)
+            st["active"] = torch.zeros(n, dtype=torch.int64, device=dev)
+            st["linear"] = torch.zeros(n, dtype=torch.int32, device=dev)
+            b = Batch(reqs=[_FakeReq(req.table_idx, p + i, p + i + 1) for i in range(n)],
+                      phase="decode")
+            b.padded_reqs = b.reqs
+            b.input_ids = st["input_ids"]
+            b.positions = st["positions"]
+            b.out_loc = st["out_loc"]
+            b.active_table_idx = st["active"]
+            b.linear_table_idx = st["linear"]
+            eng.attn_backend.prepare_metadata(b)   # persistent md (pinned kv_len_cpu)
+            b.attn_metadata.spec_shared_row = True
+            b.spec_stash = {}
+            st["batch"] = b
+            # Capture ON THE DUMMY SLOT (GraphRunner pattern): its page-table row points
+            # at the sink page and its state slot is scratch, so the warm forward and
+            # the capture run have ZERO side effects on the live request. Replays then
+            # stage the real request's addressing into the same buffers.
+            dummy = eng.dummy_req
+            self._stage_verify(st, dummy, 0, torch.zeros_like(toks))
+            model = eng.model
+            g = torch.cuda.CUDAGraph()
+            pool = next(iter(runner.graph_map.values())).pool()
+            with eng.ctx.forward_batch(b):
+                warm = model.forward()             # warmup + triton compile (uncaptured)
+                st["logits"] = torch.empty_like(warm)
+                b.spec_stash.clear()
+                with torch.cuda.graph(g, pool=pool, stream=eng.stream):
+                    st["logits"].copy_(model.forward())
+            st["h"] = model.model.last_pre_norm    # captured buffer, refreshed per replay
+            self._vg = g
+            self._vg_state = st
+            print(f"[mtp-spec] verify graph captured (bs={n})", flush=True)
+        except Exception as e:  # noqa: BLE001
+            self._vg_failed = True
+            print(f"[mtp-spec] verify graph capture FAILED ({e!r}); staying eager", flush=True)
+
+    def _stage_verify(self, st: dict, req, p: int, toks: torch.Tensor) -> None:
+        n = self.k + 1
+        eng = self.eng
+        st["input_ids"].copy_(toks)
+        st["positions"].copy_(torch.arange(p, p + n, dtype=torch.int32, device=eng.device))
+        st["out_loc"].copy_(eng.page_table[req.table_idx, p:p + n])
+        st["active"].fill_(req.table_idx)
+        st["linear"].fill_(req.table_idx)
+        b = st["batch"]
+        md = b.attn_metadata
+        for i, r in enumerate(b.reqs):
+            r.table_idx = req.table_idx
+            r.cached_len = p + i
+            r.device_len = p + i + 1
+        for i in range(n):
+            md.kv_len_cpu[i] = p + i + 1
+        # decode staging: rows/kvlen/pool_rows into the shared static buffers the
+        # captured kernels read (same call the engine's own replays use).
+        eng.attn_backend.prepare_for_replay(b)
+
+    def _replay_verify(self, req, p: int, toks: torch.Tensor):
+        st = self._vg_state
+        self._stage_verify(st, req, p, toks)
+        self._vg.replay()
+        b = st["batch"]
+        return b, st["logits"], st["h"]
+
+    def _kl_replay(self, req, vb, vlogits, toks, emitted, p, m):
+        """Roll KDA back to pre-verify and replay the accepted prefix through the
+        REAL decode path; measure KL(sequential || verify) and argmax agreement.
+        Leaves KDA state exactly as sequential execution would (replaces commit)."""
+        eng, model = self.eng, self.eng.model
+        for attn in self._kda_layers:
+            attn.spec_restore(vb.spec_stash[attn.layer_id], req.table_idx)
+        for i in range(m + 1):
+            db = self._fake_decode_batch(req.table_idx, p + i, toks[i:i + 1])
+            with eng.ctx.forward_batch(db):
+                slog = model.forward()[0]
+            ps = torch.log_softmax(slog.float(), -1)
+            pv = torch.log_softmax(vlogits[i].float(), -1)
+            kl = float(torch.sum(ps.exp() * (ps - pv)).item())
+            self.kl_sum += kl
+            self.kl_max = max(self.kl_max, kl)
+            self.kl_n += 1
+            if int(ps.argmax().item()) != int(emitted[i].item()):
+                self.kl_disagree += 1
+
+
+__all__ = ["Glm5MtpSpec"]

--- a/python/freetoken/models/glm5_next/vision.py
+++ b/python/freetoken/models/glm5_next/vision.py
@@ -1,0 +1,245 @@
+"""GLM-5.3-Flash vision tower (text-side port of HF ``Glm5NextVisionModel``).
+
+Faithful eager translation -- the tower runs once per image at prefill, so plain
+torch ops are fine. Attribute names mirror the checkpoint (``visual.blocks.N.attn.qkv``
+etc.), and every weight stays BF16, exactly like the source ``model.visual.*`` tensors.
+
+Contract (called by ``LLM.encode_images`` / the server's mm path):
+    encode_images(pixel_values, grid_thw) -> [num_image_tokens, out_hidden] bf16
+      pixel_values: [total_patches, in_ch * temporal_patch * patch * patch]  (HF processor)
+      grid_thw:     [num_images, 3] long (t, h, w) patch grid per image
+Tokens per image = t * (h/merge) * (w/merge); rows are in image order, matching the
+``image_token_id`` placeholder runs the processor writes into the prompt."""
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from freetoken.layers import BaseOP, OPList
+
+
+def _rms(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    dt = x.dtype
+    xf = x.float()
+    xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)
+    return (weight * xf.to(dt)) if weight.dtype == dt else (weight.to(dt) * xf.to(dt))
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rope_vision(q, k, cos, sin):
+    # cos/sin arrive pre-unsqueezed fp32 (built once per forward, not per block)
+    dt = q.dtype
+    q, k = q.float(), k.float()
+    qe = (q * cos) + (_rotate_half(q) * sin)
+    ke = (k * cos) + (_rotate_half(k) * sin)
+    return qe.to(dt), ke.to(dt)
+
+
+class _VLinear(BaseOP):
+    def __init__(self, in_f: int, out_f: int, bias: bool):
+        self.weight = torch.empty(out_f, in_f, dtype=torch.bfloat16)
+        self.bias = torch.empty(out_f, dtype=torch.bfloat16) if bias else None
+
+    def forward(self, x):
+        return F.linear(x, self.weight, self.bias)
+
+
+class _VNorm(BaseOP):
+    """RMSNorm (weight only) in HF fp32 semantics."""
+
+    def __init__(self, dim: int, eps: float):
+        self.weight = torch.empty(dim, dtype=torch.bfloat16)
+        self._eps = eps
+
+    def forward(self, x):
+        return _rms(x, self.weight, self._eps)
+
+
+class _VLayerNorm(BaseOP):
+    def __init__(self, dim: int):
+        self.weight = torch.empty(dim, dtype=torch.bfloat16)
+        self.bias = torch.empty(dim, dtype=torch.bfloat16)
+
+    def forward(self, x):
+        return F.layer_norm(x.float(), self.weight.shape, self.weight.float(),
+                            self.bias.float()).to(x.dtype)
+
+
+class _VAttention(BaseOP):
+    def __init__(self, vc):
+        self.qkv = _VLinear(vc["hidden_size"], vc["hidden_size"] * 3, vc["attention_bias"])
+        self.proj = _VLinear(vc["hidden_size"], vc["hidden_size"], vc["attention_bias"])
+        self.q_norm = _VNorm(vc["hidden_size"] // vc["num_heads"], vc["rms_norm_eps"])
+        self.k_norm = _VNorm(vc["hidden_size"] // vc["num_heads"], vc["rms_norm_eps"])
+        self._heads = vc["num_heads"]
+        self._scale = (vc["hidden_size"] // vc["num_heads"]) ** -0.5
+
+    def forward(self, x, bounds, cos, sin):
+        S = x.shape[0]
+        q, k, v = self.qkv.forward(x).reshape(S, 3, self._heads, -1).permute(1, 0, 2, 3).unbind(0)
+        q = self.q_norm.forward(q)
+        k = self.k_norm.forward(k)
+        q, k = _apply_rope_vision(q, k, cos, sin)
+        # per-image full attention (bounds delimits images), exact sdpa per chunk
+        outs = []
+        for i in range(len(bounds) - 1):
+            a, b = bounds[i], bounds[i + 1]
+            qi = q[a:b].transpose(0, 1)  # [H, L, D]
+            ki = k[a:b].transpose(0, 1)
+            vi = v[a:b].transpose(0, 1)
+            oi = F.scaled_dot_product_attention(qi, ki, vi, scale=self._scale)
+            outs.append(oi.transpose(0, 1))
+        out = torch.cat(outs, dim=0).reshape(S, -1)
+        return self.proj.forward(out)
+
+
+class _VMLP(BaseOP):
+    def __init__(self, vc, dim: int, inter: int, bias: bool):
+        self.gate_proj = _VLinear(dim, inter, bias)
+        self.up_proj = _VLinear(dim, inter, bias)
+        self.down_proj = _VLinear(inter, dim, bias)
+        self._limit = vc["swiglu_limit"]
+
+    def forward(self, x):
+        gate = self.gate_proj.forward(x).clamp(max=self._limit)
+        up = self.up_proj.forward(x).clamp(min=-self._limit, max=self._limit)
+        return self.down_proj.forward(F.silu(gate) * up)
+
+
+class _VBlock(BaseOP):
+    def __init__(self, vc):
+        self.norm1 = _VNorm(vc["hidden_size"], vc["rms_norm_eps"])
+        self.norm2 = _VNorm(vc["hidden_size"], vc["rms_norm_eps"])
+        self.attn = _VAttention(vc)
+        self.mlp = _VMLP(vc, vc["hidden_size"], vc["intermediate_size"], vc["attention_bias"])
+
+    def forward(self, x, bounds, cos, sin):
+        x = x + self.attn.forward(self.norm1.forward(x), bounds, cos, sin)
+        x = x + self.mlp.forward(self.norm2.forward(x))
+        return x
+
+
+class _VConv3d(BaseOP):
+    def __init__(self, out_c: int, in_c: int, k):
+        self.weight = torch.empty(out_c, in_c, *k, dtype=torch.bfloat16)
+        self.bias = torch.empty(out_c, dtype=torch.bfloat16)
+
+    def forward(self, x):
+        return F.conv3d(x, self.weight, self.bias, stride=self.weight.shape[2:])
+
+
+class _VConv2d(BaseOP):
+    def __init__(self, in_c: int, out_c: int, k: int):
+        self.weight = torch.empty(out_c, in_c, k, k, dtype=torch.bfloat16)
+        self.bias = torch.empty(out_c, dtype=torch.bfloat16)
+        self._k = k
+
+    def forward(self, x):
+        return F.conv2d(x.to(self.weight.dtype), self.weight, self.bias, stride=self._k)
+
+
+class _VPatchEmbed(BaseOP):
+    """Checkpoint path ``visual.patch_embed.proj.{weight,bias}`` -> nested ``proj``."""
+
+    def __init__(self, vc):
+        k = (vc["temporal_patch_size"], vc["patch_size"], vc["patch_size"])
+        self.proj = _VConv3d(vc["hidden_size"], vc["in_channels"], k)
+        self._shape = (vc["in_channels"], vc["temporal_patch_size"], vc["patch_size"], vc["patch_size"])
+        self._dim = vc["hidden_size"]
+
+    def forward(self, x):
+        x = x.view(-1, *self._shape).to(self.proj.weight.dtype)
+        return self.proj.forward(x).view(-1, self._dim)
+
+
+class _VMerger(BaseOP):
+    def __init__(self, vc):
+        dim, ctx = vc["out_hidden_size"], vc["projection_intermediate_size"]
+        self.proj = _VLinear(dim, dim, False)
+        self.post_projection_norm = _VLayerNorm(dim)
+        self.gate_proj = _VLinear(dim, ctx, False)
+        self.up_proj = _VLinear(dim, ctx, False)
+        self.down_proj = _VLinear(ctx, dim, False)
+        self._limit = vc["swiglu_limit"]
+
+    def forward(self, x):
+        x = self.proj.forward(x)
+        x = F.gelu(self.post_projection_norm.forward(x))
+        gate = self.gate_proj.forward(x).clamp(max=self._limit)
+        up = self.up_proj.forward(x).clamp(min=-self._limit, max=self._limit)
+        return self.down_proj.forward(F.silu(gate) * up)
+
+
+class Glm5Vision(BaseOP):
+    """The ``model.visual`` tower: patch embed -> 24 blocks -> merge/downsample -> merger."""
+
+    def __init__(self, vc: dict):
+        self._vc = vc
+        self.patch_embed = _VPatchEmbed(vc)
+        self.blocks = OPList([_VBlock(vc) for _ in range(vc["depth"])])
+        self.post_layernorm = _VNorm(vc["hidden_size"], vc["rms_norm_eps"])
+        # downsample: Conv2d(hidden -> out_hidden, k=s=merge)
+        m = vc["spatial_merge_size"]
+        self.downsample = _VConv2d(vc["hidden_size"], vc["out_hidden_size"], m)
+        self.merger = _VMerger(vc)
+
+    def _inv_freq_for(self, device) -> torch.Tensor:
+        # Computed, not loaded -- and therefore built LAZILY on the runtime device.
+        # The engine constructs models under a meta-device context; a tensor computed
+        # in __init__ stays meta (no checkpoint key overwrites it) and dies at first
+        # use ("Cannot copy out of meta tensor").
+        inv = getattr(self, "_inv_freq_cache", None)
+        if inv is None or inv.device != device:
+            head_dim = self._vc["hidden_size"] // self._vc["num_heads"]
+            rd = head_dim // 2
+            inv = 1.0 / (
+                10000.0 ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd)
+            )
+            self._inv_freq_cache = inv
+        return inv
+
+    def _position_ids(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        m = self._vc["spatial_merge_size"]
+        device = grid_thw.device
+        out = []
+        for t, h, w in grid_thw.tolist():
+            hp, wp = torch.meshgrid(torch.arange(h, device=device),
+                                    torch.arange(w, device=device), indexing="ij")
+            shape = (h // m, m, w // m, m)
+            hp = hp.reshape(shape).transpose(1, 2).flatten()
+            wp = wp.reshape(shape).transpose(1, 2).flatten()
+            out.append(torch.stack([hp, wp], dim=-1).repeat(t, 1))
+        return torch.cat(out, dim=0)
+
+    def forward(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
+        vc = self._vc
+        pos = self._position_ids(grid_thw)                        # [S, 2]
+        # Attention segments follow the qwen2_vl/glm4v convention (HF
+        # get_vision_cu_seqlens merge_temporal=False): each temporal unit is its
+        # own segment -- t segments of h*w patches per video, one for an image.
+        bounds = [0]
+        for t, h, w in grid_thw.tolist():                         # one host sync total
+            hw = h * w
+            for _ in range(int(t)):
+                bounds.append(bounds[-1] + hw)
+        x = self.patch_embed.forward(pixel_values)
+        inv = self._inv_freq_for(x.device)
+        rot = (pos.unsqueeze(-1) * inv).flatten(1)                # [S, rd/2*2]
+        emb = torch.cat((rot, rot), dim=-1)
+        cos = emb.cos().unsqueeze(-2).float()                     # fp32 once, all 24 blocks
+        sin = emb.sin().unsqueeze(-2).float()
+        for blk in self.blocks.op_list:
+            x = blk.forward(x, bounds, cos, sin)
+        x = self.post_layernorm.forward(x)
+        m = vc["spatial_merge_size"]
+        x = x.view(-1, m, m, x.shape[-1]).permute(0, 3, 1, 2)
+        x = self.downsample.forward(x).view(-1, vc["out_hidden_size"])
+        return self.merger.forward(x)
+
+
+__all__ = ["Glm5Vision"]

--- a/python/freetoken/models/glm5_next/weight.py
+++ b/python/freetoken/models/glm5_next/weight.py
@@ -1,0 +1,296 @@
+"""Weight loading for GLM-5.3-Flash (``glm5_next``).
+
+Checkpoint layout (LibertAIDAI NVFP4, verified from the shard headers):
+  * language tower under ``model.language_model.*`` -> served as ``model.*``;
+  * layer 45 is the MTP layer (eh_proj/enorm/hnorm/shared_head + its own experts) --
+    discarded, like every other FreeToken model;
+  * KDA linear layers ship SEPARATE q/k/v projections and SEPARATE per-projection
+    depthwise convs; the module serves one merged GEMM + one grouped conv, and
+    depthwise-ness makes the [q|k|v] channel concat EXACTLY equivalent;
+  * routed experts are modelopt NVFP4 (packed uint8 + fp8 block-16 scales + fp32
+    global) with separate gate/up -> the generic bank builder stacks them;
+  * everything else bf16 except hc_*_base/scale, A_log, dt_bias (fp32).
+
+Quality-first baseline: every resident weight streams through VERBATIM (bf16); the
+FP8 requant switches exist (``FREETOKEN_GLM5_ATTN_FP8`` / ``_MLP_FP8`` via
+parse_config) for the later A/B, same machinery as glm_moe_dsa.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Iterator
+
+import torch
+from freetoken.distributed import get_tp_info
+from freetoken.models.glm_moe_dsa.weight import _quant_fp8_per_row, _ShardReader
+from freetoken.models.loader import drop_page_cache
+from freetoken.models.nvfp4_banks import (
+    Nvfp4ExpertSourceSpec,
+    load_nvfp4_expert_source_banks,
+)
+from freetoken.utils import cached_load_hf_config, download_hf_weight
+from tqdm import tqdm
+
+from .config import parse_config
+
+# ---------------------------------------------------------------------------------
+# Routed experts -> offload cache (generic NVFP4 bank builder, GLM-5.3 name layout).
+# MTP layer 45 is excluded by ``layer >= config.num_layers`` (num_layers == 45).
+# ---------------------------------------------------------------------------------
+_ROUTED_EXPERT_KEY_RE = re.compile(
+    r"^model\.language_model\.layers\.(?P<layer>\d+)\.mlp\.experts\.(?P<expert>\d+)\."
+    r"(?P<proj>gate_proj|up_proj|down_proj)\.(?P<kind>weight|weight_scale|weight_scale_2)$"
+)
+def _layer_to_bank(layer: int, config) -> int | None:
+    """Host-bank id for a checkpoint layer: dense over the non-resident MoE layers
+    (resident layers live on the GPU as model weights; MTP layer 45 excluded by
+    ``layer >= num_layers``)."""
+    from .moe import offload_moe_layers
+
+    if layer < config.first_k_dense_replace or layer >= config.num_layers:
+        return None
+    if layer in config.glm5_args.resident_layer_ids:
+        return None
+    return offload_moe_layers(config).index(layer)
+
+
+_NVFP4_SOURCE_SPEC = Nvfp4ExpertSourceSpec(
+    key_pattern=_ROUTED_EXPERT_KEY_RE,
+    proj_to_role={"gate_proj": "gate", "up_proj": "up", "down_proj": "down"},
+    layer_to_bank=_layer_to_bank,
+    desc="GLM-5.3 NVFP4 experts",
+)
+
+
+def load_nvfp4_expert_sources(model_path: str, config, *, layer_sink=None):
+    return load_nvfp4_expert_source_banks(
+        model_path, config, _NVFP4_SOURCE_SPEC,
+        drop_page_cache=drop_page_cache,
+        primary=get_tp_info().is_primary(),
+        layer_sink=layer_sink,
+    )
+
+
+def load_nvfp4_expert_sources_parallel(
+    model_path: str, config, *, workers: int = 8, chunk: int = 8 << 20, layer_sink=None
+):
+    from freetoken.models.nvfp4_banks import load_nvfp4_expert_source_banks_parallel
+
+    return load_nvfp4_expert_source_banks_parallel(
+        model_path, config, _NVFP4_SOURCE_SPEC,
+        drop_page_cache=drop_page_cache,
+        primary=get_tp_info().is_primary(),
+        workers=workers, chunk=chunk, layer_sink=layer_sink,
+    )
+
+
+# ---------------------------------------------------------------------------------
+# Resident (dense) weights.
+# ---------------------------------------------------------------------------------
+def iter_weights(
+    model_path: str,
+    device: torch.device,
+    *,
+    include_moe_experts: bool,
+    include_non_moe: bool,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    assert not include_moe_experts, (
+        "GLM-5.3 routed experts are NVFP4 offload-only; they load via "
+        "load_nvfp4_expert_sources()."
+    )
+    assert include_non_moe
+    config = parse_config(cached_load_hf_config(model_path))
+    a = config.glm5_args
+    folder = download_hf_weight(model_path)
+    with open(os.path.join(folder, "model.safetensors.index.json")) as f:
+        weight_map = json.load(f)["weight_map"]
+    reader = _ShardReader(folder, weight_map, device)
+    primary = get_tp_info().is_primary()
+    attn_fp8 = config.attn_quant == "fp8_pertensor"
+    mlp_fp8 = config.dense_quant == "fp8_pertensor"
+    head_fp8 = config.lm_head_quant == "fp8_pertensor"
+
+    def _proj(src_key: str, dst_key: str, fp8: bool):
+        w = reader.get(f"{src_key}.weight")
+        if fp8:
+            q, scale = _quant_fp8_per_row(w)
+            yield f"{dst_key}.weight", q
+            yield f"{dst_key}.weight_scale", scale
+        else:
+            yield f"{dst_key}.weight", w
+
+    try:
+        for layer in tqdm(
+            range(config.num_layers),
+            desc="Loading GLM-5.3 dense weights",
+            disable=not primary,
+        ):
+            src = f"model.language_model.layers.{layer}"
+            dst = f"model.layers.{layer}"
+            # Hyper-connections: checkpoint uses the DSV4 flat names our layer also uses.
+            for t in ("hc_attn_fn", "hc_ffn_fn", "hc_attn_base", "hc_ffn_base",
+                      "hc_attn_scale", "hc_ffn_scale"):
+                yield f"{dst}.{t}", reader.get(f"{src}.{t}")
+            for norm in ("input_layernorm", "post_attention_layernorm"):
+                yield f"{dst}.{norm}.weight", reader.get(f"{src}.{norm}.weight")
+
+            sa_s, sa_d = f"{src}.self_attn", f"{dst}.self_attn"
+            if a.is_kda_layer(layer):
+                # Separate q/k/v proj + per-proj depthwise convs -> merged [q|k|v]
+                # GEMM / grouped conv (channel-concat is exact for depthwise).
+                qkv = torch.cat(
+                    [reader.get(f"{sa_s}.{p}_proj.weight") for p in ("q", "k", "v")], dim=0
+                )
+                if a.kda_fp8:
+                    qq, qscale = _quant_fp8_per_row(qkv)
+                    yield f"{sa_d}.in_proj_qkv.weight", qq
+                    yield f"{sa_d}.in_proj_qkv.weight_scale", qscale
+                else:
+                    yield f"{sa_d}.in_proj_qkv.weight", qkv
+                conv = torch.cat(
+                    [reader.get(f"{sa_s}.{p}_conv1d.weight") for p in ("q", "k", "v")], dim=0
+                )
+                yield f"{sa_d}.conv1d.weight", conv
+                for p in ("f_a_proj", "f_b_proj", "b_proj", "g_a_proj", "g_b_proj"):
+                    yield f"{sa_d}.{p}.weight", reader.get(f"{sa_s}.{p}.weight")
+                yield from _proj(f"{sa_s}.o_proj", f"{sa_d}.o_proj", a.kda_fp8)
+                for t in ("dt_bias", "A_log"):
+                    yield f"{sa_d}.{t}", reader.get(f"{sa_s}.{t}")
+                yield f"{sa_d}.o_norm.weight", reader.get(f"{sa_s}.o_norm.weight")
+            else:
+                fp8_projs = (
+                    ("q_a_proj", "q_b_proj", "kv_a_proj_with_mqa", "o_proj")
+                    if attn_fp8 else ()
+                )
+                for p in ("q_a_proj", "q_b_proj", "kv_a_proj_with_mqa", "kv_b_proj",
+                          "o_proj"):
+                    yield from _proj(f"{sa_s}.{p}", f"{sa_d}.{p}", p in fp8_projs)
+                for n in ("q_a_layernorm", "kv_a_layernorm"):
+                    yield f"{sa_d}.{n}.weight", reader.get(f"{sa_s}.{n}.weight")
+                # DSA lightning indexer + k-pool compressor (always bf16-faithful;
+                # ape/gate load into the module's fp32/bf16 slots via _materialize).
+                for p in ("wq_b", "wk", "weights_proj"):
+                    yield f"{sa_d}.indexer.{p}.weight", reader.get(f"{sa_s}.indexer.{p}.weight")
+                yield f"{sa_d}.indexer.k_norm.weight", reader.get(f"{sa_s}.indexer.k_norm.weight")
+                yield f"{sa_d}.indexer.k_norm.bias", reader.get(f"{sa_s}.indexer.k_norm.bias")
+                yield (f"{sa_d}.indexer.kpool_gate.weight",
+                       reader.get(f"{sa_s}.indexer.index_kpool_compress_gate"))
+                yield (f"{sa_d}.indexer.kpool_ape",
+                       reader.get(f"{sa_s}.indexer.index_kpool_compress_ape"))
+
+            m_s, m_d = f"{src}.mlp", f"{dst}.mlp"
+            if layer in a.resident_layer_ids:
+                # Resident layer: the full packed banks load as MODEL weights (GPU).
+                E = config.num_experts
+
+                def _stack(proj, kind):
+                    return torch.stack(
+                        [reader.get(f"{m_s}.experts.{e}.{proj}.{kind}") for e in range(E)]
+                    )
+
+                def _glob(proj, rows):
+                    return torch.stack([
+                        reader.get(f"{m_s}.experts.{e}.{proj}.weight_scale_2")
+                        .reshape(1).to(torch.float16).expand(rows)
+                        for e in range(E)
+                    ]).contiguous()
+
+                gu_p = torch.cat([_stack("gate_proj", "weight"), _stack("up_proj", "weight")], dim=1)
+                gu_s = torch.cat([_stack("gate_proj", "weight_scale"), _stack("up_proj", "weight_scale")], dim=1)
+                i_sz = gu_p.shape[1] // 2
+                gu_g = torch.cat([_glob("gate_proj", i_sz), _glob("up_proj", i_sz)], dim=1)
+                yield f"{m_d}.experts.gate_up_packed", gu_p
+                yield f"{m_d}.experts.gate_up_scale", gu_s
+                yield f"{m_d}.experts.gate_up_global", gu_g
+                yield f"{m_d}.experts.down_packed", _stack("down_proj", "weight")
+                yield f"{m_d}.experts.down_scale", _stack("down_proj", "weight_scale")
+                yield f"{m_d}.experts.down_global", _glob("down_proj", config.hidden_size)
+            if a.is_dense_layer(layer):
+                for p in ("gate_proj", "up_proj", "down_proj"):
+                    yield from _proj(f"{m_s}.{p}", f"{m_d}.{p}", mlp_fp8)
+            else:
+                yield f"{m_d}.gate.weight", reader.get(f"{m_s}.gate.weight")
+                yield (f"{m_d}.e_score_correction_bias",
+                       reader.get(f"{m_s}.gate.e_score_correction_bias"))
+                for p in ("gate_proj", "up_proj", "down_proj"):
+                    yield from _proj(f"{m_s}.shared_experts.{p}", f"{m_d}.shared_experts.{p}", mlp_fp8)
+
+        if a.mtp_enabled:
+            L = a.mtp_layer_id
+            src = f"model.language_model.layers.{L}"
+            yield "mtp.enorm.weight", reader.get(f"{src}.enorm.weight")
+            yield "mtp.hnorm.weight", reader.get(f"{src}.hnorm.weight")
+            yield "mtp.eh_proj.weight", reader.get(f"{src}.eh_proj.weight")
+            yield "mtp.shared_head.norm.weight", reader.get(f"{src}.shared_head.norm.weight")
+            dstl = "mtp.layer"
+            # layer 45 ships NO hc_* weights: plain pre-norm residual block.
+            for norm in ("input_layernorm", "post_attention_layernorm"):
+                yield f"{dstl}.{norm}.weight", reader.get(f"{src}.{norm}.weight")
+            sa_s, sa_d = f"{src}.self_attn", f"{dstl}.self_attn"
+            fp8_projs = (
+                ("q_a_proj", "q_b_proj", "kv_a_proj_with_mqa", "o_proj") if attn_fp8 else ()
+            )
+            for pj in ("q_a_proj", "q_b_proj", "kv_a_proj_with_mqa", "kv_b_proj", "o_proj"):
+                yield from _proj(f"{sa_s}.{pj}", f"{sa_d}.{pj}", pj in fp8_projs)
+            for n in ("q_a_layernorm", "kv_a_layernorm"):
+                yield f"{sa_d}.{n}.weight", reader.get(f"{sa_s}.{n}.weight")
+            for pj in ("wq_b", "wk", "weights_proj"):
+                yield f"{sa_d}.indexer.{pj}.weight", reader.get(f"{sa_s}.indexer.{pj}.weight")
+            yield f"{sa_d}.indexer.k_norm.weight", reader.get(f"{sa_s}.indexer.k_norm.weight")
+            yield f"{sa_d}.indexer.k_norm.bias", reader.get(f"{sa_s}.indexer.k_norm.bias")
+            yield (f"{sa_d}.indexer.kpool_gate.weight",
+                   reader.get(f"{sa_s}.indexer.index_kpool_compress_gate"))
+            yield (f"{sa_d}.indexer.kpool_ape",
+                   reader.get(f"{sa_s}.indexer.index_kpool_compress_ape"))
+            m_s, m_d = f"{src}.mlp", f"{dstl}.mlp"
+            yield f"{m_d}.gate.weight", reader.get(f"{m_s}.gate.weight")
+            yield (f"{m_d}.e_score_correction_bias",
+                   reader.get(f"{m_s}.gate.e_score_correction_bias"))
+            for pj in ("gate_proj", "up_proj", "down_proj"):
+                yield from _proj(f"{m_s}.shared_experts.{pj}", f"{m_d}.shared_experts.{pj}", mlp_fp8)
+            E = config.num_experts
+
+            def _stack45(proj, kind):
+                return torch.stack(
+                    [reader.get(f"{m_s}.experts.{e}.{proj}.{kind}") for e in range(E)]
+                )
+
+            def _glob45(proj, rows):
+                return torch.stack([
+                    reader.get(f"{m_s}.experts.{e}.{proj}.weight_scale_2")
+                    .reshape(1).to(torch.float16).expand(rows)
+                    for e in range(E)
+                ]).contiguous()
+
+            gu_p = torch.cat([_stack45("gate_proj", "weight"), _stack45("up_proj", "weight")], dim=1)
+            gu_s = torch.cat([_stack45("gate_proj", "weight_scale"), _stack45("up_proj", "weight_scale")], dim=1)
+            i_sz = gu_p.shape[1] // 2
+            gu_g = torch.cat([_glob45("gate_proj", i_sz), _glob45("up_proj", i_sz)], dim=1)
+            yield f"{m_d}.experts.gate_up_packed", gu_p
+            yield f"{m_d}.experts.gate_up_scale", gu_s
+            yield f"{m_d}.experts.gate_up_global", gu_g
+            yield f"{m_d}.experts.down_packed", _stack45("down_proj", "weight")
+            yield f"{m_d}.experts.down_scale", _stack45("down_proj", "weight_scale")
+            yield f"{m_d}.experts.down_global", _glob45("down_proj", config.hidden_size)
+
+        yield "model.embed_tokens.weight", reader.get("model.language_model.embed_tokens.weight")
+        yield "model.norm.weight", reader.get("model.language_model.norm.weight")
+        head = reader.get("lm_head.weight")
+        if head_fp8 and not config.tie_word_embeddings:
+            q, scale = _quant_fp8_per_row(head)
+            yield "lm_head.weight", q
+            yield "lm_head.weight_scale", scale
+        else:
+            yield "lm_head.weight", head
+    finally:
+        reader.close()
+
+
+__all__ = [
+    "iter_weights",
+    "load_nvfp4_expert_sources",
+    "load_nvfp4_expert_sources_parallel",
+]

--- a/python/freetoken/models/glm5_next/weight.py
+++ b/python/freetoken/models/glm5_next/weight.py
@@ -285,6 +285,14 @@ def iter_weights(
             yield "lm_head.weight_scale", scale
         else:
             yield "lm_head.weight", head
+
+        if config.is_multimodal:
+            # Vision tower: verbatim BF16 passthrough, model.visual.* -> visual.*
+            # (attribute tree in vision.py mirrors the checkpoint names exactly).
+            visual_keys = sorted(k for k in weight_map if k.startswith("model.visual."))
+            for k in tqdm(visual_keys, desc="Loading GLM-5.3 vision tower",
+                          disable=not primary):
+                yield k[len("model.") :], reader.get(k)
     finally:
         reader.close()
 

--- a/python/freetoken/models/glm_moe_dsa/args.py
+++ b/python/freetoken/models/glm_moe_dsa/args.py
@@ -35,6 +35,12 @@ class GlmMoeDsaArgs:
     index_head_dim: int
     index_topk: int
     indexer_types: Tuple[str, ...]
+    # DSA k-pool compression (GLM-5.3): `index_kpool` consecutive tokens are scored as ONE
+    # candidate (softmax(gate+ape)-weighted key average); selected pools expand back to raw
+    # token indices and the in-progress tail pool is always selected. 1 = per-token scoring
+    # (GLM-5.2; every field below is inert then).
+    index_kpool: int = 1
+    index_kpool_always_select_tail: bool = True
 
     @property
     def qk_head_dim(self) -> int:

--- a/python/freetoken/models/glm_moe_dsa/attention.py
+++ b/python/freetoken/models/glm_moe_dsa/attention.py
@@ -77,18 +77,30 @@ class GlmDsaIndexer(BaseOP):
         self.wk = LinearReplicated(args.hidden_size, self.head_dim, has_bias=False)
         self.k_norm = _IdxLayerNorm(self.head_dim, eps=1e-6)
         self.weights_proj = LinearReplicated(args.hidden_size, self.n_heads, has_bias=False)
+        # GLM-5.3 k-pool compressor: per-token gate scores + per-position-in-pool bias (ape),
+        # softmax over the pool -> weighted key average (see HF Glm5NextTextIndexer).
+        self.kpool = int(getattr(args, "index_kpool", 1))
+        if self.kpool > 1:
+            self.kpool_gate = LinearReplicated(args.hidden_size, self.head_dim, has_bias=False)
+            self.kpool_ape = torch.empty(self.kpool, self.head_dim, dtype=torch.float32)
         # Partial rope on the first qk_rope_head_dim dims of the 128-dim index heads,
         # same frequency table as the main rope. The convention is CONFIG-DRIVEN
         # (sglang: is_neox_style = not indexer_rope_interleave): GLM-5.2 sets
         # indexer_rope_interleave=true -> interleaved, where DeepSeek-V3.2 defaults
         # half-split. transformers >= 5.13 is explicit about this difference; <= 5.12
         # applied half-split for GLM too, which selects the wrong top-k past 2048.
-        self._rope = get_rope(
-            head_dim=self.head_dim,
-            rotary_dim=args.qk_rope_head_dim,
-            max_position=args.max_position,
-            base=args.rope_theta,
-            is_neox=not args.indexer_rope_interleave,
+        # NoPE checkpoints (GLM-5.3: qk_rope_head_dim == 0) carry no rotary anywhere in the
+        # MLA path; the partial rope of width 0 is the identity, so skip building it.
+        self._rope = (
+            get_rope(
+                head_dim=self.head_dim,
+                rotary_dim=args.qk_rope_head_dim,
+                max_position=args.max_position,
+                base=args.rope_theta,
+                is_neox=not args.indexer_rope_interleave,
+            )
+            if args.qk_rope_head_dim > 0
+            else None
         )
 
     def compute(
@@ -98,9 +110,12 @@ class GlmDsaIndexer(BaseOP):
         t = x.shape[0]
         q = self.wq_b.forward(q_resid).view(t, self.n_heads * self.head_dim)
         k = self.k_norm.forward(self.wk.forward(x)).view(t, self.head_dim)
-        q, k = self._rope.forward(positions, q, k)
+        if self._rope is not None:
+            q, k = self._rope.forward(positions, q, k)
         w = self.weights_proj.forward(x).float() * (self.n_heads**-0.5)
-        return q.view(t, self.n_heads, self.head_dim), k, w
+        gate = self.kpool_gate.forward(x) if self.kpool > 1 else None
+        ape = self.kpool_ape if self.kpool > 1 else None
+        return q.view(t, self.n_heads, self.head_dim), k, w, gate, ape
 
 
 class GlmMoeDsaAttention(BaseOP):
@@ -127,7 +142,7 @@ class GlmMoeDsaAttention(BaseOP):
         # cos/sin table from the model's max_position (1M -> ~256 MB, same
         # documented cost as DSV4's freqs table) and shares the one instance
         # across all layers via its cache.
-        self.rope = get_rope(
+        self.rope = None if args.qk_rope_head_dim == 0 else get_rope(
             head_dim=args.qk_rope_head_dim,
             rotary_dim=args.qk_rope_head_dim,
             max_position=args.max_position,
@@ -204,7 +219,8 @@ class GlmMoeDsaAttention(BaseOP):
         rope_dim = self.qk_rope_head_dim
         q_rope = q_rope.reshape(t, self.num_heads * rope_dim)
         k_rope = k_rope.reshape(t, rope_dim)
-        q_rope, k_rope = self.rope.forward(ctx.batch.positions, q_rope, k_rope)
+        if self.rope is not None:
+            q_rope, k_rope = self.rope.forward(ctx.batch.positions, q_rope, k_rope)
         q_rope = q_rope.view(t, self.num_heads, rope_dim)
 
         # Absorb kv_b's k-part into the query: q_nope[H,T,nope] @ W_uk[H,nope,lora].

--- a/python/freetoken/models/glm_moe_dsa/moe.py
+++ b/python/freetoken/models/glm_moe_dsa/moe.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple
 
+import os as _os
+
 import torch
 import torch.nn.functional as F
 from freetoken.layers import BaseOP, LinearReplicated, make_moe_layer
@@ -40,15 +42,23 @@ class GlmMoeDsaSparseBlock(BaseOP):
 
         # The offload cache indexes experts by *MoE* layer (global layer minus
         # first_k_dense_replace), matching how the loader packs the expert banks.
-        self.experts = make_moe_layer(
-            config,
-            layer_id=layer_id - config.first_k_dense_replace,
-            renormalize=config.norm_topk_prob,
-        )
+        # Subclasses (glm5_next: resident split) override _make_experts.
+        self.experts = self._make_experts(config, layer_id)
         self.shared_experts = GlmDsaGatedMLP(
             config.hidden_size,
             config.moe_intermediate_size * max(1, config.n_shared_experts),
             quant=config.dense_quant,
+        )
+
+    def _make_experts(self, config: ModelConfig, layer_id: int):
+        return make_moe_layer(
+            config,
+            layer_id=layer_id - config.first_k_dense_replace,
+            renormalize=config.norm_topk_prob,
+            # GLM-5.3 experts clamp swiglu at config.swiglu_limit (GLM-5.2: None -> silu).
+            # Only the Triton NVFP4 kernels honor the limit, so backend auto resolves there
+            # (marlin/b12x hard-code plain silu and are rejected for this kind).
+            activation="swiglu_clamp" if getattr(config, "swiglu_limit", None) else "silu",
         )
 
     def _group_limited(self, scores_for_choice: torch.Tensor) -> torch.Tensor:
@@ -64,6 +74,15 @@ class GlmMoeDsaSparseBlock(BaseOP):
     def _route(self, hidden_states: torch.Tensor) -> TopK:
         # HF computes the router logits in fp32; the gate is tiny so we match it exactly.
         logits = F.linear(hidden_states.float(), self.gate.weight.float())
+        if self.n_group <= 1 and _os.environ.get("FREETOKEN_FUSED_ROUTE", "1") == "1":
+            # tail-fusion (2026-08-28): sigmoid/+bias/topk/gather/renorm/cast chain
+            # (~8 launches) -> one kernel. Same math; see fused_route docstring.
+            from freetoken.kernel.triton.fused_route import fused_route
+
+            return fused_route(
+                logits, self.e_score_correction_bias, self.top_k,
+                self.norm_topk_prob, self.routed_scaling_factor,
+            )
         scores = logits.sigmoid()
         scores_for_choice = scores + self.e_score_correction_bias.float()
         if self.n_group > 1:
@@ -76,6 +95,9 @@ class GlmMoeDsaSparseBlock(BaseOP):
         return topk_weights.to(torch.float32).contiguous(), topk_ids.to(torch.int32).contiguous()
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        import os as _os
+        if _os.environ.get("FREETOKEN_GLM5_STUB_MOE", "0") == "1":  # ablation timing only
+            return torch.zeros_like(hidden_states)
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
         topk_weights, topk_ids = self._route(hidden_states)

--- a/python/freetoken/models/register.py
+++ b/python/freetoken/models/register.py
@@ -130,6 +130,11 @@ _MODEL_REGISTRY: dict[str, ModelSpec] = {
         "freetoken.models.glm_moe_dsa",
         "GlmMoeDsaForCausalLM",
     ),
+    # GLM-5.3-Flash (model_type glm5_next): hybrid KDA(34)+MLA/DSA(11) + mHC + NVFP4 experts.
+    "Glm5NextForConditionalGeneration": ModelSpec(
+        "freetoken.models.glm5_next",
+        "Glm5NextForCausalLM",
+    ),
 }
 
 

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -65,6 +65,9 @@ _ACT_IDS = {
     "gelu_pytorch_tanh": 2,
     "gpt_oss_swiglu": 3,
     "swigluoai": 3,
+    # silu family: the C++ generic epilogue applies swiglu_limit (finite for
+    # GLM-5.3 swiglu_clamp; +inf leaves plain silu untouched).
+    "swiglu_clamp": 0,
 }
 
 # Weight-format ids must match WFmt in csrc/cpu_moe/cpu_moe_ext.cpp.

--- a/python/freetoken/moe/expert_banks.py
+++ b/python/freetoken/moe/expert_banks.py
@@ -179,9 +179,15 @@ def _nvfp4_banks(model_path, model_config, device, dtype, dummy, parallel=False,
     native = decode_target == "cpu"
     backend = None
     if not native:
+        # Effective ROUTED-expert activation, not the raw hidden_act: a config carrying
+        # swiglu_limit (GLM-5.3) serves clamped swiglu, which only the Triton kernels
+        # implement -- marlin/b12x hard-code plain silu and must not be selected.
+        _act = getattr(model_config, "hidden_act", "silu")
+        if getattr(model_config, "swiglu_limit", None):
+            _act = "swiglu_clamp"
         backend = select_nvfp4_backend(device, getattr(model_config, "moe_intermediate_size", None),
                                        getattr(model_config, "nvfp4_backend", "auto"),
-                                       activation=getattr(model_config, "hidden_act", "silu"))
+                                       activation=_act)
         native = backend == "triton"
 
     repack_sink = None

--- a/python/freetoken/moe/fused_nvfp4.py
+++ b/python/freetoken/moe/fused_nvfp4.py
@@ -46,6 +46,13 @@ def _run_act(
     if activation == "swigluoai":
         swigluoai_and_mul(gate_up, out, alpha=act_alpha, limit=act_limit)
         return
+    if activation == "swiglu_clamp":
+        # GLM-5.3: silu(min(gate, limit)) * clamp(up, -limit, limit) -- the dsv4 fused
+        # kernel implements exactly this (verified bit-exact vs the HF formula).
+        from freetoken.kernel.triton.dsv4.fused_moe import fused_swiglu
+
+        out.copy_(fused_swiglu(gate_up, act_limit))
+        return
     _ACT[activation](gate_up, out)
 
 # Decode is captured into a CUDA graph, so the config must be fixed (no triton.autotune,

--- a/python/freetoken/scheduler/cache.py
+++ b/python/freetoken/scheduler/cache.py
@@ -60,6 +60,12 @@ class CacheManager:
         self.num_pages = num_pages
         self.page_table = page_table
         self.page_size = page_size
+        # MTP speculative decoding lookahead (glm5): allocate_paged keeps +k pages of
+        # horizon per request so the engine's verify forward can write KV at positions
+        # device_len..device_len+k-1 without any scheduler round-trip.
+        import os as _os
+
+        self.spec_horizon = int(_os.environ.get("FREETOKEN_GLM5_SPEC", "0") or 0)
         self.cache_type = type
 
     # ----- capability hooks (defaults; plugged-in pools may narrow them) -----
@@ -90,13 +96,35 @@ class CacheManager:
             return SWARadixCache(device, page_size, self.sliding_window_size)
         return create_prefix_cache(device=device, type=type, page_size=page_size)
 
+    @staticmethod
+    def _key_ids_of(req) -> "torch.Tensor":
+        """Token ids used for prefix-cache KEYS. Vision requests carry
+        ``cache_key_ids``: input_ids with each image span filled by a per-image
+        pixel-content hash (negative id range), so identical text+image prefixes
+        match while different images diverge at the span's first token. Requests
+        without it (text, or the offline mm path) key by input_ids as before.
+
+        cache_key_ids covers the PROMPT only; input_ids grows with generated
+        tokens, and insert paths slice by cached_len (prompt+generated). Splice
+        so the result always has input_ids' length -- a shorter tensor here
+        desyncs ids from page_indices and leaks pages (integrity check)."""
+        kids = getattr(req, "cache_key_ids", None)
+        if kids is None:
+            return req.input_ids
+        ids = req.input_ids
+        if len(ids) <= len(kids):
+            return kids[: len(ids)]
+        return torch.cat([kids, ids[len(kids) :]])
+
     def match_req(self, req: PendingReq) -> MatchResult:
         input_len = req.input_len
         assert input_len > 0, "Input length must be greater than 0."
-        # Multimodal requests must not reuse a shared prefix: image-placeholder tokens
-        # have identical ids across images but carry different content (and KV), so a
-        # match would serve the wrong image's KV. Match against the empty prefix.
-        ids = req.input_ids[:0] if req.mm_embeds is not None else req.input_ids[: input_len - 1]
+        # Multimodal requests without content-hash keys (offline path) must not reuse
+        # a shared prefix: image-placeholder ids are identical across images. With
+        # cache_key_ids (online vision path) the keys are content-aware and reuse is safe.
+        key_ids = self._key_ids_of(req)
+        skip_mm = req.mm_embeds is not None and getattr(req, "cache_key_ids", None) is None
+        ids = key_ids[:0] if skip_mm else key_ids[: input_len - 1]
         if self.is_swa:
             from freetoken.kvcache.swa_radix_cache import SWACacheHandle
             m = self.prefix_cache.match_prefix(ids)
@@ -263,9 +291,18 @@ class CacheManager:
     def allocate_paged(self, reqs: List[Req]) -> None:
         needed_pages = 0
         allocation_info: List[Tuple[int, int, int]] = []
+        width = self.page_table.shape[1]
+        # Horizon only while the pool is comfortable; the spec gate in the engine checks
+        # req.spec_alloc_len before verifying, so a skipped horizon just means no spec.
+        horizon = self.spec_horizon if len(self.free_slots) > 1024 else 0
         for req in reqs:
             first_page = div_ceil(req.cached_len, self.page_size)
             last_page = div_ceil(req.device_len, self.page_size)
+            if horizon:
+                first_page = max(first_page, req.spec_alloc_len // self.page_size)
+                tgt = min(req.device_len + horizon, width)
+                last_page = max(last_page, div_ceil(tgt, self.page_size))
+                req.spec_alloc_len = max(req.spec_alloc_len, last_page * self.page_size)
             if last_page > first_page:
                 needed_pages += last_page - first_page
                 allocation_info.append((req.table_idx, first_page, last_page))
@@ -299,10 +336,9 @@ class CacheManager:
         #                                           We should free it if the request has finished.
         page_indices = self.page_table[req.table_idx, : req.cached_len]
         old_handle = req.cache_handle
-        # Multimodal requests are never inserted into the shared prefix cache (see
-        # ``match_req``). Their KV pages stay owned by the active request and are freed
-        # on completion; nothing is exposed for cross-request reuse.
-        if req.mm_embeds is not None:
+        # Multimodal requests without content-hash keys are never inserted (see
+        # ``match_req``); with cache_key_ids their pages are safely reusable.
+        if req.mm_embeds is not None and getattr(req, "cache_key_ids", None) is None:
             self.unlock(old_handle)
             if finished:
                 tail = self._padded_tail(req, old_handle.cached_len)
@@ -310,7 +346,7 @@ class CacheManager:
                     self._free_swa(tail)
                 self._free(tail)
             return
-        insert_ids = req.input_ids[: req.cached_len]
+        insert_ids = self._key_ids_of(req)[: req.cached_len]
         cached_len, new_handle = self.prefix_cache.insert_prefix(insert_ids, page_indices)
         # unlock until all operations on handle is done
         self.unlock(old_handle)
@@ -350,7 +386,7 @@ class CacheManager:
         old_handle = req.cache_handle
         page_indices = self.page_table[req.table_idx, : req.cached_len]
 
-        if req.mm_embeds is not None:
+        if req.mm_embeds is not None and getattr(req, "cache_key_ids", None) is None:
             self.unlock(old_handle)
             if finished:
                 self._free(page_indices[old_handle.cached_len :])
@@ -376,7 +412,7 @@ class CacheManager:
                 frozen_idx = 1 - req.mamba_next_track_idx
                 frozen = req.mamba_ping_pong[frozen_idx]
                 prefix_len, mamba_exist = self.prefix_cache.insert(
-                    req.input_ids[:L], page_indices[:L], frozen)
+                    self._key_ids_of(req)[:L], page_indices[:L], frozen)
                 pool.free([s for s in req.mamba_ping_pong if mamba_exist or s != frozen])
                 req.mamba_ping_pong = None
                 self._free(page_indices[free_upto : max(free_upto, prefix_len)])
@@ -390,7 +426,7 @@ class CacheManager:
             keep_live = False
             if insert_len == req.cached_len and insert_len > 0:
                 prefix_len, mamba_exist = self.prefix_cache.insert(
-                    req.input_ids[:insert_len], page_indices[:insert_len], req.linear_slot_idx)
+                    self._key_ids_of(req)[:insert_len], page_indices[:insert_len], req.linear_slot_idx)
                 self.unlock(old_handle)
                 self._free(page_indices[free_upto : max(free_upto, prefix_len)])
                 keep_live = not mamba_exist           # tree now owns linear_slot_idx
@@ -413,13 +449,13 @@ class CacheManager:
         frozen_idx = 1 - req.mamba_next_track_idx          # the slot the forward just wrote
         frozen = req.mamba_ping_pong[frozen_idx]
         prefix_len, mamba_exist = self.prefix_cache.insert(
-            req.input_ids[:L], page_indices[:L], frozen)
+            self._key_ids_of(req)[:L], page_indices[:L], frozen)
         self.unlock(old_handle)
         self._free(page_indices[old_handle.cached_len : prefix_len])
         # Lock the committed snapshot node FIRST: the replacement-slot alloc below can trigger
         # evict_mamba (via ensure_mamba_slots), which would otherwise reclaim this still-unlocked
         # just-donated node -- freeing its KV pages under the still-decoding request.
-        m = self.prefix_cache.match_prefix(req.input_ids[:L])
+        m = self.prefix_cache.match_prefix(self._key_ids_of(req)[:L])
         # Same re-point as the generic path: the dedup free above returned this request's own
         # pages for [old_handle.cached_len, prefix_len) while its row still named them.
         if prefix_len > old_handle.cached_len:
@@ -444,7 +480,7 @@ class CacheManager:
         old_handle = req.cache_handle
         page_indices = self.page_table[req.table_idx, : req.cached_len]
 
-        if req.mm_embeds is not None:
+        if req.mm_embeds is not None and getattr(req, "cache_key_ids", None) is None:
             self.unlock(old_handle)
             if finished:
                 tail = self._padded_tail(req, old_handle.cached_len)
@@ -464,7 +500,7 @@ class CacheManager:
             # unfinished chunk's frontier is already > 0 and must be honored (else insert adopts
             # sentinel slots -> the request's later SWA gathers read slot 0 -> corruption).
             _, freed = self.prefix_cache.insert(
-                req.input_ids[:insert_len], page_indices[:insert_len],
+                self._key_ids_of(req)[:insert_len], page_indices[:insert_len],
                 swa_evicted_seqlen=req.swa_evicted_seqlen,
                 update_kv_after_len=old_handle.cached_len)
         self.unlock(old_handle)
@@ -492,8 +528,8 @@ class CacheManager:
                 )
                 if keep_from > 0:
                     self._free_swa(
-                        self.prefix_cache.trim_head_swa(req.input_ids[:prompt_len], keep_from))
-                self.prefix_cache.match_prefix(req.input_ids[:prompt_len])
+                        self.prefix_cache.trim_head_swa(self._key_ids_of(req)[:prompt_len], keep_from))
+                self.prefix_cache.match_prefix(self._key_ids_of(req)[:prompt_len])
         else:
             # inc_lock is node-granular, and the suffix insert just made this chunk's whole
             # extend one node: locking it would pin the entire chunk's swa for all of decode,
@@ -504,8 +540,8 @@ class CacheManager:
             keep_from = align_down(
                 max(insert_len - self.sliding_window_size - _SWA_RETAIN_GAP, 0), self.page_size)
             if keep_from > 0:
-                self.prefix_cache.match_prefix(req.input_ids[:keep_from])
-            m = self.prefix_cache.match_prefix(req.input_ids[:insert_len])
+                self.prefix_cache.match_prefix(self._key_ids_of(req)[:keep_from])
+            m = self.prefix_cache.match_prefix(self._key_ids_of(req)[:insert_len])
             # Re-point the page table to the tree's live slots for the committed region. Any dup
             # slots insert reclaimed had their full->swa mapping reset to the 0 sentinel; unlike the
             # full pool (KV survives in place until realloc), a stale swa mapping would make the
@@ -523,6 +559,8 @@ class CacheManager:
         to the finishing request. ``start`` is page-aligned (a match/insert boundary), so the
         full-pool page bases derived via ``[::page_size]`` are identical to the unpadded slice."""
         end = div_ceil(req.cached_len, self.page_size) * self.page_size
+        # Spec horizon pages (beyond cached_len) belong to this request too.
+        end = max(end, getattr(req, "spec_alloc_len", 0))
         return self.page_table[req.table_idx, start:end]
 
     def _free_req_slots(self, req: Req, keep_live: bool = False) -> None:

--- a/python/freetoken/scheduler/prefill.py
+++ b/python/freetoken/scheduler/prefill.py
@@ -176,6 +176,14 @@ class PrefillAdder:
                 "Multimodal prompts must fit in a single prefill chunk; increase "
                 "--max-extend-tokens or shrink the prompt."
             )
+        mm_embeds = pending_req.mm_embeds
+        if mm_embeds is not None and cached_len > 0 and pending_req.cache_key_ids is not None:
+            # A cache hit may cover leading images (whole or partial spans -- content
+            # hashes guarantee a matched span is the SAME image). The extend only
+            # scatters the remaining placeholder rows; drop the covered ones. Image
+            # positions are exactly the negative key ids.
+            covered = int((pending_req.cache_key_ids[:cached_len] < 0).sum())
+            mm_embeds = mm_embeds[covered:]
         req = CLS(
             input_ids=pending_req.input_ids[: cached_len + chunk_size],
             table_idx=table_idx,
@@ -184,10 +192,11 @@ class PrefillAdder:
             uid=pending_req.uid,
             cache_handle=cache_handle,
             sampling_params=pending_req.sampling_params,
-            mm_embeds=pending_req.mm_embeds,
+            mm_embeds=mm_embeds,
         )
         # Hybrid GDN per-request state slots (None for non-hybrid). On a fresh admit these are
         # freshly allocated; on a chunked continuation they are inherited from the prior chunk.
+        req.cache_key_ids = pending_req.cache_key_ids
         req.linear_slot_idx = linear_slot_idx
         req.mamba_ping_pong = ping_pong
         req.mamba_next_track_idx = next_track_idx
@@ -245,7 +254,13 @@ class PrefillManager:
 
     def add_one_req(self, req: UserMsg) -> None:
         self.pending_list.append(
-            PendingReq(req.uid, req.input_ids, req.sampling_params, mm_embeds=req.mm_embeds)
+            PendingReq(
+                req.uid,
+                req.input_ids,
+                req.sampling_params,
+                mm_embeds=req.mm_embeds,
+                cache_key_ids=getattr(req, "cache_key_ids", None),
+            )
         )
 
     def schedule_next_batch(self, prefill_budget: int) -> Batch | None:

--- a/python/freetoken/scheduler/scheduler.py
+++ b/python/freetoken/scheduler/scheduler.py
@@ -489,6 +489,79 @@ class Scheduler(SchedulerIOMixin):
                     "Dropping request %d because its abort arrived before admission", msg.uid
                 )
                 return
+            if getattr(msg, "mm_images", None):
+                # Vision: encode pixels into soft-token embeddings here -- this process
+                # owns the model/GPU; the tower is a ~0.6B BF16 ViT, a few ms per image.
+                try:
+                    import numpy as np
+
+                    model = self.engine.model
+                    assert hasattr(model, "encode_images"), (
+                        "model is text-only (boot with FREETOKEN_GLM5_VISION=1)"
+                    )
+                    pix_parts, grids = [], []
+                    for d in msg.mm_images:
+                        t, gh, gw = d["grid"]
+                        arr = np.frombuffer(d["pix"], dtype=np.float32).copy()
+                        pix_parts.append(arr.reshape(t * gh * gw, -1))
+                        grids.append([t, gh, gw])
+                    msg.mm_embeds = model.encode_images(
+                        torch.from_numpy(np.concatenate(pix_parts, axis=0)).to(
+                            self.device, torch.bfloat16
+                        ),
+                        torch.tensor(grids, dtype=torch.long, device=self.device),
+                    )
+                    # Content-hash cache keys: fill each image's placeholder span with a
+                    # per-image pixel hash (negative id range). Identical prefixes with the
+                    # SAME image become prefix-cache hits; different images diverge at the
+                    # span's first token, so cross-image reuse is impossible.
+                    image_token_id = getattr(
+                        self.engine.model.config, "image_token_id", None
+                    )
+                    if image_token_id is not None:
+                        import hashlib
+
+                        key_ids = msg.input_ids.clone()
+                        pos = (key_ids == image_token_id).nonzero(as_tuple=True)[0]
+                        runs = []
+                        if pos.numel():
+                            brk = (pos[1:] - pos[:-1] > 1).nonzero(as_tuple=True)[0] + 1
+                            runs = [
+                                t
+                                for t in torch.tensor_split(pos, brk.tolist())
+                                if t.numel()
+                            ]
+                        expected = sum(d["grid"][0] for d in msg.mm_images)
+                        assert len(runs) == expected, (
+                            f"{len(runs)} image-token spans vs {expected} expected "
+                            "(one per image, grid_t per video; literal placeholder "
+                            "text in the prompt?)"
+                        )
+                        ri = 0
+                        for d in msg.mm_images:
+                            h = int.from_bytes(
+                                hashlib.blake2b(d["pix"], digest_size=8).digest(), "big"
+                            )
+                            hid = -(h % (2**31 - 2)) - 2
+                            for _ in range(d["grid"][0]):
+                                key_ids[runs[ri]] = hid
+                                ri += 1
+                        msg.cache_key_ids = key_ids
+                    msg.mm_images = None
+                except Exception as exc:  # noqa: BLE001 -- reply, never crash the loop
+                    logger.warning_rank0(
+                        f"vision encode failed for request {msg.uid}: {exc!r}"
+                    )
+                    self.send_result(
+                        [
+                            ErrorReplyMsg(
+                                uid=msg.uid,
+                                error=f"could not encode request images: {exc}",
+                                code="invalid_image",
+                            )
+                        ]
+                    )
+                    return
             input_len, max_seq_len = len(msg.input_ids), self.engine.max_seq_len
             max_output_len = max_seq_len - input_len
             if max_output_len <= 0:

--- a/python/freetoken/scheduler/utils.py
+++ b/python/freetoken/scheduler/utils.py
@@ -18,6 +18,9 @@ class PendingReq:
     sampling_params: SamplingParams
     chunked_req: ChunkedReq | None = None
     mm_embeds: torch.Tensor | None = None
+    # input_ids with image spans replaced by per-image content hashes; prefix-cache
+    # keys only (the model always consumes the real input_ids).
+    cache_key_ids: torch.Tensor | None = None
 
     @property
     def input_len(self) -> int:

--- a/python/freetoken/server/anthropic_api.py
+++ b/python/freetoken/server/anthropic_api.py
@@ -33,6 +33,7 @@ from .anthropic_models import (
     AnthropicUsage,
 )
 from .generation import (
+    extract_images,
     KEEPALIVE,
     ContentDelta,
     GenDone,
@@ -148,7 +149,7 @@ async def handle_anthropic_count_tokens(req: AnthropicCountTokensRequest, state:
     # a checkpoint whose chat template raises ValueError is a server fault, not a bad request,
     # so it must not fall into the convert/empty-prompt ValueError branch.
     try:
-        messages, template_tools, _, ctk = convert_anthropic_prompt(
+        messages, template_tools, _, ctk, _images = convert_anthropic_prompt(
             req, reasoning_parser=getattr(state.config, "reasoning_parser", None)
         )
     except ValueError as exc:
@@ -214,8 +215,19 @@ def convert_anthropic_prompt(
                 # -> reasoning_content; redacted_thinking stays skipped (opaque payload).
                 thinking_parts.append(block.thinking)
             elif block.type == "image":
-                # Text-only server: drop image blocks rather than failing the request.
-                continue
+                # Vision: convert the Anthropic image source into an OpenAI-shaped
+                # image_url part; extract_images decodes it and the chat template's
+                # image branch emits the placeholder tokens. Opaque/unknown sources
+                # keep the old drop behavior.
+                src = block.source or {}
+                if src.get("type") == "base64" and src.get("data"):
+                    media = src.get("media_type") or "image/png"
+                    url = f"data:{media};base64,{src['data']}"
+                elif src.get("type") == "url" and src.get("url"):
+                    url = src["url"]
+                else:
+                    continue
+                content_parts.append({"type": "image_url", "image_url": {"url": url}})
             elif block.type == "tool_use":
                 tool_calls.append(
                     {
@@ -296,7 +308,8 @@ def convert_anthropic_prompt(
         elif req.thinking.get("type") == "disabled":
             ctk = thinking_toggle_kwargs(False)
 
-    return render_messages(messages), template_tools, parser_tools, ctk
+    images = extract_images(messages) or None
+    return render_messages(messages), template_tools, parser_tools, ctk, images
 
 
 def convert_anthropic_to_genspec(
@@ -304,11 +317,12 @@ def convert_anthropic_to_genspec(
     model_sampling: dict[str, Any],
     reasoning_parser: str | None = None,
 ) -> GenSpec:
-    messages, template_tools, parser_tools, ctk = convert_anthropic_prompt(
+    messages, template_tools, parser_tools, ctk, images = convert_anthropic_prompt(
         req, reasoning_parser=reasoning_parser
     )
     return GenSpec(
         messages=messages,
+        images=images,
         sampling_params=resolve_sampling(
             temperature=req.temperature,
             top_k=req.top_k,

--- a/python/freetoken/server/api_models.py
+++ b/python/freetoken/server/api_models.py
@@ -10,6 +10,7 @@ class MessageContent(BaseModel):
     type: str
     text: str | None = None
     image_url: Any | None = None
+    video_url: Any | None = None
     audio_url: Any | None = None
 
 

--- a/python/freetoken/server/generation.py
+++ b/python/freetoken/server/generation.py
@@ -137,6 +137,8 @@ class GenSpec:
     messages: list[dict[str, Any]]                       # normalized, template-ready
     sampling_params: SamplingParams
     chat_template_kwargs: dict[str, Any] = field(default_factory=dict)
+    # Preprocessed images in template order (see TokenizeMsg.images); None = text-only.
+    images: list[Any] | None = None
     template_tools: list[dict[str, Any]] | None = None   # tools the model sees (TokenizeMsg.tools)
     parser_tools: list[dict[str, Any]] | None = None     # tools for FunctionCallParser; None disables parsing
 
@@ -198,7 +200,16 @@ def _render_message(message: dict[str, Any]) -> dict[str, Any]:
     m = dict(message)
     content = m.get("content")
     if isinstance(content, list):
-        m["content"] = _flatten_text_parts(content)
+        if any(
+            isinstance(p, dict)
+            and p.get("type") in ("image_url", "image", "video_url", "video")
+            for p in content
+        ):
+            # Multimodal message: keep the structured part list (payload stripped) so
+            # the chat template's image branch emits its placeholder tokens.
+            m["content"] = _mm_content_parts(content)
+        else:
+            m["content"] = _flatten_text_parts(content)
     # Templates read different reasoning keys (reasoning_content: most; reasoning:
     # gemma4; thinking: gpt-oss) — accept any, emit both.
     reasoning = m.get("reasoning_content") or m.get("reasoning") or m.get("thinking")
@@ -228,6 +239,60 @@ def _render_message(message: dict[str, Any]) -> dict[str, Any]:
             rendered.append(tc)
         m["tool_calls"] = rendered
     return m
+
+
+def _mm_content_parts(parts: list[Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for part in parts:
+        ptype = part.get("type") if isinstance(part, dict) else None
+        if ptype == "text":
+            out.append({"type": "text", "text": part.get("text") or ""})
+        elif ptype in ("image_url", "image"):
+            out.append({"type": "image_url"})  # payload travels separately (GenSpec.images)
+        elif ptype in ("video_url", "video"):
+            out.append({"type": "video_url"})
+        else:
+            raise ValueError(f"Unsupported content part type in multimodal message: {ptype}")
+    return out
+
+
+def extract_images(messages: list[dict[str, Any]]) -> list[Any]:
+    """Decode + preprocess every image content part (data URI / http URL), in template
+    order. Returns [] for text-only conversations. Raises ValueError on a bad payload
+    (adapters map it to a 400 like any other malformed message)."""
+    images: list[Any] = []
+    for m in messages:
+        content = m.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in ("image_url", "image"):
+                from freetoken.models.glm5_next.image_process import (
+                    decode_image_part,
+                    preprocess_image,
+                )
+
+                img = decode_image_part(part.get("image_url") or part.get("image"))
+                pixels, grid = preprocess_image(img)
+                # Transport-safe payload: the ZMQ msgpack codec only carries
+                # primitives/bytes/1-D tensors -- raw fp32 bytes + a grid list ride
+                # both hops (api -> tokenizer -> scheduler) unchanged.
+                images.append({"kind": "image", "pix": pixels.tobytes(), "grid": list(grid)})
+            elif isinstance(part, dict) and part.get("type") in ("video_url", "video"):
+                from freetoken.models.glm5_next.image_process import (
+                    decode_video_part,
+                    preprocess_video,
+                )
+
+                frames, ts = decode_video_part(part.get("video_url") or part.get("video"))
+                pixels, grid, unit_ts = preprocess_video(frames, ts)
+                images.append({
+                    "kind": "video",
+                    "pix": pixels.tobytes(),
+                    "grid": list(grid),
+                    "ts": [float(t) for t in unit_ts],
+                })
+    return images
 
 
 def _flatten_text_parts(parts: list[Any]) -> str:
@@ -269,6 +334,7 @@ async def submit_generation(spec: GenSpec, state: Any) -> int:
             sampling_params=spec.sampling_params,
             chat_template_kwargs=spec.chat_template_kwargs,
             tools=spec.template_tools,
+            images=spec.images,
         )
     )
     return uid

--- a/python/freetoken/server/openai_api.py
+++ b/python/freetoken/server/openai_api.py
@@ -34,6 +34,7 @@ from .generation import (
     generate_events,
     generate_full,
     prerender_error,
+    extract_images,
     render_messages,
     resolve_sampling,
     submit_generation,
@@ -66,8 +67,10 @@ def chat_request_to_genspec(
     thinking_type = _thinking_type(req)
     if req.reasoning_effort or thinking_type:
         ctk = effort_toggle_kwargs(req.reasoning_effort, ctk, thinking_type=thinking_type)
+    raw_messages = [m.model_dump(exclude_none=True) for m in req.messages]
     return GenSpec(
-        messages=render_messages([m.model_dump(exclude_none=True) for m in req.messages]),
+        messages=render_messages(raw_messages),
+        images=extract_images(raw_messages) or None,
         sampling_params=resolve_sampling(
             temperature=req.temperature,
             top_k=req.top_k,

--- a/python/freetoken/tokenizer/server.py
+++ b/python/freetoken/tokenizer/server.py
@@ -253,10 +253,15 @@ def tokenize_worker(
                         errors[0] if len(errors) == 1 else BatchFrontendMsg(data=errors)
                     )
                 if ok_msgs:
-                    backend = [
-                        UserMsg(uid=msg.uid, input_ids=t, sampling_params=msg.sampling_params)
-                        for msg, t in zip(ok_msgs, ok_tensors, strict=True)
-                    ]
+                    backend = []
+                    for msg, t in zip(ok_msgs, ok_tensors, strict=True):
+                        um = UserMsg(
+                            uid=msg.uid, input_ids=t, sampling_params=msg.sampling_params
+                        )
+                        images = getattr(msg, "images", None)
+                        if images:
+                            um.mm_images = images  # transport-safe dicts, verbatim
+                        backend.append(um)
                     send_backend.put(backend[0] if len(backend) == 1 else BatchBackendMsg(data=backend))
             if len(abort_msg) > 0:
                 batch_output = BatchBackendMsg(

--- a/python/freetoken/tokenizer/tokenize.py
+++ b/python/freetoken/tokenizer/tokenize.py
@@ -23,6 +23,51 @@ from .effort import (
 logger = init_logger(__name__)
 
 
+def _expand_image_tokens(prompt: str, images: list) -> str:
+    """Expand multimodal placeholders in template order, mirroring
+    Glm5NextProcessor: the k-th ``<|image|>`` becomes grid.prod/merge^2 image
+    tokens; the k-th ``<|video|>`` becomes one frame block per temporal unit
+    (``<|begin_of_image|>`` + h*w/merge^2 image tokens + ``<|end_of_image|>`` +
+    "T.T seconds"). Placeholder kinds/counts must match the request payloads;
+    the model asserts the same token-count invariant at prefill."""
+    import re
+
+    from freetoken.models.glm5_next.image_process import IMAGE_TOKEN, MERGE
+
+    VIDEO_TOKEN = "<|video|>"
+    parts = re.split(r"(<\|image\|>|<\|video\|>)", prompt)
+    n_ph = sum(1 for p in parts if p in (IMAGE_TOKEN, VIDEO_TOKEN))
+    if n_ph != len(images):
+        raise ValueError(
+            f"prompt renders {n_ph} multimodal placeholders but the request "
+            f"carries {len(images)} payloads"
+        )
+    it = iter(images)
+    out = []
+    for p in parts:
+        if p == IMAGE_TOKEN:
+            d = next(it)
+            if d.get("kind", "image") != "image":
+                raise ValueError("placeholder order mismatch: expected an image payload")
+            t, gh, gw = d["grid"]
+            out.append(IMAGE_TOKEN * ((t * gh * gw) // (MERGE * MERGE)))
+        elif p == VIDEO_TOKEN:
+            d = next(it)
+            if d.get("kind") != "video":
+                raise ValueError("placeholder order mismatch: expected a video payload")
+            t, gh, gw = d["grid"]
+            per_unit = (gh * gw) // (MERGE * MERGE)
+            ts = d.get("ts") or [k * 1.0 for k in range(t)]
+            out.append("".join(
+                f"<|begin_of_image|>{IMAGE_TOKEN * per_unit}<|end_of_image|>"
+                f"{ts[k]:.1f} seconds"
+                for k in range(t)
+            ))
+        else:
+            out.append(p)
+    return "".join(out)
+
+
 def resolve_thinking_mode(chat_template_kwargs: dict[str, Any] | None, tools: Any | None) -> str:
     """Resolve the thinking mode (``"thinking"`` or ``"chat"``) for a chat request.
 
@@ -60,6 +105,9 @@ class TokenizeManager:
         # TODO: batch tokenization
         for msg in msgs:
             prompt = self.render_prompt(msg)
+            images = getattr(msg, "images", None)
+            if images:
+                prompt = _expand_image_tokens(prompt, images)
             # A jinja chat template owns every special token (HF's apply_chat_template
             # tokenizes with add_special_tokens=False for the same reason): tokenizers
             # that auto-add bos (muse-glimmer's, llama's) would otherwise double it --


### PR DESCRIPTION
## Summary

Adds serving support for [zai-org/GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash) (`model_type: glm5_next`) — Z.ai's 320B / 18B-active MoE and the first GLM to combine sparse and linear attention — targeting single-GPU hosts with expert offload:

- new `models/glm5_next` package: 34 KDA linear-attention layers (fla-core `chunk_kda` / `fused_recurrent_kda`, decode passes `cu_seqlens` so batched single-token requests keep per-request state), 11 MLA/DSA sparse-attention layers, Manifold-Constrained Hyper-Connections (the DSV4 kernels, plus a weightless mean `hc_head`), 288-expert top-8 routing, and the MTP head skipped at load (`FREETOKEN_GLM5_MTP=1` scaffolding is inert without engine hooks)
- NoPE end to end: `rotary_dim=0` guards in the shared GLM/DSA attention and `D_R=0` constexpr branches in the sparse kernels
- DSA key-pooling (`index_kpool_*` weights): pooled keys reuse the decode-logits kernel over strided rows and score bitwise-identical to the HF reference
- hybrid KV pools: dense `layer_ids` remapping so only the 11 MLA/DSA layers allocate latent slabs (without it the 34 KDA layers each claimed one)
- clamped swiglu (`swiglu_limit: 10.0`): configs carrying the limit route to the Triton NVFP4 expert backend (`marlin`/`b12x` hard-code plain silu and are rejected), and the CPU MoE epilogue applies `silu(min(gate, lim)) * clamp(up, ±lim)` — `lim == +inf` leaves every other model bitwise unchanged
- hotness-driven resident/offload expert split: `FREETOKEN_GLM5_RESIDENT_LAYERS=3-6,8-11` keeps the named layers' experts on the GPU as model weights (no host bank, no cache slots), cutting the host pin from ~163 GiB to ~129 GiB so a 157 GiB host fits; `num_moe_layers` excludes them for every bank/cache consumer
- three fused Triton kernels used by the model code (KDA gate math, mHC pre-norm, router epilogue); each matches its eager chain to 1 ulp, and the fused router's expert selection is id-identical to `torch.topk` on 200 random batches
- optional per-row FP8 for the non-expert projections (`FREETOKEN_GLM5_ATTN_FP8` / `_MLP_FP8` / `_KDA_FP8`, all default off)

## Validation

Validated on a single RTX PRO 6000 Blackwell Workstation Edition (96 GB), 157 GiB host RAM, PCIe Gen5 x16; torch `2.11.0+cu130`, triton `3.6.0`, CUDA 13.0:

- `LibertAIDAI/GLM-5.3-Flash-NVFP4` (181 GiB experts) served with `FREETOKEN_GLM5_RESIDENT_LAYERS=3-6,8-11`, `--moe-cache-auto`, 256K `--max-seq-len-override`: greedy arithmetic and Chinese-QA probes returned the expected answers; an 8K-token needle prompt recalled the planted passphrase; single-stream decode at this branch's defaults (BF16 non-expert weights) ran 23.5–23.7 tok/s
- during development the port was teacher-forced against a pure-PyTorch HF-reference implementation (real weights, dequantized experts): 48/48 steps across 3 prompts matched the reference argmax token for token; the DSA pooled keys and the clamped-swiglu kernel were verified bitwise against the HF formulas
- `python -m compileall -q python` passes; every patch applies cleanly onto current `main`

## Scope

Serving-throughput work from the same effort is intentionally left out to keep this reviewable: speculative expert prefetch, short-prompt on-demand prefill, decode-GEMV retuning, and the MTP speculative-decoding engine hooks (measured net-negative on PCIe-bound offload) are follow-up material. The vision tower is not loaded (text-only). Defaults are conservative: no resident split, no FP8, no MTP unless the environment variables opt in.


## Tuned companion

The defaults here are deliberately conservative. The full tuning layer from the same effort is maintained separately as a patch overlay in [Cerynitius/freetoken-ox-boost](https://github.com/Cerynitius/freetoken-ox-boost); on the same single-GPU box it takes single-stream decode from this branch's 23.7 tok/s (BF16 defaults) to **~35 tok/s**, 2-way concurrent aggregate to 44.9, and 10-token TTFT to 0.59 s.

What it adds on top of this PR: the non-expert FP8 switches enabled by default, speculative expert prefetch (layer L+1's gate scored a layer early, +8%), short-prompt on-demand prefill (TTFT 3.5x), decode-GEMV retuning (marlin tile config, +4.5%), an M-tiled FP8 GEMV for decode micro-batches (2-way aggregate +13%), and a 2-slot 256K KV pool that frees ~10 GiB for the expert cache (~84% hit rate).

What it trades for that: FP8 numerics on the non-expert projections by default (MMLU-100 spot-check held at 94 vs 89 for BF16, but the numerics are not bitwise), epsilon-level reduction-order changes in the retuned GEMVs, decode-GEMV tile defaults retuned for one card (RTX PRO 6000) rather than swept across GPUs, prefetch/prefill hooks in the shared offload serving path, and a KV-capacity-for-cache default that assumes the 2x256K working set. Those trade-offs are why this PR keeps upstream defaults untouched.
