### PR TITLE
feat(qwen4-exp): mmap PLE tables from disc

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,7 @@ parsers all resolve automatically from the checkpoint and the GPU.
 |---|---|---|
 | `--model-path`, `--model` | required | Local dir, HF repo id, or an FTW dir (auto-detected) |
 | `--served-model-name` | basename of `--model` | Model id reported by `/v1/models` |
+| `--ple-backend` | pinned | Qwen3.8 PLE storage: `pinned` or `mmap` |
 
 ### Server & runtime
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,5 +38,6 @@ for them; other checkpoints of the same architectures work too.
   FreeToken's fast-load format, and `ft serve --model` auto-detects the result.
 - DeepSeek-V4 checkpoints must keep the `inference/config.json` subdir — the
   authoritative model args are read from there.
-- Qwen3.8-Flash-Next keeps a 47.7 GiB PLE n-gram table pinned in host RAM.
+- Qwen3.8-Flash-Next supports `--ple-backend mmap` for demand-paging its PLE table
+  from the original safetensors while retaining decode CUDA graphs.
 - Multimodal checkpoints are served text-only.

--- a/python/freetoken/engine/config.py
+++ b/python/freetoken/engine/config.py
@@ -28,6 +28,7 @@ class EngineConfig:
     # parallel reader's extra (non-reclaimable) whole-shard buffer; "serial" forces the
     # low-memory reclaimable read; "parallel" forces the fast read.
     expert_load: str = "auto"
+    ple_backend: str = "pinned"
     moe_cache_size: int = 0
     moe_cache_rate: float | None = None
     moe_cache_auto: bool = False

--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -1219,6 +1219,21 @@ _DENSE_MOE_SETTINGS = {
 }
 
 
+def _validate_ple_backend(config: EngineConfig, model_config) -> None:
+    ple_backend = getattr(config, "ple_backend", "pinned")
+    if ple_backend not in ("pinned", "mmap"):
+        raise ValueError(f"ple_backend must be 'pinned' or 'mmap', got {ple_backend!r}")
+    if ple_backend == "pinned":
+        return
+
+    qwen4_args = getattr(model_config, "qwen4_args", None)
+    if qwen4_args is None or not getattr(qwen4_args, "ple_layer_ids", ()):
+        raise ValueError(
+            "--ple-backend mmap is currently supported only for "
+            "Qwen3.8-Flash-Next checkpoints with a PLE table"
+        )
+
+
 def _adjust_config(config: EngineConfig):
     def override(attr: str, value: Any):  # this is dangerous, use with caution
         object.__setattr__(config, attr, value)
@@ -1264,6 +1279,7 @@ def _adjust_config(config: EngineConfig):
             override("cuda_graph_bs", [1])
             override("cuda_graph_max_bs", 1)
 
+    _validate_ple_backend(config, model_config)
     if config.cuda_graph_max_bs is None:
         override("cuda_graph_max_bs", config.max_running_req)
 

--- a/python/freetoken/engine/graph.py
+++ b/python/freetoken/engine/graph.py
@@ -118,6 +118,7 @@ class GraphRunner:
         self.moe_offload_cache = moe_offload_cache
         self.stream = stream
         self.device = device
+        self.model = model
         self._capture_graphs(max_seq_len, vocab_size, model)
 
     def _reset_moe_offload_cache(self) -> None:
@@ -172,6 +173,7 @@ class GraphRunner:
                           else self.dummy_req.table_idx)
             self.buffer.table_idx[:bs].fill_(dummy_slot)
             with get_global_ctx().forward_batch(batch):
+                model.prepare_cuda_graph_capture(batch)
                 self.buffer.logits[:bs] = model.forward()
                 # Keep the offload cache warmed for capture. Resetting here forces
                 # CUDA graph capture to replay cold-cache expert copies.
@@ -193,6 +195,7 @@ class GraphRunner:
         assert self.can_use_cuda_graph(batch)
         self.buffer.copy_from(batch)
         g = self.graph_map[batch.padded_size]
+        self.model.prepare_cuda_graph_replay(batch)
         self.attn_backend.prepare_for_replay(batch)
         g.replay()
         return self.buffer.logits[: batch.size]
@@ -214,4 +217,5 @@ class GraphRunner:
         # caller / next capture (GraphRunner._capture_graphs already runs it).
         self.graph_map = {}
         self.buffer = None
+        self.model.reset_cuda_graph()
         gc.collect()

--- a/python/freetoken/models/blocks.py
+++ b/python/freetoken/models/blocks.py
@@ -16,12 +16,23 @@ from freetoken.utils import nvtx_annotate
 if TYPE_CHECKING:
     import torch
 
+    from freetoken.core import Batch
+
     from .config import ModelConfig
 
 
 class BaseLLMModel(ABC, BaseOP):
     @abstractmethod
     def forward(self) -> torch.Tensor: ...
+
+    def prepare_cuda_graph_capture(self, batch: Batch) -> None:
+        pass
+
+    def prepare_cuda_graph_replay(self, batch: Batch) -> None:
+        pass
+
+    def reset_cuda_graph(self) -> None:
+        pass
 
 
 class GatedMLP(BaseOP):

--- a/python/freetoken/models/qwen4_exp/model.py
+++ b/python/freetoken/models/qwen4_exp/model.py
@@ -105,6 +105,28 @@ class Qwen4ExpModel(BaseOP):
         """The PLE layers in decoder order -- the seam the loader attaches table backends to."""
         return list(self._ple)
 
