### PR TITLE
test(qwen4_exp): compare chunked prefill to one-shot at bf16 tolerance

### DIFF
--- a/tests/models/qwen4_exp/test_qsa_backend.py
+++ b/tests/models/qwen4_exp/test_qsa_backend.py
@@ -4,7 +4,8 @@
     tokens every complete block is selected, so QSA IS dense attention: the selection must be
     exactly the causal prefix and the layer output must match ``TorchDenseQSAReference`` (fp32)
     and a flashinfer dense run over the same pool;
-(b) chunked prefill at unaligned cut points equals one-shot prefill (the dual-source compress);
+(b) chunked prefill at unaligned cut points matches one-shot prefill to bf16 tolerance (the
+    dual-source compress);
 (c) a captured decode replay equals the eager decode step.
 """
 
@@ -133,7 +134,11 @@ def test_flashinfer_dense_matches_the_sparse_path():
 @requires_cuda
 @pytest.mark.parametrize("cut", [1001, 4096, 4097], ids=["unaligned", "page-boundary", "boundary+1"])
 def test_chunked_prefill_matches_one_shot(cut: int):
-    """Cut points that are not multiples of index_ratio exercise the dual-source compress."""
+    """Cut points that are not multiples of index_ratio exercise the dual-source compress.
+
+    Not bit for bit: the projections see a different M (5000 vs 5000 - cut rows) and cuBLAS
+    may pick a different kernel per shape, so the indexer's q and k round differently and a
+    few rows flip one block at the top-k margin. Same tolerance as the oracle tests above."""
     config = parsed_config()
     fixture = Fixture(config, num_pages=512)
     attn = fixture.layer(QSA_LAYER)
@@ -145,7 +150,7 @@ def test_chunked_prefill_matches_one_shot(cut: int):
     attn.forward(x[:cut], fixture.batch([head], "prefill"))
     tail = fixture.req(1, cut, length)
     got = attn.forward(x[cut:], fixture.batch([tail], "prefill"))
-    assert torch.equal(got, one_shot[cut:])
+    torch.testing.assert_close(got.float(), one_shot[cut:].float(), rtol=2e-2, atol=2e-2)
 
 
 @requires_cuda


### PR DESCRIPTION
## What

`test_chunked_prefill_matches_one_shot` asserts `torch.equal` between the chunked and the one-shot prefill output of the QSA layer. On torch 2.11.0+cu130 / flashinfer 0.6.18 / triton 3.6.0 (RTX 6000 Ada, sm_89) all three cut points fail on `main` (af71ba4), by a few bf16 ulps. This compares at the tolerance the neighbouring oracle tests in the same file already use (`rtol=2e-2, atol=2e-2`) and says why in the docstring.

## Why this is the test's contract and not a chunked-prefill bug

Measured on plain `main` with the test's own fixture, seed and cut points:

- Both paths are deterministic: one-shot vs one-shot and chunked vs chunked are bit-equal run to run.
- The rounding comes from GEMM shape. `qkv_proj` over the *same rows* gives different bf16 results for M=5000 and M=904 (max diff 3.9e-3, one ulp at that magnitude); the indexer's q and k differ for every cut. cuBLAS picks its kernel per shape, which a chunked prefill cannot avoid.
- Those indexer differences flip one block at the top-k margin in a handful of rows; no row moves by more than 1e-2.

| cut | rows compared | rows with a different block set | max abs diff (output) | `qkv_proj` max diff, M=5000 vs M=rows |
|---|---:|---:|---:|---:|
| 1001 (unaligned) | 3999 | 3 | 2.58e-3 | 0 (bit-equal) |
| 4096 (page-boundary) | 904 | 1 | 2.56e-3 | 3.9e-3 |
| 4097 (boundary+1) | 903 | 1 | 2.56e-3 | 3.9e-3 |

The bf16 defaults of `assert_close` (atol 1e-5) also fail, on elements near 1e-6, so the explicit tolerance is the one that matches the rest of the file.

## Testing

`tests/models/qwen4_exp/test_qsa_backend.py` on the stack above: 9 passed (was 3 failed, 6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173pf9k9fSVtwbm3f898HDt
