### PR TITLE
fix(rocm): avoid indirect host pointers during HIP graph capture

### DIFF
--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -1001,7 +1001,12 @@ class OffloadMoeCache:
             for per_layer, cache in self.banks:
                 cache[: self.num_experts].copy_(per_layer[layer_id])
             return
-        if self._copy_fused_ok:
+        # HIP graphs do not reliably retain the pinned-host mappings hidden behind the
+        # fused kernel's device-side pointer table. Direct per-bank tensor arguments do.
+        use_fused = self._copy_fused_ok and not (
+            torch.version.hip and torch.cuda.is_current_stream_capturing()
+        )
+        if use_fused:
             from freetoken.kernel.fast_index_copy import fast_index_copy_multi_jit
 
             # One launch copies the missing rows for every bank (instead of one launch per

--- a/tests/moe/test_fused_copy.py
+++ b/tests/moe/test_fused_copy.py
@@ -5,9 +5,10 @@ zero-copy case), across banks of differing per-row sizes.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
-
 from freetoken.moe.offload_cache import _BANK_SCHEMAS, OffloadMoeCache
 
 CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
@@ -17,6 +18,104 @@ CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 # kernel/aot_models.py must be listed in its TEST_FEATURE_SIZES so the per-bank kernels
 # stay prebuilt under FREETOKEN_DISABLE_JIT=1.
 FEATS = [8192, 512, 256, 4096, 512, 256]
+
+
+def test_rocm_graph_capture_uses_per_bank_copy(monkeypatch):
+    calls = []
+    tensor = torch.empty(1)
+    cache = SimpleNamespace(
+        banks=[([tensor], tensor)],
+        _pending_src_layer=0,
+        _pending_whole_layer=False,
+        _unpinned_layers=frozenset(),
+        _copy_fused_ok=True,
+        _copy_dst_ptrs=tensor,
+        _copy_src_ptrs=[tensor],
+        _copy_feat_bytes=tensor,
+        evict_slots=tensor,
+        src_indices=tensor,
+        num_indices=tensor,
+    )
+    monkeypatch.setattr(torch.version, "hip", "7.0", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    monkeypatch.setattr(
+        "freetoken.kernel.fast_index_copy.fast_index_copy_multi_jit",
+        lambda *args: calls.append("fused"),
+    )
+    monkeypatch.setattr(
+        "freetoken.kernel.fast_index_copy_jit",
+        lambda *args: calls.append("legacy"),
+    )
+
+    OffloadMoeCache.copy_missing(cache)
+
+    assert calls == ["legacy"]
+
+
+@CUDA
+@pytest.mark.slow
+def test_qwen36_sized_pinned_rows_survive_rocm_graph_replay():
+    if not torch.version.hip:
+        pytest.skip("ROCm regression")
+
+    layers, experts, cache_size, topk = 40, 256, 2117, 8
+    cache = OffloadMoeCache(
+        num_layers=layers,
+        num_experts=experts,
+        cache_size=cache_size,
+        device=torch.device("cuda"),
+        quant_format="q4_k_q5_k",
+    )
+    # Qwen3.6-35B-A3B: H=2048, I=512. Keep the real packed bytes per expert.
+    features = {"gate_up": 2 * 512 * (2048 // 256) * 144,
+                "down": 2048 * (512 // 256) * 176}
+    sources = {}
+    fingerprints = torch.arange(experts, dtype=torch.uint8)
+    for name, feature_bytes in features.items():
+        source = torch.empty((experts, feature_bytes), dtype=torch.uint8, pin_memory=True)
+        source[:, 0] = fingerprints
+        sources[name] = [source] * layers
+    cache.set_bank_sources(sources)
+    assert cache._copy_fused_ok
+
+    patterns = (
+        torch.arange(experts, dtype=torch.int32, device="cuda")[:, None]
+        + torch.arange(topk, dtype=torch.int32, device="cuda")[None, :]
+    ) % experts
+    routes = [patterns[layer * 13 % experts].clone() for layer in range(layers)]
+    slots = [torch.empty_like(route) for route in routes]
+
+    def body():
+        for layer, (route, layer_slots) in enumerate(zip(routes, slots)):
+            layer_slots.copy_(route)
+            cache.ensure_experts(layer, layer_slots)
+            cache.copy_missing()
+
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        body()
+    side.synchronize()
+    cache.reset()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=side):
+        body()
+    cache.reset()
+    torch.cuda.synchronize()
+
+    for step in range(512):
+        for layer, route in enumerate(routes):
+            route.copy_(patterns[(step + layer * 13) % experts])
+        graph.replay()
+    torch.cuda.synchronize()
+
+    for route, layer_slots in zip(routes, slots):
+        expected = route.cpu().tolist()
+        resident = layer_slots.cpu().tolist()
+        for _, bank in cache.banks:
+            assert bank[resident, 0].cpu().tolist() == expected
 
 
 def _build_cache(num_layers, num_experts, cache_size):


### PR DESCRIPTION
## Summary

ROCm graph capture can fault when the fused multi-bank expert copy reads pinned-host source addresses indirectly through a device pointer table. During HIP capture only, use the existing per-bank copy path whose source is a direct tensor argument.

- eager ROCm keeps the fused path
- CUDA keeps the fused path
- only HIP graph capture falls back

## Branch-contained reproducer

The public PoC branch contains the fallback, a CPU dispatch contract, and a slow HIP acceptance test using realistic Qwen3.6 geometry:

- 40 layers, 256 experts, 2,117 slots, top-k 8
- 1,179,648-byte Q4_K gate/up rows
- 720,896-byte Q5_K down rows
- 512 graph replays with changing routes and exact row fingerprints

```sh
pytest -q tests/moe/test_fused_copy.py::test_rocm_graph_capture_uses_per_bank_copy
pytest -q tests/moe/test_fused_copy.py::test_qwen36_sized_pinned_rows_survive_rocm_graph_replay
```

Public PoC: https://github.com/ErikBPF/FreeToken/pull/2

## Fresh public-branch evidence

A clean public-branch build on a machine with 128 GB RAM, a Ryzen 9 5950X CPU, and a Radeon RX 9070 XT 16 GB GPU (`gfx1201`) completed the branch's direct-copy HIP graph microbenchmark with:

- graph copies verified
- bit-exact output
- 0.216279 ms serialized median
- 0.182385 ms overlapped median

Artifact: https://github.com/ErikBPF/FreeToken/blob/draft/qwen36-rocm-full-poc/benchmarks/results/qwen36-graph-stream-overlap-gfx1201.json

This evidence validates direct-copy graph mechanics, not the exact 512-replay acceptance test and not endpoint throughput. No speedup claim is made by this PR.

## Scope and overlap

Two files only. This complements #260, whose MVP intentionally disables HIP graph capture, and does not duplicate its ROCm bring-up changes. Qwen model support, FTW changes, endpoint tuning, and research documentation are excluded.