+    def prepare_mmap_ple_graph_capture(self, batch: Batch) -> None:
+        for ple in self._ple:
+            table = ple.ple_embedding.table
+            table.prepare_cuda_graph_capture(batch.padded_size * ple.ple_embedding.num_heads)
+
+    def prepare_mmap_ple_graph_replay(self, batch: Batch) -> None:
+        from .ple import build_ple_metadata
+
+        meta = build_ple_metadata(batch, self._ple[0].args, batch.input_ids.device)
+        pending = []
+        for ple in self._ple:
+            table = ple.ple_embedding.table
+            row_ids = ple.ple_embedding.row_ids(meta)
+            table.prefetch(row_ids)
+            pending.append((table, row_ids))
+        for table, row_ids in pending:
+            table.prepare_cuda_graph_replay(row_ids)
+
+    def reset_mmap_ple_graph(self) -> None:
+        for ple in self._ple:
+            ple.ple_embedding.table.reset_cuda_graph()
+
     def forward(self, input_ids: torch.Tensor, batch: Batch) -> torch.Tensor:
         hidden = self.embed_tokens.forward(input_ids).repeat(1, self.hc_count)
         meta = None
@@ -126,6 +148,7 @@ class Qwen4ExpModel(BaseOP):
 class Qwen4ExpForCausalLM(BaseLLMModel):
     def __init__(self, config: ModelConfig) -> None:
         self._config = config
+        self._mmap_ple = False
         self.model = Qwen4ExpModel(config)
         if getattr(config, "lm_head_quant", "none") == "nvfp4":
             from freetoken.kernel.triton.nvfp4_linear import Nvfp4LMHead
@@ -143,8 +166,20 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
             )
         super().__init__()
 
+    def prepare_cuda_graph_capture(self, batch: Batch) -> None:
+        if self._mmap_ple:
+            self.model.prepare_mmap_ple_graph_capture(batch)
+
+    def prepare_cuda_graph_replay(self, batch: Batch) -> None:
+        if self._mmap_ple:
+            self.model.prepare_mmap_ple_graph_replay(batch)
+
+    def reset_cuda_graph(self) -> None:
+        if self._mmap_ple:
+            self.model.reset_mmap_ple_graph()
+
     def load_host_tables(self, engine_config) -> int:
-        """Attach the PLE n-gram table (pinned checkpoint bank, or zeros for dummy weights); returns the pinned host bytes the engine reserves from its pin budget."""
+        """Attach the PLE table and return persistent pinned bytes."""
         ple_layers = self.model.ple_layers
         if not ple_layers:
             return 0
@@ -168,6 +203,22 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
                 emb.ngram_heads_offsets.copy_(torch.tensor(offsets, dtype=torch.int64))
                 emb.attach_table(ZeroTable(offsets[-1] + sizes[-1], args.ngram_head_dim))
             return 0
+
+        ple_backend = getattr(engine_config, "ple_backend", "pinned")
+        if ple_backend == "mmap":
+            from .ple import MmapStagedTable
+            from .weight import load_mmap_ple_table
+
+            table = load_mmap_ple_table(engine_config.model_path, self._config.qwen4_args)
+            self._ple_table = table  # Keep mappings alive.
+            self._mmap_ple = True
+            for ple in ple_layers:
+                ple.ple_embedding.attach_table(
+                    MmapStagedTable(table.storage, float(table.weight_scale))
+                )
+            return 0
+        if ple_backend != "pinned":
+            raise ValueError(f"unsupported PLE backend {ple_backend!r}")
 
         from .weight import load_ple_table
 

--- a/python/freetoken/models/qwen4_exp/ple.py
+++ b/python/freetoken/models/qwen4_exp/ple.py
@@ -11,14 +11,13 @@ HF reference: ``Qwen4ExpTextNGramEmbedding`` (modeling_qwen4_exp.py:1018) and
     D = U + silu(conv1d(norm_conv(U)))           # depthwise, kernel 4, dilation ngram_size
     R += D                                       # before the attention hyper-connection mix
 
-The table is the 47.7 GiB FP8 n-gram store: ``PinnedUVATable`` keeps it in pinned host memory and
-gathers rows over UVA, optionally started early on a side stream (``PLELayer.start_prefetch``).
-``GpuResidentTable`` is the small-table oracle the pinned backend is diffed against.
+The FP8 n-gram store can use pinned host memory or mmap-backed safetensors.
 """
 
 from __future__ import annotations
 
 import math
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Protocol, Sequence, Tuple
 
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
     from freetoken.models.config import ModelConfig
 
     from .config import Qwen4ExpArgs
+    from .weight import MmapPleStorage
 
 
 _MASK64 = (1 << 64) - 1
@@ -47,7 +47,7 @@ _PLE_LAYER_PRIME = 10007
 class PLETableBackend(Protocol):
     """Row store for one PLE layer's n-gram embedding table (Qwen3.8: 40M rows x 160, FP8 + one scalar scale).
 
-    Frozen contract. ``GpuResidentTable`` (oracle, small tables) and ``PinnedUVATable`` (the real 47.7 GiB pinned-host table) implement it. Rows are addressed by the
+    ``GpuResidentTable``, ``PinnedUVATable``, and ``MmapStagedTable`` implement it. Rows use the
     GLOBAL hashed id, i.e. the per-head vocab offset is already added by ``NGramEmbedding``.
 
     ``lookup`` gets ``row_ids [T, num_ngram_heads]`` (int64, device) and returns
