### PR TITLE
fix(server): stop gemma4 tool-call markers leaking into content

### DIFF
--- a/python/freetoken/server/function_call_parser.py
+++ b/python/freetoken/server/function_call_parser.py
@@ -259,6 +259,17 @@ class BaseFormatDetector(ABC):
     # bot_token is a parse trigger, not a uniqueness claim.
     toolcall_opener: str | None = None
 
+    def scrub_markup(self, text: str) -> str:
+        """Remove this format's markup from text about to be surfaced as content.
+
+        Called on the one-shot parse paths and the end-of-stream drain, so a marker the
+        parser could not turn into a call cannot ride along. NOT called per streaming
+        chunk: parse_streaming_increment still releases a partial opener mid-stream.
+        The default keeps the text untouched, so a detector that does not override this
+        surfaces raw text as it always has.
+        """
+        return text
+
     def __init__(self):
         # Streaming state management
         # Buffer for accumulating incomplete patterns that arrive across multiple streaming chunks
@@ -2060,12 +2071,24 @@ class Gemma4Detector(BaseFormatDetector):
             re.DOTALL,
         )
 
+    # The opener's stable prefix. A block that never completed leaves only part of the
+    # opener behind, which the exact-match bot_token check cannot catch. The closer
+    # ("<tool_call|>") does not share this prefix; finish_streaming replaces it
+    # separately, and the one-shot path does not scrub it at all.
+    _marker_prefix = "<|tool_call"
+
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
 
+    def scrub_markup(self, text: str) -> str:
+        """Content ends where tool markup begins: an opener the parser could not turn
+        into a call is still protocol framing, not assistant-visible text."""
+        idx = text.find(self._marker_prefix)
+        return text if idx == -1 else text[:idx]
+
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         idx = text.find(self.bot_token)
-        normal_text = text[:idx].strip() if idx != -1 else text
+        normal_text = text[:idx].strip() if idx != -1 else self.scrub_markup(text)
         if idx == -1:
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
@@ -2331,6 +2354,9 @@ class Gemma4Detector(BaseFormatDetector):
         self._g4_reset()
         if mode != "idle" or self.bot_token in residual:
             return ""
+        # A stream that ends mid-marker leaves an opener prefix the bot_token check
+        # above cannot see; the closer never starts with it, so both scrubs apply.
+        residual = self.scrub_markup(residual)
         if self.eot_token in residual:
             residual = residual.replace(self.eot_token, "")
         if self.prev_tool_call_arr and residual.strip() == "":
@@ -3591,7 +3617,9 @@ class FunctionCallParser:
                 if pos != -1:
                     tail_start = max(tail_start, pos + len(tok))
             if tail_start != -1:
-                tail = full_text[tail_start:]
+                # has_tool_call() only recognises a COMPLETE opener, so a truncated one
+                # trailing the last call would ride into content; scrub before appending.
+                tail = self.detector.scrub_markup(full_text[tail_start:])
                 normal = parsed_result.normal_text or ""
                 # Only plain text: an unterminated final block would make the
                 # "last closer" precede it and leak markup into content.
@@ -3599,7 +3627,10 @@ class FunctionCallParser:
                     parsed_result.normal_text = normal + tail
             return parsed_result
         else:
-            return StreamingParseResult(normal_text=full_text, calls=[])
+            # Re-surfacing full_text would undo the detector's own scrub and leak the
+            # markup. Detectors that do not scrub return it unchanged, so an
+            # unparseable block never blanks their response.
+            return StreamingParseResult(normal_text=self.detector.scrub_markup(full_text), calls=[])
 
     def parse_stream_chunk(self, chunk_text: str) -> Tuple[str, list[ToolCallItem]]:
         """

--- a/tests/server/test_function_call_parser.py
+++ b/tests/server/test_function_call_parser.py
@@ -343,3 +343,94 @@ def test_streaming_support_flags():
     # test_streaming_model_matrix.py::test_non_streaming_detector_falls_back_to_buffered_parse).
     for name in SUPPORTED_TOOL_CALL_PARSERS:
         assert FunctionCallParser(TOOLS, tool_call_parser=name).supports_streaming() is True
+
+
+def test_gemma4_partial_opener_does_not_leak_into_content():
+    # A call block that never completes leaves an opener prefix in the text. The
+    # prose before it is real content; the marker is protocol framing and must not
+    # reach the client.
+    parser = FunctionCallParser(TOOLS, tool_call_parser="gemma4")
+
+    result = parser.parse_non_stream("Let me check that.<|tool_call")
+
+    assert result.normal_text == "Let me check that."
+    assert result.calls == []
+
+
+def test_gemma4_truncated_call_does_not_leak_into_content():
+    # Generation cut mid-arguments: a well-formed opener, no closer, nothing
+    # parseable. Content must be empty rather than the raw block.
+    parser = FunctionCallParser(TOOLS, tool_call_parser="gemma4")
+
+    result = parser.parse_non_stream('<|tool_call>call:get_weather{city:<|"|>Par')
+
+    assert result.normal_text == ""
+    assert result.calls == []
+
+
+def test_gemma4_malformed_opener_does_not_leak_into_content():
+    # The opener's closing '>' is missing, so find() misses and the whole block
+    # used to be surfaced verbatim.
+    parser = FunctionCallParser(TOOLS, tool_call_parser="gemma4")
+
+    result = parser.parse_non_stream(
+        '<|tool_call call:get_weather{city:<|"|>Paris<|"|>}<tool_call|>'
+    )
+
+    assert "<|tool_call" not in result.normal_text
+
+
+def test_gemma4_streaming_partial_opener_does_not_leak_at_finish():
+    parser = FunctionCallParser(TOOLS, tool_call_parser="gemma4")
+
+    texts, calls = _feed(parser, ["Let me check that.", "<|tool_call"])
+
+    surfaced = "".join(texts) + parser.finish_stream()
+    assert "<|tool_call" not in surfaced
+    # The prose is real content: scrubbing the marker must not take it with it.
+    assert surfaced == "Let me check that."
+    assert calls == []
+
+
+def test_gemma4_partial_opener_after_a_parsed_call_does_not_leak():
+    # The shape #203 reports: a correctly parsed tool_calls array AND a stray marker
+    # in content. The tail after the last closer is surfaced as content, and
+    # has_tool_call() misses a partial opener, so the marker rode along.
+    parser = FunctionCallParser(TOOLS, tool_call_parser="gemma4")
+
+    result = parser.parse_non_stream(
+        '<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}<tool_call|><|tool_call'
+    )
+
+    assert len(result.calls) == 1
+    assert "<|tool_call" not in result.normal_text
+
+
+def test_gemma4_prose_after_a_parsed_call_still_surfaces():
+    # Guard for the fix above: scrubbing the tail must not swallow real trailing text.
+    parser = FunctionCallParser(TOOLS, tool_call_parser="gemma4")
+
+    result = parser.parse_non_stream(
+        '<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}<tool_call|>\nAnything else?'
+    )
+
+    assert len(result.calls) == 1
+    assert "Anything else?" in result.normal_text
+
+
+@pytest.mark.parametrize("parser_name", ["qwen25", "mistral", "deepseekv32", "minimax"])
+def test_unparsed_block_keeps_trailing_prose(parser_name):
+    # A detector that surfaces raw text for an unparseable block must keep doing so:
+    # returning "" here would hand the client an empty message instead of the answer.
+    blocks = {
+        "qwen25": "<tool_call>\n{not valid json}\n</tool_call>\n",
+        "mistral": "[TOOL_CALLS] [{bad json}]\n",
+        "deepseekv32": "<｜DSML｜function_calls>garbage\n",
+        "minimax": "<minimax:tool_call>garbage\n",
+    }
+    parser = FunctionCallParser(TOOLS, tool_call_parser=parser_name)
+
+    result = parser.parse_non_stream(blocks[parser_name] + "Here is the answer: 42.")
+
+    assert result.calls == []
+    assert "Here is the answer: 42." in result.normal_text


### PR DESCRIPTION
Fixes #203.

## Three paths surfaced the marker, not one

`Gemma4Detector` surfaced its own protocol markers as assistant content wherever a
tool-call block failed to parse.

1. **`detect_and_parse`** slices strictly before the opener only when it finds the exact
   `<|tool_call>` byte sequence. When `find()` misses, the whole text became
   `normal_text`, so a partial or malformed opener reached `message.content` verbatim.
   This is the path the issue identifies.
2. **`finish_streaming`** has the same blind spot: its `bot_token in residual` guard
   cannot see a stream that ended mid-marker.
3. **`FunctionCallParser.parse_non_stream`** carried the leak even when the detector got
   it right. It discarded the detector's `normal_text` and re-surfaced `full_text`
   whenever no call parsed; and it appended the tail after the last closer guarded only
   by `has_tool_call()`, which does not recognise a truncated opener.

Path 3 is the shape the report actually describes — a stray marker in content *alongside
a correctly parsed `tool_calls` array*:

```python
parse_non_stream('<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}<tool_call|><|tool_call')
# main:     calls=1, normal_text='<|tool_call'
# this PR:  calls=1, normal_text=''
```

## The fix

Those paths now run the text through a new `BaseFormatDetector.scrub_markup()`. The base
implementation returns the text unchanged; `Gemma4Detector` overrides it to cut at
`<|tool_call`, the prefix its **opener** stabilises on. (The closer `<tool_call|>` does
not share that prefix — `finish_streaming` replaces it separately, and the one-shot path
does not scrub it at all; see the known gaps below.)

The default-is-identity part is load-bearing rather than defensive style. On the
`parse_non_stream` branch it would be tempting to just trust the detector's
`normal_text`, but for a block that fails to parse several detectors return `''` there
while the raw text is what reaches the client today:

| detector | `detect_and_parse().normal_text` | what `parse_non_stream` surfaces (main and this PR) |
|---|---|---|
| qwen25 | `''` | `...Here is the answer: 42.` |
| mistral | `''` | `...Here is the answer: 42.` |
| deepseekv32 | `''` | `...Here is the answer: 42.` |
| minimax | `''` | `...Here is the answer: 42.` |

(measured on `<tool_call>\n{not valid json}\n</tool_call>\nHere is the answer: 42.` and
its per-format equivalents). Scrubbing unconditionally there would hand those four an
empty response instead of the answer, so the base default leaves text alone and
`test_unparsed_block_keeps_trailing_prose` pins it.

## Known gaps this does NOT close

Stated up front so the scope is not overread:

1. **Per-chunk streaming still leaks.** `scrub_markup()` runs on the one-shot paths and
   the end-of-stream drain, not inside `parse_streaming_increment`. A partial opener
   followed by more text in a later chunk is released as it always was:

   ```python
   chunks = ['Hi.', '<|tool_call', ' oops more text']
   # both main and this PR: 'Hi.<|tool_call oops more text'
   ```

   Closing that means teaching the gemma-4 streaming path to hold back a suspected
   marker prefix the way `test_streaming_partial_tag_holdback_then_release` expects for
   qwen25, which is a larger change than #203 calls for. Happy to do it here if you want
   it in one go.
2. **A stray closer with no opener still leaks on the one-shot path.**
   `parse_non_stream('All done.<tool_call|>')` returns `All done.<tool_call|>`, because
   the closer does not start with `<|tool_call` and the `idx == -1` branch never runs the
   `eot_token` replace that `finish_streaming` does. Pre-existing.

## Deliberate behaviour change, gemma4 only

One-shot parsing now agrees with streaming. Given
`<|tool_call>call:get_weather{bad<tool_call|>\nHere is the answer: 42.`:

| | `main` | this PR |
|---|---|---|
| streaming | `''` | `''` |
| non-streaming | `<|tool_call>call:get_weather{bad<tool_call|>\nHere is the answer: 42.` | `''` |

So `main` returns different content for the same request depending on `stream`. This PR
makes them agree. The cost: gemma4 prose *after* an unparseable block is no longer
surfaced non-streaming — it already wasn't, streaming. Happy to preserve the tail on both
paths instead if you prefer that direction.

## Tests

10 cases added to `tests/server/test_function_call_parser.py`.

Five reproduce the bug — each fails on `main` and passes here:

- `test_gemma4_partial_opener_does_not_leak_into_content`
- `test_gemma4_truncated_call_does_not_leak_into_content`
- `test_gemma4_malformed_opener_does_not_leak_into_content`
- `test_gemma4_streaming_partial_opener_does_not_leak_at_finish`
- `test_gemma4_partial_opener_after_a_parsed_call_does_not_leak`

Five pass on `main` too, and are there to pin behaviour this fix must not break — an
earlier revision of it did break them:

- `test_gemma4_prose_after_a_parsed_call_still_surfaces`
- `test_unparsed_block_keeps_trailing_prose[qwen25|mistral|deepseekv32|minimax]`

## What I tested on

- CPU / OS: Apple M4, macOS 27.0 (arm64) — **no NVIDIA GPU, no CUDA**
- Python 3.12.13, torch 2.13.0 (`torch.cuda.is_available()` is `False`)
- Branched off bd372b6
- Checkpoint: **none — no model was loaded or served**
- Command:
  ```bash
  pytest tests/server/test_function_call_parser.py
  ```

## What I could not verify

- **No GPU serving run, and no gemma-4 GGUF was exercised.** The reproduction and the
  fix are both at parser level, driven by unit tests. On this machine `flashlib` has no
  wheel: of the 17 test files in `tests/server/`, 4 fail to import and 7 more have
  flashlib-dependent failures, leaving 6 that run clean. The runnable subset —
  `tests/server/` minus the 4 that cannot be imported, plus `tests/tokenizer/` and
  `tests/daemon/` — goes from **477 passed on `main` to 487 on this branch, with an
  identical set of 59 `ModuleNotFoundError: flashlib` failures on both sides**. That is
  no regression within the subset, not a clean full-suite run. Since there is
  deliberately no `pull_request` CI here, that gate can only be someone running the
  suite on a CUDA box — I cannot supply the hardware/checkpoint/command detail
  CONTRIBUTING asks for, because I never served a model.
- **The concurrency signal in #203 is not reproduced.** The report measured 31 leaks in
  182 concurrent tool calls versus 0 in 553 sequential. What is reproduced here is the
  parser-level cause, deterministically and without concurrency. This removes the paths
  that surface a malformed opener; it does not explain why the opener is malformed more
  often under concurrency. That open question — pointing at detokenisation or
  per-sequence buffering rather than the parser — stays open, and this PR should not be
  read as closing it.

## Noticed while here, deliberately left out

The `normal_text = text[:idx].strip() if idx != -1 else text` line is identical in 7
other detectors (`Qwen25`, `Mistral`, `Glm47`, `DeepSeekV32`, `Qwen3Coder`, `MiniMax`,
`GptOss`), so the same leak class exists there. Filed separately as #347 to keep this to
one change; `scrub_markup()` is the hook to fix them with.
