### PR TITLE
fix(models): load NVFP4 expert banks from checkpoints without a safetensors index

### DIFF
--- a/python/freetoken/models/nvfp4_banks.py
+++ b/python/freetoken/models/nvfp4_banks.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import collections
+import glob
 import json
 import os
 import re
+import struct
 from dataclasses import dataclass
 from typing import Callable
 
@@ -62,6 +64,26 @@ def _alloc_nvfp4_host_banks(num_layers: int, E: int, H: int, I: int):
     }, num_layers)
 
 
+def _weight_map(folder: str) -> dict[str, str]:
+    """Tensor name -> shard filename. From ``model.safetensors.index.json`` when present, else
+    each ``*.safetensors`` shard's header (single-file / no-index checkpoints, e.g. the RadixArk
+    NVFP4 layout that splits weights across model-bf16-* / model-plefp8-* / layer-*-experts-*).
+    Mirrors the no-index fallback in ``models.weight.iter_expert_tensors_parallel``."""
+    index_path = os.path.join(folder, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        with open(index_path, encoding="utf-8") as f:
+            return json.load(f)["weight_map"]
+    weight_map: dict[str, str] = {}
+    for shard in sorted(os.path.basename(p) for p in glob.glob(os.path.join(folder, "*.safetensors"))):
+        with open(os.path.join(folder, shard), "rb") as fh:
+            n = struct.unpack("<Q", fh.read(8))[0]
+            hdr = json.loads(fh.read(n))
+        for nm in hdr:
+            if nm != "__metadata__":
+                weight_map[nm] = shard
+    return weight_map
+
+
 def load_nvfp4_expert_source_banks(
     model_path: str,
     config,
@@ -87,9 +109,7 @@ def load_nvfp4_expert_source_banks(
     until then (the caller owns that tradeoff).
     """
     folder = download_hf_weight(model_path)
-    index_path = os.path.join(folder, "model.safetensors.index.json")
-    with open(index_path, encoding="utf-8") as f:
-        weight_map = json.load(f)["weight_map"]
+    weight_map = _weight_map(folder)
 
     E = config.num_experts
     H = config.hidden_size
@@ -219,8 +239,7 @@ def load_nvfp4_expert_source_banks_parallel(
     from freetoken.models.weight import iter_expert_tensors_parallel
 
     folder = download_hf_weight(model_path)
-    with open(os.path.join(folder, "model.safetensors.index.json"), encoding="utf-8") as f:
-        weight_map = json.load(f)["weight_map"]
+    weight_map = _weight_map(folder)
 
     E = config.num_experts
     H = config.hidden_size

--- a/tests/models/qwen4_exp/test_weight.py
+++ b/tests/models/qwen4_exp/test_weight.py
@@ -18,6 +18,8 @@ from freetoken.kernel.aot_models import SUPPORTED_MODELS, expert_bank_row_bytes
 from freetoken.models.qwen4_exp.weight import (
     _ZERO_CENTERED_NORM_SUFFIXES,
     iter_weights,
+    load_nvfp4_expert_sources,
+    load_nvfp4_expert_sources_parallel,
     load_ple_table,
 )
 from freetoken.moe.host_banks import HostBank, read_range_into
@@ -408,3 +410,82 @@ def test_fusion_pad_rides_the_tensor_device():
     key, fused = _try_fuse("model.layers.0.attn_hyper_connection.block_inject_weight.weight", inject, buf)
     assert fused.device.type == "cuda" and fused.shape[0] == 336
     assert torch.equal(fused[324:], torch.zeros(12, 64, device="cuda", dtype=torch.bfloat16))
+
+
+# ======================================================================================
+# Routed NVFP4 expert source banks, loaded from a no-index checkpoint
+# ======================================================================================
+#
+# The RadixArk Qwen3.8-Flash-Next-NVFP4 checkpoint ships NO model.safetensors.index.json:
+# its weights are split across model-bf16-*, model-plefp8-* and layer-*-experts-* shards.
+# The dense (iter_weights) and PLE (load_ple_table) paths already enumerate shards from
+# their headers in that case; the NVFP4 expert-bank loaders must do the same instead of
+# crashing on the missing index.
+
+
+def _expert_tensors(lm: str, layer: int, E: int, H: int, I: int) -> dict[str, torch.Tensor]:
+    """One layer's routed NVFP4 experts in the ModelOpt layout: packed uint8 weight,
+    fp8-e4m3 block scale, and a scalar per-tensor global (weight_scale_2)."""
+    out: dict[str, torch.Tensor] = {}
+    for expert in range(E):
+        base = f"{lm}.layers.{layer}.mlp.experts.{expert}"
+        for proj, rows, cols in (("gate_proj", I, H), ("up_proj", I, H), ("down_proj", H, I)):
+            out[f"{base}.{proj}.weight"] = torch.randint(0, 256, (rows, cols // 2), dtype=torch.uint8)
+            out[f"{base}.{proj}.weight_scale"] = torch.ones(rows, cols // 16, dtype=torch.float8_e4m3fn)
+            out[f"{base}.{proj}.weight_scale_2"] = torch.tensor(0.5)
+    return out
+
+
+@pytest.fixture(scope="module")
+def expert_ckpt(tmp_path_factory) -> tuple[str, dict[str, torch.Tensor]]:
+    """A no-index checkpoint whose only tensors are routed NVFP4 experts, split across two
+    shards (named like the real layer-*-experts-* files) so the reader must build its
+    name->shard map from the shard headers. I=16 keeps the down block-scale bank non-empty."""
+    torch.manual_seed(1)
+    folder = tmp_path_factory.mktemp("qwen4_exp_experts")
+    tensors = _expert_tensors("model.language_model", 0, E=2, H=32, I=16)
+    names = sorted(tensors)
+    save_file({n: tensors[n] for n in names[::2]}, str(folder / "layer-00000-experts-0000-0001.safetensors"))
+    save_file({n: tensors[n] for n in names[1::2]}, str(folder / "layer-00000-experts-0002-0003.safetensors"))
+    return str(folder), tensors
+
+
+def _expert_config() -> SimpleNamespace:
+    return SimpleNamespace(num_layers=1, num_moe_layers=1, num_experts=2,
+                           hidden_size=32, moe_intermediate_size=16)
+
+
+def _assert_expert_banks(banks: dict[str, list[torch.Tensor]], tensors, config) -> None:
+    H, I, E = config.hidden_size, config.moe_intermediate_size, config.num_experts
+    lm = "model.language_model"
+    assert set(banks) == {"gate_up_packed", "gate_up_scale", "gate_up_global",
+                          "down_packed", "down_scale", "down_global"}
+    for name in banks:
+        assert len(banks[name]) == 1  # one MoE layer
+    for expert in range(E):
+        base = f"{lm}.layers.0.mlp.experts.{expert}"
+        # gate/up fused on the output-row axis: [gate | up]
+        assert torch.equal(banks["gate_up_packed"][0][expert, :I], tensors[f"{base}.gate_proj.weight"])
+        assert torch.equal(banks["gate_up_packed"][0][expert, I:], tensors[f"{base}.up_proj.weight"])
+        assert torch.equal(banks["gate_up_scale"][0][expert, :I], tensors[f"{base}.gate_proj.weight_scale"])
+        assert torch.equal(banks["gate_up_scale"][0][expert, I:], tensors[f"{base}.up_proj.weight_scale"])
+        assert torch.equal(banks["down_packed"][0][expert], tensors[f"{base}.down_proj.weight"])
+        assert torch.equal(banks["down_scale"][0][expert], tensors[f"{base}.down_proj.weight_scale"])
+        # the scalar global scale is broadcast into the per-row bank
+        assert torch.all(banks["gate_up_global"][0][expert, :I] == 0.5)
+        assert torch.all(banks["gate_up_global"][0][expert, I:] == 0.5)
+        assert torch.all(banks["down_global"][0][expert] == 0.5)
+
+
+def test_nvfp4_expert_banks_parallel_load_from_a_no_index_checkpoint(expert_ckpt):
+    """The path that crashed at launch: the parallel reader must enumerate shards from their
+    headers when model.safetensors.index.json is absent, not raise FileNotFoundError."""
+    folder, tensors = expert_ckpt
+    banks = load_nvfp4_expert_sources_parallel(folder, _expert_config(), workers=4)
+    _assert_expert_banks(banks, tensors, _expert_config())
+
+
+def test_nvfp4_expert_banks_serial_load_from_a_no_index_checkpoint(expert_ckpt):
+    folder, tensors = expert_ckpt
+    banks = load_nvfp4_expert_sources(folder, _expert_config())
+    _assert_expert_banks(banks, tensors, _expert_config())


### PR DESCRIPTION
## Problem

Launching Qwen3.8-Flash-Next (the #257 model) with the offload MoE backend crashes at startup:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../RadixArk--Qwen3.8-Flash-Next-NVFP4/snapshots/.../model.safetensors.index.json'
  File "python/freetoken/models/nvfp4_banks.py", line 222, in load_nvfp4_expert_source_banks_parallel
```

Reproduced with:

```
ft serve --model RadixArk/Qwen3.8-Flash-Next-NVFP4 \
    --moe-backend offload --moe-cache-auto \
    --max-running-requests 1 --kv-reserve-tokens 50000
```

The dense weights load fine ("Loading weights: 206/206"), then the scheduler dies when the offload cache builds the expert banks.

## Root cause

The RadixArk `Qwen3.8-Flash-Next-NVFP4` checkpoint ships **no `model.safetensors.index.json`**. Its weights are split across three shard families:

- `model-bf16-*.safetensors` — dense bf16 weights
- `model-plefp8-*.safetensors` — the n-gram PLE table
- `layer-{L}-experts-{A}-{B}.safetensors` — routed NVFP4 experts (48 layers × 512 experts)

The dense path (`iter_weights` → `iter_weight_files`) and the PLE path (`_ple_table_files`) both already handle a missing index by globbing `*.safetensors` and reading shard headers — which is why the dense load succeeds. But both NVFP4 expert-bank loaders in `models/nvfp4_banks.py` (serial and parallel) hard-opened the index file to build their tensor→shard map, so they raise `FileNotFoundError` as soon as the bank build starts. (`iter_expert_tensors_parallel`, which the parallel path delegates to, already has the no-index fallback — but it's only reached *after* the outer function crashes on the index read.)

## Fix

One helper in `models/nvfp4_banks.py`, used by both loaders:

- `_weight_map(folder)` — returns the name→shard map from `model.safetensors.index.json` when present, else builds it from each `*.safetensors` shard's header (the same fallback `iter_expert_tensors_parallel` already uses).

Checkpoints that do carry an index keep using it unchanged; this only adds the fallback.

## Tests

Added two tests in `tests/models/qwen4_exp/test_weight.py` (serial + parallel) that build a no-index checkpoint whose only tensors are routed NVFP4 experts — split across two shards named like the real `layer-*-experts-*` files — and assert the full 6-bank placement (gate/up fused on the output-row axis, down separate, scalar `weight_scale_2` broadcast into the per-row global banks). Both fail with the launch crash's exact `FileNotFoundError` before the fix, pass after.

- `tests/models/qwen4_exp/test_weight.py`: 24/24 pass.
- `tests/models/` + `tests/moe/`: identical results before/after (the pre-existing failures in this environment are all `FileNotFoundError: 'ninja'` from JIT-compiling CUDA extensions; 56 failed / 192 passed on baseline → 56 failed / 194 passed with the fix, +2 = the new tests).

## Validation against the real checkpoint

`_weight_map` on the actual snapshot dir maps all 296,475 tensors across the 206 shards (matching the dense loader's 206/206), and the NVFP4 expert spec regex then finds exactly 48 × 512 × 3 × 3 = 221,184 expert tensors — every tensor the bank loaders need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