@@ -207,6 +207,161 @@ class PinnedUVATable:
             return rows
         out.copy_(rows)
         return out
+
+
+@dataclass
+class _MmapPending:
+    row_ids: torch.Tensor
+    future: Future[torch.Tensor]
+
+
+class MmapStagedTable:
+    """Gather mmap-backed PLE rows on the CPU and stage them to CUDA."""
+
+    external_cuda_graph_staging = True
+
+    def __init__(
+        self,
+        storage: MmapPleStorage,
+        scale: float = 1.0,
+        *,
+        device: torch.device | None = None,
+    ) -> None:
+        self.storage = storage
+        self.scale = float(scale)
+        self.num_rows = storage.num_rows
+        self.head_dim = storage.head_dim
+        self.dtype = torch.bfloat16
+        self._device = device or torch.device("cuda", torch.cuda.current_device())
+        if self._device.type != "cuda":
+            raise ValueError("MmapStagedTable requires a CUDA device")
+        self._executor: ThreadPoolExecutor | None = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="ple-mmap"
+        )
+        self._pending: _MmapPending | None = None
+        self._graph_staging: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def _gather_after_copy(
+        self,
+        ready: torch.cuda.Event,
+        host_ids: torch.Tensor,
+        host_rows: torch.Tensor,
+    ) -> torch.Tensor:
+        ready.synchronize()
+        # Inference mode is thread-local; staging tensors were created under it.
+        with torch.inference_mode():
+            return self.storage.gather(host_ids, host_rows)
+
+    def _schedule(self, row_ids: torch.Tensor) -> Future[torch.Tensor]:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "MmapStagedTable cannot run in a CUDA graph; use --cuda-graph-max-bs 0"
+            )
+        flat = row_ids.reshape(-1)
+        host_ids = torch.empty(flat.numel(), dtype=torch.int64, device="cpu", pin_memory=True)
+        host_rows = torch.empty(
+            (flat.numel(), self.head_dim),
+            dtype=torch.uint8,
+            device="cpu",
+            pin_memory=True,
+        )
+        host_ids.copy_(flat, non_blocking=True)
+        ready = torch.cuda.Event()
+        ready.record(torch.cuda.current_stream(self._device))
+        executor = self._executor
+        if executor is None:
+            raise RuntimeError("MmapStagedTable is closed")
+        return executor.submit(self._gather_after_copy, ready, host_ids, host_rows)
+
+    def _finish(self, row_ids: torch.Tensor) -> torch.Tensor:
+        pending, self._pending = self._pending, None
+        if pending is not None and pending.row_ids is row_ids:
+            return pending.future.result()
+        if pending is not None:
+            pending.future.result()
+        return self._schedule(row_ids).result()
+
+    def prepare_cuda_graph_capture(self, num_rows: int) -> None:
+        if num_rows in self._graph_staging:
+            return
+        raw = torch.empty((num_rows, self.head_dim), dtype=torch.uint8, device=self._device)
+        rows = torch.zeros((num_rows, self.head_dim), dtype=self.dtype, device=self._device)
+        self._graph_staging[num_rows] = (raw, rows)
+
+    def prepare_cuda_graph_replay(self, row_ids: torch.Tensor) -> None:
+        staging = self._graph_staging.get(row_ids.numel())
+        if staging is None:
+            raise RuntimeError(f"no mmap PLE graph buffer for {row_ids.numel()} rows")
+        host_rows = self._finish(row_ids)
+        raw, rows = staging
+        raw.copy_(host_rows, non_blocking=True)
+        rows.copy_(raw.view(torch.float8_e4m3fn))
+        if self.scale != 1.0:
+            rows.mul_(self.scale)
+
+    def cuda_graph_lookup(
+        self,
+        tokens: int,
+        num_heads: int,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        staging = self._graph_staging.get(tokens * num_heads)
+        if staging is None:
+            raise RuntimeError(f"no mmap PLE graph buffer for {tokens * num_heads} rows")
+        rows = staging[1].view(tokens, -1)
+        if out is None:
+            return rows
+        out.copy_(rows)
+        return out
+
+    def reset_cuda_graph(self) -> None:
+        self._graph_staging.clear()
+
+    def prefetch(self, row_ids: torch.Tensor) -> None:
+        if row_ids.numel() == 0 or torch.cuda.is_current_stream_capturing():
+            return
+        if self._pending is not None:
+            self._pending.future.result()
+        self._pending = _MmapPending(row_ids=row_ids, future=self._schedule(row_ids))
+
+    def lookup(self, row_ids: torch.Tensor, out: torch.Tensor | None = None) -> torch.Tensor:
+        if torch.cuda.is_current_stream_capturing():
+            staging = self._graph_staging.get(row_ids.numel())
+            if staging is None:
+                raise RuntimeError(f"no mmap PLE graph buffer for {row_ids.numel()} rows")
+            rows = staging[1].view(*row_ids.shape[:-1], -1)
+            if out is None:
+                return rows
+            out.copy_(rows)
+            return out
+
+        host_rows = self._finish(row_ids)
+        raw = host_rows.to(device=self._device, non_blocking=True)
+        rows = raw.view(torch.float8_e4m3fn).to(self.dtype)
+        if self.scale != 1.0:
+            rows.mul_(self.scale)
+        rows = rows.view(*row_ids.shape[:-1], -1)
+        if out is None:
+            return rows
+        out.copy_(rows)
+        return out
+
+    def close(self) -> None:
+        executor, self._executor = self._executor, None
+        if executor is None:
+            return
+        pending, self._pending = self._pending, None
+        try:
+            if pending is not None:
+                pending.future.result()
+        finally:
+            executor.shutdown(wait=True, cancel_futures=True)
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 def _splitmix64(value: int) -> int:
@@ -566,15 +721,23 @@ class PLELayer(BaseOP):
         assert self.state_len <= CHUNK_SIZE, (
             f"PLE conv history {self.state_len} exceeds CHUNK_SIZE {CHUNK_SIZE}"
         )
-        self._pending: Tuple[PLEMetadata, torch.Tensor] | None = None
+        self._pending: Tuple[PLEMetadata, torch.Tensor | None] | None = None
 
     def start_prefetch(self, batch: Batch, meta: PLEMetadata | None = None) -> None:
         """Hash this forward's n-grams and start the table gather on the side stream."""
         if meta is None:
             meta = build_ple_metadata(batch, self.args, batch.input_ids.device)
+        table = self.ple_embedding.table
+        if (
+            batch.input_ids.is_cuda
+            and torch.cuda.is_current_stream_capturing()
+            and getattr(table, "external_cuda_graph_staging", False)
+        ):
+            self._pending = (meta, None)
+            return
         row_ids = self.ple_embedding.row_ids(meta)
         self._pending = (meta, row_ids)
-        self.ple_embedding.table.prefetch(row_ids)
+        table.prefetch(row_ids)
 
     def forward(
         self,
@@ -592,10 +755,17 @@ class PLELayer(BaseOP):
                 meta = build_ple_metadata(batch, self.args, R.device)
         elif pending is not None and pending[0] is meta:
             row_ids = pending[1]
-        if row_ids is None:
-            row_ids = self.ple_embedding.row_ids(meta)
-
-        embeddings = self.ple_embedding.table.lookup(row_ids).to(R.dtype)
+        table = self.ple_embedding.table
+        if (
+            R.is_cuda
+            and torch.cuda.is_current_stream_capturing()
+            and getattr(table, "external_cuda_graph_staging", False)
+        ):
+            embeddings = table.cuda_graph_lookup(meta.input_ids.numel(), self.ple_embedding.num_heads)
+        else:
+            if row_ids is None:
+                row_ids = self.ple_embedding.row_ids(meta)
+            embeddings = table.lookup(row_ids).to(R.dtype)
         key = self.norm_key.forward(self.key_proj.forward(embeddings))
         value = self.value_proj.forward(embeddings)
         query = self.norm_query.forward(R)
@@ -709,6 +879,7 @@ class PLELayer(BaseOP):
 
 __all__ = [
     "GpuResidentTable",
+    "MmapStagedTable",
     "NGramEmbedding",
     "ZeroTable",
     "PLELayer",

--- a/python/freetoken/models/qwen4_exp/weight.py
+++ b/python/freetoken/models/qwen4_exp/weight.py
@@ -12,11 +12,12 @@ Dropped: ``mtp.*`` (speculative head, including its stacked ``mtp.layers.0.mlp.e
 from __future__ import annotations
 
 import json
+import mmap
 import os
 import re
 import struct
 from dataclasses import dataclass
-from typing import Iterator
+from typing import BinaryIO, Iterator
 
 import safetensors
 import torch
@@ -202,6 +203,112 @@ class PleTable:
         return self.bank.tensor
 
 
+@dataclass(frozen=True)
+class PleShard:
+    """A PLE byte range in a safetensor file."""
+
+    path: str
+    offset: int
+    nbytes: int
+    rows: int
+    cols: int
+
+
+@dataclass(frozen=True)
+class PleLayout:
+    """Validated on-disk PLE layout."""
+
+    shards: tuple[PleShard, ...]
+    weight_scale: torch.Tensor
+    rows_per_shard: int
+    head_dim: int
+
+
+class MmapPleStorage:
+    """Memory-map PLE safetensor ranges and gather selected rows."""
+
+    def __init__(self, layout: PleLayout) -> None:
+        self.rows_per_shard = layout.rows_per_shard
+        self.head_dim = layout.head_dim
+        self.num_rows = len(layout.shards) * self.rows_per_shard
+        self.nbytes = sum(shard.nbytes for shard in layout.shards)
+        self._files: dict[str, BinaryIO] = {}
+        self._maps: dict[str, mmap.mmap] = {}
+        self._shards: list[torch.Tensor] = []
+        try:
+            for shard in layout.shards:
+                mapping = self._maps.get(shard.path)
+                if mapping is None:
+                    fh = open(shard.path, "rb")
+                    mapping = mmap.mmap(fh.fileno(), length=0, access=mmap.ACCESS_COPY)
+                    if hasattr(mapping, "madvise") and hasattr(mmap, "MADV_RANDOM"):
+                        mapping.madvise(mmap.MADV_RANDOM)
+                    self._files[shard.path] = fh
+                    self._maps[shard.path] = mapping
+                tensor = torch.frombuffer(
+                    mapping,
+                    dtype=torch.uint8,
+                    count=shard.nbytes,
+                    offset=shard.offset,
+                ).reshape(shard.rows, shard.cols)
+                self._shards.append(tensor)
+        except Exception:
+            self.close()
+            raise
+
+    def gather(self, row_ids: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        """Copy valid rows into a CPU buffer; invalid IDs produce zeros."""
+        ids = row_ids.reshape(-1)
+        if ids.device.type != "cpu" or ids.dtype != torch.int64:
+            raise ValueError("mmap PLE row ids must be a CPU int64 tensor")
+        expected = (ids.numel(), self.head_dim)
+        if out.device.type != "cpu" or out.dtype != torch.uint8 or tuple(out.shape) != expected:
+            raise ValueError(
+                f"mmap PLE output must be CPU uint8 {expected}, got {out.device} "
+                f"{out.dtype} {tuple(out.shape)}"
+            )
+        out.zero_()
+        if ids.numel() == 0:
+            return out
+
+        valid = (ids >= 0) & (ids < self.num_rows)
+        positions = valid.nonzero().reshape(-1)
+        if positions.numel() == 0:
+            return out
+        valid_ids = ids.index_select(0, positions)
+        shard_ids = torch.div(valid_ids, self.rows_per_shard, rounding_mode="floor")
+        for shard_id in torch.unique(shard_ids).tolist():
+            in_shard = (shard_ids == shard_id).nonzero().reshape(-1)
+            dst_positions = positions.index_select(0, in_shard)
+            local_ids = valid_ids.index_select(0, in_shard).remainder(self.rows_per_shard)
+            rows = self._shards[shard_id].index_select(0, local_ids)
+            out.index_copy_(0, dst_positions, rows)
+        return out
+
+    def close(self) -> None:
+        self._shards.clear()
+        for mapping in self._maps.values():
+            mapping.close()
+        self._maps.clear()
+        for fh in self._files.values():
+            fh.close()
+        self._files.clear()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+@dataclass(frozen=True)
+class MmapPleTable:
+    """Mapped PLE storage and its FP8 scale."""
+
+    storage: MmapPleStorage
+    weight_scale: torch.Tensor
+
+
 _PLE_ST_DTYPE = "F8_E4M3"
 
 
@@ -222,15 +329,8 @@ def _ple_table_files(folder: str) -> list[str]:
     return sorted(os.path.join(folder, shard) for shard in files)
 
 
-def load_ple_table(model_path: str, qwen4_args, *, pin: bool = True,
-                   workers: int = 8, chunk: int = 8 << 20) -> PleTable:
-    """Concatenate the checkpoint's ``ngram_embedding.shard_<i>`` tensors into one pinned host bank.
-
-    The checkpoint splits the table into ``split_ngram_parts`` equal row blocks named by shard
-    index and scattered over the ``model-plefp8-*`` shards in header (lexicographic) order, so the
-    bank is filled shard by shard at ``shard_index * rows_per_shard``. Each read is O_DIRECT: the
-    table is ~47.7 GiB and must not also sit in the page cache while the bank holds the same bytes.
-    """
+def _ple_layout(model_path: str, qwen4_args) -> PleLayout:
+    """Parse and validate the PLE shards."""
     folder = download_hf_weight(model_path)
     parts: dict[int, tuple[str, int, int]] = {}  # shard index -> (path, file offset, bytes)
     scale: torch.Tensor | None = None
@@ -266,22 +366,60 @@ def load_ple_table(model_path: str, qwen4_args, *, pin: bool = True,
     if scale is None:
         raise ValueError("PLE table has no weight_scale")
 
-    bank = HostBank((expected * rows, cols), torch.float8_e4m3fn)
+    shards = tuple(
+        PleShard(path=parts[i][0], offset=parts[i][1], nbytes=parts[i][2], rows=rows, cols=cols)
+        for i in range(expected)
+    )
     shard_bytes = rows * cols
-    bar = byte_bar(expected * shard_bytes, "Loading PLE table")
+    for shard_id, shard in enumerate(shards):
+        if shard.nbytes != shard_bytes:
+            raise ValueError(
+                f"PLE shard {shard_id} is {shard.nbytes} B, expected {shard_bytes}"
+            )
+    return PleLayout(
+        shards=shards,
+        weight_scale=scale,
+        rows_per_shard=rows,
+        head_dim=cols,
+    )
+
+
+def load_ple_table(model_path: str, qwen4_args, *, pin: bool = True,
+                   workers: int = 8, chunk: int = 8 << 20) -> PleTable:
+    """Concatenate the checkpoint's ``ngram_embedding.shard_<i>`` tensors into one pinned host bank.
+
+    The checkpoint splits the table into ``split_ngram_parts`` equal row blocks named by shard
+    index and scattered over the ``model-plefp8-*`` shards in header (lexicographic) order, so the
+    bank is filled shard by shard at ``shard_index * rows_per_shard``. Each read is O_DIRECT: the
+    table is ~47.7 GiB and must not also sit in the page cache while the bank holds the same bytes.
+    """
+    layout = _ple_layout(model_path, qwen4_args)
+
+    bank = HostBank((len(layout.shards) * layout.rows_per_shard, layout.head_dim),
+                    torch.float8_e4m3fn)
+    bar = byte_bar(sum(shard.nbytes for shard in layout.shards), "Loading PLE table")
     try:
         buf = bank.memoryview()
-        for shard in range(expected):
-            path, offset, nbytes = parts[shard]
-            assert nbytes == shard_bytes, f"PLE shard {shard} is {nbytes} B, expected {shard_bytes}"
-            read_range_into(buf, path, file_offset=offset, nbytes=nbytes,
-                            dest_offset=shard * shard_bytes, workers=workers, chunk=chunk)
-            bar.update(nbytes)
+        dest_offset = 0
+        for shard in layout.shards:
+            read_range_into(buf, shard.path, file_offset=shard.offset, nbytes=shard.nbytes,
+                            dest_offset=dest_offset, workers=workers, chunk=chunk)
+            dest_offset += shard.nbytes
+            bar.update(shard.nbytes)
     finally:
         bar.close()
     if pin and torch.cuda.is_available():
         bank.pin()
-    return PleTable(bank=bank, weight_scale=scale)
+    return PleTable(bank=bank, weight_scale=layout.weight_scale)
+
+
+def load_mmap_ple_table(model_path: str, qwen4_args) -> MmapPleTable:
+    """Map the PLE safetensor ranges."""
+    layout = _ple_layout(model_path, qwen4_args)
+    return MmapPleTable(
+        storage=MmapPleStorage(layout),
+        weight_scale=layout.weight_scale,
+    )
 
 
 # ======================================================================================
@@ -320,9 +458,12 @@ def load_nvfp4_expert_sources_parallel(
 
 
 __all__ = [
+    "MmapPleStorage",
+    "MmapPleTable",
     "PleTable",
     "iter_weights",
     "load_nvfp4_expert_sources",
     "load_nvfp4_expert_sources_parallel",
+    "load_mmap_ple_table",
     "load_ple_table",
 ]

--- a/python/freetoken/server/args.py
+++ b/python/freetoken/server/args.py
@@ -500,6 +500,13 @@ def parse_args(
         ),
     )
 
+    parser.add_argument(
+        "--ple-backend",
+        default=ServerArgs.ple_backend,
+        choices=["pinned", "mmap"],
+        help="Qwen3.8 PLE storage backend; mmap demand-pages safetensors.",
+    )
+
     moe_cache_group = parser.add_mutually_exclusive_group()
     moe_cache_group.add_argument(
         "--moe-cache-size",

--- a/tests/engine/test_ple_backend.py
+++ b/tests/engine/test_ple_backend.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+from freetoken.engine.engine import _validate_ple_backend
+from freetoken.engine.graph import GraphRunner
+
+
+def _config(backend: str, *, graph_bs=None, graph_max=None):
+    return SimpleNamespace(
+        ple_backend=backend,
+        cuda_graph_bs=graph_bs,
+        cuda_graph_max_bs=graph_max,
+    )
+
+
+def _qwen_config(*, ple: bool = True):
+    return SimpleNamespace(
+        qwen4_args=SimpleNamespace(ple_layer_ids=(2,) if ple else ()),
+    )
+
+
+def _adjust(config, model_config):
+    return _validate_ple_backend(config, model_config)
+
+
+def test_pinned_ple_keeps_cuda_graph_configuration():
+    config = _config("pinned", graph_bs=[1, 2], graph_max=2)
+    _adjust(config, _qwen_config())
+    assert config.cuda_graph_bs == [1, 2]
+    assert config.cuda_graph_max_bs == 2
+
+
+def test_mmap_ple_keeps_cuda_graph_configuration():
+    config = _config("mmap", graph_bs=[1, 2], graph_max=2)
+    _adjust(config, _qwen_config())
+    assert config.cuda_graph_bs == [1, 2]
+    assert config.cuda_graph_max_bs == 2
+
+
+def test_mmap_ple_rejects_models_without_a_ple_table():
+    config = _config("mmap")
+    with pytest.raises(ValueError, match="Qwen3.8-Flash-Next"):
+        _adjust(config, SimpleNamespace())
+    with pytest.raises(ValueError, match="PLE table"):
+        _adjust(config, _qwen_config(ple=False))
+
+
+def test_unknown_ple_backend_is_rejected_programmatically():
+    with pytest.raises(ValueError, match="ple_backend"):
+        _adjust(_config("nvme"), _qwen_config())
+
+
+def test_graph_replay_prepares_model_before_replay():
+    events = []
+
+    class Buffer:
+        logits = torch.zeros(2, 3)
+
+        def copy_from(self, batch):
+            events.append("copy")
+
+    class Model:
+        def prepare_cuda_graph_replay(self, batch):
+            events.append("model")
+
+    class Attention:
+        def prepare_for_replay(self, batch):
+            events.append("attention")
+
+    class Graph:
+        def replay(self):
+            events.append("replay")
+
+    runner = object.__new__(GraphRunner)
+    runner.max_graph_bs = 2
+    runner.buffer = Buffer()
+    runner.model = Model()
+    runner.attn_backend = Attention()
+    runner.graph_map = {2: Graph()}
+    batch = SimpleNamespace(is_decode=True, size=1, padded_size=2)
+
+    logits = runner.replay(batch)
+
+    assert logits.shape == (1, 3)
+    assert events == ["copy", "model", "attention", "replay"]

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -17,8 +17,10 @@ import numpy as np
 import pytest
 import torch
 
+import freetoken.models.qwen4_exp.ple as ple_module
 from freetoken.models.config import ModelConfig
 from freetoken.models.qwen4_exp.config import parse_config
+from freetoken.models.qwen4_exp.model import Qwen4ExpModel
 from freetoken.models.qwen4_exp.ple import (
     GpuResidentTable,
     PinnedUVATable,
@@ -38,6 +40,56 @@ requires_hf_ref = pytest.mark.skipif(
     not (_HF_REF_PYTHON and Path(_HF_REF_PYTHON).exists()),
     reason="set FREETOKEN_QWEN4_HF_PYTHON to a transformers build that ships qwen4_exp",
 )
+
+
+def test_mmap_graph_hooks_stage_every_ple_layer(monkeypatch):
+    events = []
+    meta = object()
+
+    class Table:
+        def __init__(self, name):
+            self.name = name
+
+        def prepare_cuda_graph_capture(self, rows):
+            events.append(("capture", self.name, rows))
+
+        def prefetch(self, row_ids):
+            events.append(("prefetch", self.name, row_ids.item()))
+
+        def prepare_cuda_graph_replay(self, row_ids):
+            events.append(("replay", self.name, row_ids.item()))
+
+        def reset_cuda_graph(self):
+            events.append(("reset", self.name))
+
+    def ple(name, row):
+        table = Table(name)
+        embedding = SimpleNamespace(
+            num_heads=4,
+            table=table,
+            row_ids=lambda got_meta: torch.tensor([row]) if got_meta is meta else None,
+        )
+        return SimpleNamespace(args=object(), ple_embedding=embedding)
+
+    model = object.__new__(Qwen4ExpModel)
+    model._ple = (ple("a", 11), ple("b", 22))
+    batch = SimpleNamespace(padded_size=3, input_ids=torch.zeros(3))
+    monkeypatch.setattr(ple_module, "build_ple_metadata", lambda *args: meta)
+
+    model.prepare_mmap_ple_graph_capture(batch)
+    model.prepare_mmap_ple_graph_replay(batch)
+    model.reset_mmap_ple_graph()
+
+    assert events == [
+        ("capture", "a", 12),
+        ("capture", "b", 12),
+        ("prefetch", "a", 11),
+        ("prefetch", "b", 22),
+        ("replay", "a", 11),
+        ("replay", "b", 22),
+        ("reset", "a"),
+        ("reset", "b"),
+    ]
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/models/qwen4_exp/test_weight.py
+++ b/tests/models/qwen4_exp/test_weight.py
@@ -18,6 +18,7 @@ from freetoken.kernel.aot_models import SUPPORTED_MODELS, expert_bank_row_bytes
 from freetoken.models.qwen4_exp.weight import (
     _ZERO_CENTERED_NORM_SUFFIXES,
     iter_weights,
+    load_mmap_ple_table,
     load_ple_table,
 )
 from freetoken.moe.host_banks import HostBank, read_range_into
@@ -323,6 +324,110 @@ def test_load_ple_table_rejects_a_shard_count_mismatch(checkpoint):
     args = SimpleNamespace(split_ngram_parts=NGRAM_SHARDS + 1, ngram_head_dim=NGRAM_DIM)
     with pytest.raises(ValueError, match="shards 0"):
         load_ple_table(folder, args, pin=False)
+
+
+def test_mmap_ple_table_gathers_rows_without_materializing_the_table(checkpoint):
+    folder, raw = checkpoint
+    args = SimpleNamespace(split_ngram_parts=NGRAM_SHARDS, ngram_head_dim=NGRAM_DIM)
+    table = load_mmap_ple_table(folder, args)
+    prefix = "model.language_model.layers.0.ple.ple_embedding.ngram_embedding"
+    ids = torch.tensor([
+        0,
+        NGRAM_ROWS - 1,
+        NGRAM_ROWS,
+        2 * NGRAM_ROWS + 3,
+        NGRAM_SHARDS * NGRAM_ROWS - 1,
+        -1,
+        NGRAM_SHARDS * NGRAM_ROWS,
+    ], dtype=torch.int64)
+    out = torch.empty(ids.numel(), NGRAM_DIM, dtype=torch.uint8)
+    try:
+        assert table.storage.gather(ids, out) is out
+        assert table.storage.num_rows == NGRAM_SHARDS * NGRAM_ROWS
+        assert table.storage.nbytes == NGRAM_SHARDS * NGRAM_ROWS * NGRAM_DIM
+        for i, row_id in enumerate(ids.tolist()[:5]):
+            shard, row = divmod(row_id, NGRAM_ROWS)
+            want = raw[f"{prefix}.shard_{shard}.weight"][row].view(torch.uint8)
+            assert torch.equal(out[i], want)
+        assert out[-2:].count_nonzero() == 0
+        assert float(table.weight_scale) == 0.125
+    finally:
+        table.storage.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs cuda")
+def test_mmap_staged_backend_matches_checkpoint_rows(checkpoint):
+    from freetoken.models.qwen4_exp.ple import MmapStagedTable
+
+    folder, raw = checkpoint
+    args = SimpleNamespace(split_ngram_parts=NGRAM_SHARDS, ngram_head_dim=NGRAM_DIM)
+    table = load_mmap_ple_table(folder, args)
+    backend = MmapStagedTable(table.storage, float(table.weight_scale))
+    prefix = "model.language_model.layers.0.ple.ple_embedding.ngram_embedding"
+    source = torch.cat([
+        raw[f"{prefix}.shard_{i}.weight"] for i in range(NGRAM_SHARDS)
+    ]).cuda()
+    ids = torch.tensor([[0, 6, 7, 17], [27, 20, 3, 14]], device="cuda")
+    want = source.index_select(0, ids.reshape(-1)).to(torch.bfloat16)
+    want = (want * float(table.weight_scale)).view(2, -1)
+    try:
+        # Match the scheduler's inference-mode context.
+        with torch.inference_mode():
+            assert torch.equal(backend.lookup(ids), want)
+            backend.prefetch(ids)
+            assert torch.equal(backend.lookup(ids), want)
+    finally:
+        backend.close()
+        table.storage.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs cuda")
+def test_mmap_staged_backend_cuda_graph_replay_stages_new_rows(checkpoint):
+    from freetoken.models.qwen4_exp.ple import MmapStagedTable
+
+    folder, raw = checkpoint
+    args = SimpleNamespace(split_ngram_parts=NGRAM_SHARDS, ngram_head_dim=NGRAM_DIM)
+    table = load_mmap_ple_table(folder, args)
+    backend = MmapStagedTable(table.storage, float(table.weight_scale))
+    prefix = "model.language_model.layers.0.ple.ple_embedding.ngram_embedding"
+    source = torch.cat([
+        raw[f"{prefix}.shard_{i}.weight"] for i in range(NGRAM_SHARDS)
+    ]).cuda()
+    graphs = {}
+    captured = {}
+    try:
+        for tokens in (1, 2):
+            backend.prepare_cuda_graph_capture(tokens * 4)
+            captured[tokens] = torch.empty(
+                tokens, 4 * NGRAM_DIM, dtype=torch.bfloat16, device="cuda"
+            )
+        torch.cuda.synchronize()
+        for tokens in (1, 2):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured[tokens].copy_(backend.cuda_graph_lookup(tokens, 4))
+            graphs[tokens] = graph
+
+        for ids in (
+            torch.tensor([[0, 6, 7, 17]], device="cuda"),
+            torch.tensor([[1, 8, 15, 22], [4, 11, 18, 25]], device="cuda"),
+            torch.tensor([[27, 20, 3, 14]], device="cuda"),
+        ):
+            tokens = ids.shape[0]
+            with torch.inference_mode():
+                backend.prefetch(ids)
+                backend.prepare_cuda_graph_replay(ids)
+                graphs[tokens].replay()
+            torch.cuda.synchronize()
+            want = source.index_select(0, ids.reshape(-1)).to(torch.bfloat16)
+            want = (want * float(table.weight_scale)).view_as(captured[tokens])
+            assert torch.equal(captured[tokens], want)
+    finally:
+        graphs.clear()
+        torch.cuda.synchronize()
+        backend.reset_cuda_graph()
+        backend.close()
+        table.storage.close()
 
 
 # ======================================================================================

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -469,6 +469,9 @@ def test_graph_capture_reuses_warm_offload_cache_before_capture(monkeypatch):
             pass
 
     class FakeModel:
+        def prepare_cuda_graph_capture(self, batch):
+            pass
+
         def forward(self):
             events.append("forward")
             batch = get_global_ctx().batch

--- a/tests/server/test_parser_auto_selection.py
+++ b/tests/server/test_parser_auto_selection.py
@@ -94,3 +94,13 @@ def test_an_explicit_choice_beats_inference():
         pinned, _ = parse_args(["--model", ANON_PATH, "--reasoning-parser", "qwen3"])
     assert off.reasoning_parser is None
     assert pinned.reasoning_parser == "qwen3"
+
+
+def test_ple_backend_is_exposed_by_the_server_cli():
+    config = _Config({"architectures": ["Qwen4ExpForConditionalGeneration"],
+                      "torch_dtype": "bfloat16"})
+    with patch("freetoken.utils.cached_load_hf_config", lambda _path: config):
+        default, _ = parse_args(["--model", ANON_PATH])
+        mapped, _ = parse_args(["--model", ANON_PATH, "--ple-backend", "mmap"])
+    assert default.ple_backend == "pinned"
+    assert mapped.ple_backend == "mmap"


### PR DESCRIPTION
closes  #79 offload PLE to Disk

Adds `--ple-backend mmap`, demand-paging Qwen3.8-Flash-Next’s 47.7 GiB PLE table from NVMe

## Usage:
set ple-backend `pinned`  (default) or `mmap`
```
ft serve \
  --model RadixArk/Qwen3.8-Flash-Next-NVFP4 \
  --ple-backend mmap \
  --expert-load serial \
  --attention-backend qsa_sparse \
  --page-size 64 \
  --nvfp4-backend triton \
  --max-running-requests 1 \
  --max-seq-len-override 250000 \
  --kv-reserve-tokens 250000 \
  --max-prefill-length 8192 \
  --memory-ratio 0.85 \
  --enable-cache-report
  ```
## Performance tests:
Fits into 128GB of total RAM + VRAM  space with 250K FP16 context. 

Tests under RTX 5090, 96 GB RAM: 
| Context | PP (tok/s) | TG (tok/s) |
|---:|---:|---:|
| 0K | — | 44.75 |
| 32K | 3,045 | 37.90 |
| 128K | 2,981 | 39.02 |



looks sweet, but appreciate tests with pinned PLE to avoid negative regression, don't have enough RAM for that