### PR TITLE
fix: [BUG] qwen3_5 dense: mixed-precision NVFP4 crashes in ct_bf16_fuse (Float8 × BFloat16 promotion)

### DIFF
--- a/python/freetoken/models/loader.py
+++ b/python/freetoken/models/loader.py
@@ -182,6 +182,9 @@ class ShardReader:
     def names_in(self, file: str) -> list[str]:
         return [name for name, shard in self._map.items() if shard == file]
 
+    def __contains__(self, name: str) -> bool:
+        return name in self._map
+
     def get_tensor(self, name: str) -> torch.Tensor:
         import safetensors
 

--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -645,7 +645,11 @@ def _iter_weights_compressed_tensors(
                     continue
 
                 if name.endswith(".weight"):
-                    yield from _emit_bf16_weight(name, reader.get_tensor(raw_name))
+                    # Some exports (e.g. GDN in_proj_{qkv,z}) quantize a bare ``.weight`` to
+                    # per-tensor FP8 (no weight_packed); ``reader`` supports ``in`` across all
+                    # shards, so a sibling scale in a different shard is still found.
+                    tensor = _load_maybe_quantized(reader, raw_name, reader)
+                    yield from _emit_bf16_weight(name, tensor)
                     continue
 
                 # A_log / dt_bias (kept fp32 by the model; the load downcast exempts them).


### PR DESCRIPTION
Fixes #238