### PR TITLE
feat(server): OpenAI protocol coverage -- sampling extras, n, echo/suffix, usage details, tokenize/detokenize/metrics

### DIFF
--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -1,0 +1,101 @@
+# OpenAI-compatible API: endpoints and parameters
+
+What `ft serve` accepts on its OpenAI-shaped routes, what it ignores, and what it refuses,
+next to the same surface in vLLM, SGLang and llama.cpp's server. "honoured" means the value
+changes the generation; "accepted" means the request is not rejected but the value has no
+effect; "400" means the server refuses the request with a clear message.
+
+## Endpoints
+
+| route | FreeToken | vLLM | SGLang | llama.cpp |
+|---|---|---|---|---|
+| `POST /v1/chat/completions` | yes | yes | yes | yes |
+| `POST /v1/completions` | yes | yes | yes | yes |
+| `GET /v1/models`, `GET /v1/models/{id}` | yes | yes | yes | yes |
+| `POST /v1/responses` (+ get, cancel) | yes | yes | yes | yes |
+| `POST /v1/messages` (Anthropic), `count_tokens` | yes | yes | no | yes |
+| `POST /tokenize`, `POST /detokenize` (also under `/v1/`) | yes | yes | yes | yes (`/tokenize`, `/detokenize`) |
+| `GET /metrics` (Prometheus) | yes | yes | yes | yes |
+| `GET /version` | yes | yes | yes | no (`/props`) |
+| `GET /health` | yes | yes | yes | yes |
+| `GET /v1/stats`, `/v1/cache/*`, `/v1/requests`, `/v1/admin/*` | yes (FreeToken control plane) | `/metrics` only | `/get_server_info`, `/flush_cache` | `/slots`, `/props`, `/metrics` |
+| `POST /v1/embeddings`, `/rerank`, `/score`, `/pooling` | no (generative models only) | embedding / reranker models | embedding / reranker models | yes, any model with pooling |
+| `POST /v1/audio/*`, `/v1/files`, `/v1/batches` | no | transcriptions, batch runner (offline) | transcriptions, files, batches | no |
+| `POST /infill`, `/apply-template`, `/completion` (non-OpenAI) | `suffix` on `/v1/completions`; `/tokenize` with `messages` renders the template | no | no | yes |
+
+## Chat completions: request
+
+| parameter | FreeToken | vLLM | SGLang | llama.cpp |
+|---|---|---|---|---|
+| `model`, `messages` (text + `image_url` parts) | honoured | honoured | honoured | honoured |
+| `max_tokens`, `max_completion_tokens` | honoured (default 32k) | honoured | honoured | `max_tokens` |
+| `temperature`, `top_p`, `top_k` | honoured | honoured | honoured | honoured |
+| `min_p` | honoured (prob. below `min_p` x top prob dropped) | honoured | honoured | honoured |
+| `presence_penalty`, `frequency_penalty` | honoured, over generated tokens | honoured | honoured | honoured |
+| `repetition_penalty` | honoured, over prompt + generated tokens (HF semantics) | honoured | honoured | `repeat_penalty` |
+| `logit_bias` | honoured (token id -> bias, clamped to [-100, 100]) | honoured | honoured | honoured |
+| `min_tokens` | honoured: no EOS / stop token before this many generated tokens | honoured | `min_new_tokens` | no |
+| `stop` (strings), `stop_token_ids` | honoured | honoured | honoured | `stop` only |
+| `include_stop_str_in_output` | honoured | honoured | `no_stop_trim` | no |
+| `skip_special_tokens` | honoured; default off here, the reasoning and tool parsers read the tags | honoured (default on) | honoured (default on) | n/a |
+| `n` | honoured, 1..16, one generation per choice (the prefix cache shares the prompt) | honoured | honoured | `n_cmpl` |
+| `stream`, `stream_options.include_usage` | honoured | honoured | honoured | honoured |
+| `logprobs`, `top_logprobs` | 400 on this route (see #224); `/v1/completions` `logprobs` 400 | honoured | honoured | `n_probs` |
+| `tools`, `tool_choice` (`auto` / `none` / `required` / named), `parallel_tool_calls` | honoured | honoured | honoured | honoured |
+| `reasoning_effort`, `thinking`, `chat_template_kwargs` | honoured | `chat_template_kwargs` | honoured | honoured |
+| `continue_final_message` | honoured (the last assistant message is continued, no generation prompt) | honoured | honoured | no |
+| `response_format` `json_object` / `json_schema`, guided decoding | 400 (no constrained decoding) | honoured (xgrammar / guidance) | honoured (xgrammar / outlines / llguidance) | `grammar`, `json_schema` |
+| `seed` | accepted, not honoured (one batched sampling kernel, no per-request generator) | honoured | `sampling_seed` | honoured |
+| `user`, `metadata`, `store`, `service_tier` | accepted, ignored | accepted, ignored | accepted, ignored | accepted, ignored |
+| `request_id` | honoured: becomes the response id | honoured | `rid` | `id_slot` (different meaning) |
+| `function_call` (legacy) | 400 | 400 | 400 | no |
+| `best_of`, `use_beam_search`, `length_penalty`, `prompt_logprobs`, `echo` (chat), `truncate_prompt_tokens`, `priority`, `cache_salt`, `lora` | no | honoured | partly | partly |
+| `ignore_eos` | honoured (benchmarking) | honoured | honoured | honoured |
+
+## Legacy completions: request
+
+`prompt` as a string or a list of strings (token-id prompts are refused); the same sampling
+parameters as above; plus:
+
+| parameter | FreeToken | vLLM | SGLang | llama.cpp |
+|---|---|---|---|---|
+| `echo` | honoured (the prompt leads the text; not with `logprobs`) | honoured | honoured | no |
+| `suffix` | honoured on models with fill-in-the-middle tokens (`<|fim_prefix|>` ... `<|fim_middle|>`): the prompt becomes prefix-suffix-middle | 400 | 400 | `/infill` |
+| `n` | honoured, prompt-major choice order (`prompt i`, sample `k` -> `index i*n+k`) | honoured | honoured | no |
+| `logprobs` | 400 (see #224 for the sampled-token logprobs) | honoured | honoured | `n_probs` |
+
+## Responses
+
+| field | FreeToken | notes |
+|---|---|---|
+| `id` | `chatcmpl-<uid>` / `cmpl-<uuid>`, or `<prefix>-<request_id>` when the client sent one | |
+| `created`, `model`, `object` | yes | |
+| `system_fingerprint` | `null` | vLLM and SGLang also send `null` |
+| `choices[].message.reasoning_content` | yes, when the model reasoned | vLLM `reasoning_content`, llama.cpp `reasoning_content` |
+| `choices[].message.tool_calls` | yes | |
+| `choices[].finish_reason` | `stop`, `length`, `tool_calls` | |
+| `usage.prompt_tokens`, `completion_tokens`, `total_tokens` | yes | for `n > 1` the prompt is counted once, completions summed |
+| `usage.prompt_tokens_details.cached_tokens` | with `--enable-cache-report` | vLLM, SGLang: always |
+| `usage.completion_tokens_details.reasoning_tokens` | yes, when the model emitted a reasoning end tag | vLLM, SGLang |
+| streaming: one `[DONE]`, an optional final usage chunk | yes | |
+| llama.cpp `timings` | no; `/v1/stats` and `/metrics` carry the server-side rates | |
+
+## Tokenize / detokenize
+
+```
+POST /tokenize      {"prompt": "text", "add_special_tokens": true, "return_token_strs": false}
+POST /tokenize      {"messages": [...], "add_generation_prompt": true, "chat_template_kwargs": {}}
+                    -> {"count": N, "max_model_len": L, "tokens": [...], "token_strs": [...]?}
+POST /detokenize    {"tokens": [...], "skip_special_tokens": false} -> {"prompt": "text"}
+```
+
+`messages` are rendered through the model's chat template exactly as a generation would
+render them, so `count` equals the `prompt_tokens` that generation reports.
+
+## Not implemented, on purpose
+
+- Constrained decoding (`response_format` json / json_schema, regex, grammar): needs a
+  grammar engine on the sampling path.
+- Prompt logprobs and `echo` with `logprobs`: need the prefill logits.
+- Per-request `seed`: the batched sampling kernel draws from one generator.
+- Embeddings, reranking, scoring, audio: not generation.

--- a/python/freetoken/core.py
+++ b/python/freetoken/core.py
@@ -33,8 +33,9 @@ class SamplingParams:
     presence_penalty: float = 0.0
     frequency_penalty: float = 0.0
     repetition_penalty: float = 1.0
-    # token id -> additive logit bias (OpenAI logit_bias, clamped to [-100, 100] by the API).
-    logit_bias: dict[int, float] | None = None
+    # OpenAI logit_bias as [[token id, bias], ...] (clamped to [-100, 100] by the API). A list,
+    # not a dict: the messages cross process boundaries as msgpack, which refuses int map keys.
+    logit_bias: list[list[float]] | None = None
     # No EOS / stop token before this many generated tokens (vLLM min_tokens, SGLang
     # min_new_tokens). The scheduler fills min_tokens_stop_ids with the ids to mask.
     min_tokens: int = 0

--- a/python/freetoken/core.py
+++ b/python/freetoken/core.py
@@ -25,10 +25,43 @@ class SamplingParams:
     # Stop strings (OpenAI `stop` / Anthropic `stop_sequences`). Generation finishes when one
     # appears in the decoded output; the matched substring (and anything after) is trimmed.
     stop_strs: list[str] = field(default_factory=list)
+    # ---- logits processors (engine/sample.py), all off by default ----
+    # min_p: drop tokens whose probability is below min_p x the top probability.
+    min_p: float = 0.0
+    # OpenAI presence/frequency penalties over the generated tokens; repetition_penalty is the
+    # HF/vLLM multiplicative penalty over prompt + generated tokens (1.0 = off).
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.0
+    repetition_penalty: float = 1.0
+    # token id -> additive logit bias (OpenAI logit_bias, clamped to [-100, 100] by the API).
+    logit_bias: dict[int, float] | None = None
+    # No EOS / stop token before this many generated tokens (vLLM min_tokens, SGLang
+    # min_new_tokens). The scheduler fills min_tokens_stop_ids with the ids to mask.
+    min_tokens: int = 0
+    min_tokens_stop_ids: list[int] = field(default_factory=list)
+    # Extra token ids that end generation with finish_reason "stop" (vLLM stop_token_ids).
+    stop_token_ids: list[int] = field(default_factory=list)
+    # Keep the matched stop string in the output instead of trimming it (vLLM
+    # include_stop_str_in_output, SGLang no_stop_trim).
+    include_stop_str_in_output: bool = False
+    # Decode with skip_special_tokens. Off by default here: the reasoning and tool parsers
+    # consume the <think>/tool tags from the decoded text.
+    skip_special_tokens: bool = False
 
     @property
     def is_greedy(self) -> bool:
         return (self.temperature <= 0.0 or self.top_k == 1) and self.top_p == 1.0
+
+    @property
+    def needs_logits_processing(self) -> bool:
+        return bool(
+            self.min_p > 0.0
+            or self.presence_penalty != 0.0
+            or self.frequency_penalty != 0.0
+            or self.repetition_penalty != 1.0
+            or self.logit_bias
+            or self.min_tokens > 0
+        )
 
 
 @dataclass(eq=False)

--- a/python/freetoken/engine/sample.py
+++ b/python/freetoken/engine/sample.py
@@ -11,14 +11,110 @@ if TYPE_CHECKING:
 
 
 @dataclass
+class LogitsPlan:
+    """Inputs of the logits processors for the rows of one batch that asked for any
+    (presence / frequency / repetition penalties, logit_bias, min_tokens, min_p).
+
+    Built on the host in ``Sampler.prepare`` from the requests' SamplingParams and
+    token histories, applied on the device by ``apply_logits_processors`` before the
+    sampling kernel. ``None`` when no request in the batch uses a processor, so the
+    default path stays exactly as it was. Row indices inside the plan are LOCAL (0..r-1,
+    in the order of ``rows``); ``rows`` maps them back to the batch.
+    """
+
+    rows: torch.Tensor  # [r] int64 batch rows
+    temps: torch.Tensor  # [r, 1] float32 temperatures (min_p works on probabilities)
+    presence: torch.Tensor | None = None  # [r, 1] float32
+    frequency: torch.Tensor | None = None  # [r, 1] float32
+    repetition: torch.Tensor | None = None  # [r, 1] float32 (1.0 = off)
+    # Generated ids per row, right-padded with vocab_size (a scratch column that is
+    # dropped), for the presence / frequency counts and the repetition mask.
+    hist_ids: torch.Tensor | None = None  # [r, L] int64
+    # Prompt ids per row, same padding: repetition_penalty also covers the prompt.
+    prompt_ids: torch.Tensor | None = None  # [r, P] int64
+    bias_rows: torch.Tensor | None = None  # [b] int64 local rows
+    bias_ids: torch.Tensor | None = None  # [b] int64
+    bias_vals: torch.Tensor | None = None  # [b] float32
+    # Rows still under min_tokens and the ids (EOS + stop_token_ids, padded) they must
+    # not sample yet.
+    min_rows: torch.Tensor | None = None  # [m] int64 local rows
+    min_ids: torch.Tensor | None = None  # [m, S] int64
+    min_p: torch.Tensor | None = None  # [r, 1] float32 (0 = off for that row)
+
+
+@dataclass
 class BatchSamplingArgs:
     temperatures: torch.Tensor | None
     top_k: torch.Tensor | None = None
     top_p: torch.Tensor | None = None
+    plan: LogitsPlan | None = None
 
 
 def make_device_tensor(data: List, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+    if device.type != "cuda":  # the unit tests build plans on the CPU
+        return torch.tensor(data, dtype=dtype, device=device)
     return torch.tensor(data, dtype=dtype, pin_memory=True).to(device, non_blocking=True)
+
+
+def _padded_rows(rows: list[list[int]], pad: int, device: torch.device) -> torch.Tensor:
+    """[len(rows), max_len] int64 with ``pad`` on the right. A synchronous copy: the
+    histories can be long (prompt + output) and a pinned buffer must not be freed under
+    an in-flight non_blocking copy."""
+    width = max(1, max((len(r) for r in rows), default=1))
+    out = torch.full((len(rows), width), pad, dtype=torch.int64)
+    for i, r in enumerate(rows):
+        if r:
+            out[i, : len(r)] = torch.as_tensor(r, dtype=torch.int64)
+    return out.to(device)
+
+
+def apply_logits_processors(
+    logits: torch.Tensor, plan: LogitsPlan, vocab_size: int
+) -> torch.Tensor:
+    """A float32 copy of ``logits`` with the plan applied to its rows, in vLLM's order:
+    repetition -> presence -> frequency penalties, logit_bias, the min_tokens mask, then
+    min_p. Rows outside the plan are copied unchanged."""
+    out = logits.to(torch.float32, copy=True)
+    sub = out[plan.rows]  # [r, V] (advanced indexing copies)
+    r = sub.shape[0]
+    device = sub.device
+    neg_inf = float("-inf")
+
+    if plan.hist_ids is not None:
+        counts = torch.zeros((r, vocab_size + 1), dtype=torch.float32, device=device)
+        counts.scatter_add_(1, plan.hist_ids, torch.ones_like(plan.hist_ids, dtype=torch.float32))
+        counts = counts[:, :vocab_size]
+        if plan.repetition is not None:
+            seen = counts > 0
+            if plan.prompt_ids is not None:
+                in_prompt = torch.zeros((r, vocab_size + 1), dtype=torch.bool, device=device)
+                in_prompt.scatter_(1, plan.prompt_ids, torch.ones_like(plan.prompt_ids, dtype=torch.bool))
+                seen = seen | in_prompt[:, :vocab_size]
+            # HF / vLLM semantics: divide positive logits, multiply negative ones.
+            penalized = torch.where(sub > 0, sub / plan.repetition, sub * plan.repetition)
+            sub = torch.where(seen, penalized, sub)
+        if plan.presence is not None:
+            sub = sub - plan.presence * (counts > 0).to(sub.dtype)
+        if plan.frequency is not None:
+            sub = sub - plan.frequency * counts
+
+    if plan.bias_ids is not None:
+        sub.index_put_((plan.bias_rows, plan.bias_ids), plan.bias_vals, accumulate=True)
+
+    if plan.min_ids is not None:
+        block = torch.zeros((plan.min_ids.shape[0], vocab_size + 1), dtype=torch.bool, device=device)
+        block.scatter_(1, plan.min_ids, torch.ones_like(plan.min_ids, dtype=torch.bool))
+        rows = sub[plan.min_rows]
+        sub[plan.min_rows] = torch.where(block[:, :vocab_size], torch.full_like(rows, neg_inf), rows)
+
+    if plan.min_p is not None:
+        probs = torch.softmax(sub / plan.temps, dim=-1)
+        keep = probs >= plan.min_p * probs.amax(dim=-1, keepdim=True)
+        keep = keep | (plan.min_p <= 0.0)  # rows without min_p stay untouched
+        sub = torch.where(keep, sub, torch.full_like(sub, neg_inf))
+
+    out[plan.rows] = sub
+    return out
 
 
 def sample_impl(
@@ -55,10 +151,87 @@ class Sampler:
     device: torch.device
     vocab_size: int
 
+    def _plan(self, batch: Batch, params) -> LogitsPlan | None:
+        """The LogitsPlan for this batch, or None when no request asks for a processor.
+        Token histories come from the host-side ``req.input_ids``; under overlap
+        scheduling the previous step's token may not be appended yet, so a penalty sees
+        the history one token late. That is the accepted cost of keeping the counts off
+        the device."""
+        MIN_T = 1e-6
+        rows = [i for i, p in enumerate(params) if p.needs_logits_processing]
+        if not rows:
+            return None
+        picked = [(batch.reqs[i], params[i]) for i in rows]
+        temps = [[max(0.0 if p.is_greedy else p.temperature, MIN_T)] for _, p in picked]
+        plan = LogitsPlan(
+            rows=make_device_tensor(rows, torch.int64, self.device),
+            temps=make_device_tensor(temps, torch.float32, self.device),
+        )
+        pad = self.vocab_size
+
+        want_hist = any(
+            p.presence_penalty != 0.0 or p.frequency_penalty != 0.0 or p.repetition_penalty != 1.0
+            for _, p in picked
+        )
+        if want_hist:
+            hist: list[list[int]] = []
+            prompts: list[list[int]] = []
+            want_prompt = False
+            for req, p in picked:
+                prompt_len = req.max_device_len - req.output_len
+                ids = req.input_ids
+                penalized = p.presence_penalty != 0.0 or p.frequency_penalty != 0.0 or p.repetition_penalty != 1.0
+                hist.append(ids[prompt_len:].tolist() if penalized else [])
+                if p.repetition_penalty != 1.0:
+                    want_prompt = True
+                    prompts.append(ids[:prompt_len].tolist())
+                else:
+                    prompts.append([])
+            plan.hist_ids = _padded_rows(hist, pad, self.device)
+            if want_prompt:
+                plan.prompt_ids = _padded_rows(prompts, pad, self.device)
+            if any(p.presence_penalty != 0.0 for _, p in picked):
+                plan.presence = make_device_tensor([[p.presence_penalty] for _, p in picked], torch.float32, self.device)
+            if any(p.frequency_penalty != 0.0 for _, p in picked):
+                plan.frequency = make_device_tensor([[p.frequency_penalty] for _, p in picked], torch.float32, self.device)
+            if any(p.repetition_penalty != 1.0 for _, p in picked):
+                plan.repetition = make_device_tensor([[p.repetition_penalty] for _, p in picked], torch.float32, self.device)
+
+        bias_rows: list[int] = []
+        bias_ids: list[int] = []
+        bias_vals: list[float] = []
+        for local, (_, p) in enumerate(picked):
+            for tid, val in (p.logit_bias or {}).items():
+                if 0 <= tid < self.vocab_size:
+                    bias_rows.append(local)
+                    bias_ids.append(int(tid))
+                    bias_vals.append(float(val))
+        if bias_ids:
+            plan.bias_rows = make_device_tensor(bias_rows, torch.int64, self.device)
+            plan.bias_ids = make_device_tensor(bias_ids, torch.int64, self.device)
+            plan.bias_vals = make_device_tensor(bias_vals, torch.float32, self.device)
+
+        min_rows: list[int] = []
+        min_ids: list[list[int]] = []
+        for local, (req, p) in enumerate(picked):
+            if p.min_tokens > 0 and p.min_tokens_stop_ids:
+                generated = len(req.input_ids) - (req.max_device_len - req.output_len)
+                if generated < p.min_tokens:
+                    min_rows.append(local)
+                    min_ids.append([t for t in p.min_tokens_stop_ids if 0 <= t < self.vocab_size])
+        if min_rows:
+            plan.min_rows = make_device_tensor(min_rows, torch.int64, self.device)
+            plan.min_ids = _padded_rows(min_ids, pad, self.device)
+
+        if any(p.min_p > 0.0 for _, p in picked):
+            plan.min_p = make_device_tensor([[p.min_p] for _, p in picked], torch.float32, self.device)
+        return plan
+
     def prepare(self, batch: Batch) -> BatchSamplingArgs:
         params = [r.sampling_params for r in batch.reqs]
+        plan = self._plan(batch, params)
         if all(p.is_greedy for p in params):
-            return BatchSamplingArgs(temperatures=None)
+            return BatchSamplingArgs(temperatures=None, plan=plan)
 
         MIN_P = MIN_T = 1e-6
         ts = [max(0.0 if p.is_greedy else p.temperature, MIN_T) for p in params]
@@ -70,11 +243,13 @@ class Sampler:
             top_k = make_device_tensor(top_ks, torch.int32, self.device)
         if any(p < 1.0 for p in top_ps):
             top_p = make_device_tensor(top_ps, torch.float32, self.device)
-        return BatchSamplingArgs(temperatures, top_k=top_k, top_p=top_p)
+        return BatchSamplingArgs(temperatures, top_k=top_k, top_p=top_p, plan=plan)
 
     @nvtx_annotate("Sampler")
     def sample(self, logits: torch.Tensor, args: BatchSamplingArgs) -> torch.Tensor:
         with torch.cuda.nvtx.range("Sampler"):
+            if args.plan is not None:
+                logits = apply_logits_processors(logits, args.plan, self.vocab_size)
             if args.temperatures is None:  # greedy sampling
                 return torch.argmax(logits, dim=-1)
             return sample_impl(logits.float(), args.temperatures, args.top_k, args.top_p)

--- a/python/freetoken/engine/sample.py
+++ b/python/freetoken/engine/sample.py
@@ -201,8 +201,8 @@ class Sampler:
         bias_ids: list[int] = []
         bias_vals: list[float] = []
         for local, (_, p) in enumerate(picked):
-            for tid, val in (p.logit_bias or {}).items():
-                if 0 <= tid < self.vocab_size:
+            for tid, val in p.logit_bias or ():
+                if 0 <= int(tid) < self.vocab_size:
                     bias_rows.append(local)
                     bias_ids.append(int(tid))
                     bias_vals.append(float(val))

--- a/python/freetoken/message/frontend.py
+++ b/python/freetoken/message/frontend.py
@@ -56,6 +56,9 @@ class UserReply(BaseFrontendMsg):
     finish_reason: str | None = None
     # The stop string that ended generation (Anthropic reports it as stop_reason='stop_sequence').
     matched_stop: str | None = None
+    # On the finished reply: tokens generated up to and including the reasoning end tag
+    # (0 when the model emitted none) -> usage.completion_tokens_details.reasoning_tokens.
+    reasoning_tokens: int = 0
 
 
 @dataclass

--- a/python/freetoken/message/tokenizer.py
+++ b/python/freetoken/message/tokenizer.py
@@ -36,6 +36,10 @@ class DetokenizeMsg(BaseTokenizerMsg):
     # The request's stop strings (None when it has none), so the detokenizer can hold back
     # a trailing partial-stop prefix instead of streaming it and then needing to retract.
     stop_strs: list[str] | None = None
+    # Keep the matched stop string in the output (SamplingParams.include_stop_str_in_output).
+    keep_stop_str: bool = False
+    # Decode this request with skip_special_tokens (SamplingParams.skip_special_tokens).
+    skip_special_tokens: bool = False
     # KV page-pool usage snapshot at this step (not-evictable used/total), passed
     # through to the frontend for the shell status bar. 0/0 for owned-KV models.
     kv_used_pages: int = 0

--- a/python/freetoken/scheduler/scheduler.py
+++ b/python/freetoken/scheduler/scheduler.py
@@ -342,7 +342,7 @@ class Scheduler(SchedulerIOMixin):
                 hit_length = not req.can_decode
                 hit_eos = (
                     not req.sampling_params.ignore_eos and next_token in self.eos_token_ids
-                )
+                ) or next_token in req.sampling_params.stop_token_ids
                 matched_stop = (
                     self._match_stop_str(req)
                     if not hit_eos and req.sampling_params.stop_strs
@@ -368,6 +368,8 @@ class Scheduler(SchedulerIOMixin):
                         finish_reason=finish_reason,
                         matched_stop=matched_stop,
                         stop_strs=req.sampling_params.stop_strs or None,
+                        keep_stop_str=req.sampling_params.include_stop_str_in_output,
+                        skip_special_tokens=req.sampling_params.skip_special_tokens,
                     )
                 )
 
@@ -520,6 +522,11 @@ class Scheduler(SchedulerIOMixin):
                 logger.warning_rank0(
                     f"Adjust max_tokens to {max_output_len} for request {msg.uid}."
                 )
+            sp = msg.sampling_params
+            if sp.min_tokens > 0:
+                # min_tokens: the sampler masks these ids while the output is shorter.
+                sp.min_tokens = min(sp.min_tokens, sp.max_tokens)
+                sp.min_tokens_stop_ids = sorted(set(self.eos_token_ids) | set(sp.stop_token_ids))
             self.prefill_manager.add_one_req(msg)
         elif isinstance(msg, AbortBackendMsg):
             logger.debug_rank0("Aborting request %d", msg.uid)

--- a/python/freetoken/server/api_models.py
+++ b/python/freetoken/server/api_models.py
@@ -90,11 +90,30 @@ class ChatCompletionRequest(BaseModel):
     function_call: Any | None = None
     logit_bias: dict[str, float] | None = None
     response_format: dict[str, Any] | None = None
+    # The last message is an assistant prefix the model continues (no generation prompt).
+    continue_final_message: bool = False
+    # ---- sampling extras shared with vLLM / SGLang / llama.cpp (all optional) ----
+    min_p: float | None = None
+    repetition_penalty: float | None = None
+    min_tokens: int = 0
+    stop_token_ids: list[int] | None = None
+    include_stop_str_in_output: bool = False
+    skip_special_tokens: bool | None = None
+    # Accepted for OpenAI compatibility, not honoured: the batched sampling kernel has no
+    # per-request generator (seed); user / metadata / store are opaque to the server.
+    seed: int | None = None
+    user: str | None = None
+    # A client-chosen id echoed as the response id (vLLM request_id / SGLang rid).
+    request_id: str | None = None
 
     @model_validator(mode="after")
     def _sync_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
             self.max_tokens = self.max_completion_tokens
+        if self.continue_final_message and (
+            not self.messages or self.messages[-1].role != "assistant"
+        ):
+            raise ValueError("continue_final_message needs a final assistant message")
         return self
 
 
@@ -120,12 +139,51 @@ class CompletionRequest(BaseModel):
     suffix: str | None = None
     logit_bias: dict[str, float] | None = None
     response_format: dict[str, Any] | None = None
+    # ---- sampling extras shared with vLLM / SGLang / llama.cpp (all optional) ----
+    min_p: float | None = None
+    repetition_penalty: float | None = None
+    min_tokens: int = 0
+    stop_token_ids: list[int] | None = None
+    include_stop_str_in_output: bool = False
+    skip_special_tokens: bool | None = None
+    # Accepted for OpenAI compatibility, not honoured: the batched sampling kernel has no
+    # per-request generator (seed); user / metadata / store are opaque to the server.
+    seed: int | None = None
+    user: str | None = None
+    # A client-chosen id echoed as the response id (vLLM request_id / SGLang rid).
+    request_id: str | None = None
 
     @model_validator(mode="after")
     def _sync_max_completion_tokens(self) -> "CompletionRequest":
         if self.max_completion_tokens is not None:
             self.max_tokens = self.max_completion_tokens
         return self
+
+
+MAX_N = 16  # choices per request; each is a full generation, so keep the fan-out bounded
+
+
+class TokenizeRequest(BaseModel):
+    """``POST /tokenize`` (the vLLM / SGLang shape): a raw prompt, or chat messages that
+    are rendered through the model's chat template first."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str | None = None
+    prompt: str | None = None
+    messages: list[Message] | None = None
+    add_special_tokens: bool = True
+    add_generation_prompt: bool = True
+    return_token_strs: bool = False
+    chat_template_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class DetokenizeRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    model: str | None = None
+    tokens: list[int]
+    skip_special_tokens: bool = False
 
 
 class ModelCard(BaseModel):

--- a/python/freetoken/server/api_server.py
+++ b/python/freetoken/server/api_server.py
@@ -355,16 +355,20 @@ class FrontendManager:
         yield b"data: [DONE]\n\n"
         logger.debug("Finished streaming response for user %s", uid)
 
-    async def stream_with_cancellation(self, generator, request: Request, uid: int):
+    async def stream_with_cancellation(self, generator, request: Request, uid):
+        """``uid`` is one request id or a sequence of them (an ``n > 1`` fan-out streams
+        several generations into one response): a disconnect aborts every one."""
+        uids = list(uid) if isinstance(uid, (list, tuple)) else [uid]
         try:
             async for chunk in generator:
                 # detect if the client has disconnected
                 if await request.is_disconnected():
-                    logger.info("Client disconnected for user %s", uid)
+                    logger.info("Client disconnected for user %s", uids)
                     raise asyncio.CancelledError
                 yield chunk
         except asyncio.CancelledError:
-            asyncio.create_task(self.abort_user(uid))
+            for one in uids:
+                asyncio.create_task(self.abort_user(one))
             raise
 
     async def abort_user(self, uid: int):

--- a/python/freetoken/server/control_api.py
+++ b/python/freetoken/server/control_api.py
@@ -68,6 +68,24 @@ def register_control_routes(
 
     from .stats import build_stats
 
+    @app.get("/metrics")
+    async def metrics():
+        """Prometheus text exposition of /v1/stats (the llama.cpp / vLLM convention)."""
+        from fastapi.responses import PlainTextResponse
+
+        from .stats import prometheus_text
+
+        doc = build_stats(
+            get_state(), request_ring.requests_p95_ms(), request_ring.requests_ttft_mean_ms()
+        )
+        return PlainTextResponse(prometheus_text(doc), media_type="text/plain; version=0.0.4")
+
+    @app.get("/version")
+    async def version():
+        from freetoken import __version__
+
+        return {"version": __version__}
+
     @app.get("/v1/stats")
     async def stats():
         doc = build_stats(

--- a/python/freetoken/server/generation.py
+++ b/python/freetoken/server/generation.py
@@ -200,9 +200,9 @@ def resolve_sampling(
         raise ValueError(f"repetition_penalty must be positive, got {resolved_rep}")
     if min_tokens < 0:
         raise ValueError(f"min_tokens must be >= 0, got {min_tokens}")
-    bias: dict[int, float] | None = None
+    bias: list[list[float]] | None = None
     if logit_bias:
-        bias = {}
+        bias = []
         for key, value in logit_bias.items():
             try:
                 tid = int(key)
@@ -210,7 +210,7 @@ def resolve_sampling(
                 raise ValueError(f"logit_bias keys must be token ids, got {key!r}") from None
             if tid < 0:
                 raise ValueError(f"logit_bias token id must be >= 0, got {tid}")
-            bias[tid] = max(-100.0, min(100.0, float(value)))  # the OpenAI range
+            bias.append([tid, max(-100.0, min(100.0, float(value)))])  # the OpenAI range
     ids = [int(t) for t in (stop_token_ids or [])]
     if any(t < 0 for t in ids):
         raise ValueError("stop_token_ids must be non-negative token ids")

--- a/python/freetoken/server/generation.py
+++ b/python/freetoken/server/generation.py
@@ -111,6 +111,7 @@ class GenDone:
     completion_tokens: int
     matched_stop: str | None = None
     cached_tokens: int = 0
+    reasoning_tokens: int = 0
 
 
 GenEvent = ReasoningDelta | ContentDelta | ToolCallStart | ToolCallArgsDelta | ToolCallsDelta | GenDone
@@ -126,6 +127,7 @@ class GenResult:
     completion_tokens: int
     matched_stop: str | None = None
     cached_tokens: int = 0
+    reasoning_tokens: int = 0
 
 
 @dataclass
@@ -163,9 +165,19 @@ def resolve_sampling(
     ignore_eos: bool,
     model_sampling: dict[str, Any],
     stop: str | list[str] | None = None,
+    min_p: float | None = None,
+    presence_penalty: float = 0.0,
+    frequency_penalty: float = 0.0,
+    repetition_penalty: float | None = None,
+    logit_bias: dict[str, float] | dict[int, float] | None = None,
+    min_tokens: int = 0,
+    stop_token_ids: list[int] | None = None,
+    include_stop_str_in_output: bool = False,
+    skip_special_tokens: bool | None = None,
 ) -> SamplingParams:
     """Map a protocol's sampling fields onto the engine's neutral SamplingParams,
-    filling unspecified fields from the checkpoint's recommended defaults."""
+    filling unspecified fields from the checkpoint's recommended defaults. Range errors
+    raise ValueError (the adapters answer 400)."""
 
     def pick(value, key, framework):
         return value if value is not None else model_sampling.get(key, framework)
@@ -177,14 +189,50 @@ def resolve_sampling(
     # non-positive value is a client error.
     if max_tokens is not None and max_tokens < 1:
         raise ValueError(f"max_tokens must be at least 1, got {max_tokens}")
-    return SamplingParams(
+    resolved_min_p = float(pick(min_p, "min_p", 0.0))
+    resolved_rep = float(pick(repetition_penalty, "repetition_penalty", 1.0))
+    if not 0.0 <= resolved_min_p <= 1.0:
+        raise ValueError(f"min_p must be in [0, 1], got {resolved_min_p}")
+    for name, value in (("presence_penalty", presence_penalty), ("frequency_penalty", frequency_penalty)):
+        if not -2.0 <= float(value) <= 2.0:
+            raise ValueError(f"{name} must be in [-2, 2], got {value}")
+    if resolved_rep <= 0.0:
+        raise ValueError(f"repetition_penalty must be positive, got {resolved_rep}")
+    if min_tokens < 0:
+        raise ValueError(f"min_tokens must be >= 0, got {min_tokens}")
+    bias: dict[int, float] | None = None
+    if logit_bias:
+        bias = {}
+        for key, value in logit_bias.items():
+            try:
+                tid = int(key)
+            except (TypeError, ValueError):
+                raise ValueError(f"logit_bias keys must be token ids, got {key!r}") from None
+            if tid < 0:
+                raise ValueError(f"logit_bias token id must be >= 0, got {tid}")
+            bias[tid] = max(-100.0, min(100.0, float(value)))  # the OpenAI range
+    ids = [int(t) for t in (stop_token_ids or [])]
+    if any(t < 0 for t in ids):
+        raise ValueError("stop_token_ids must be non-negative token ids")
+    params = SamplingParams(
         ignore_eos=ignore_eos,
         max_tokens=DEFAULT_MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens,
         temperature=pick(temperature, "temperature", 0.0),
         top_k=pick(top_k, "top_k", -1),
         top_p=pick(top_p, "top_p", 1.0),
         stop_strs=[s for s in stop_list if s],  # drop empty strings (would match everything)
+        min_p=resolved_min_p,
+        presence_penalty=float(presence_penalty),
+        frequency_penalty=float(frequency_penalty),
+        repetition_penalty=resolved_rep,
+        logit_bias=bias,
+        min_tokens=int(min_tokens),
+        stop_token_ids=ids,
+        include_stop_str_in_output=bool(include_stop_str_in_output),
     )
+    if skip_special_tokens is not None:
+        params.skip_special_tokens = bool(skip_special_tokens)
+    return params
 
 
 def render_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -558,6 +606,7 @@ async def _generate_events_impl(uid: int, spec: GenSpec, state: Any) -> AsyncIte
     prompt_tokens = 0
     completion_tokens = 0
     cached_tokens = 0
+    reasoning_tokens = 0
     pending = ""
     parse_tools = spec.parse_tools
     reasoning_parser = _make_reasoning_parser(spec, state)
@@ -653,6 +702,7 @@ async def _generate_events_impl(uid: int, spec: GenSpec, state: Any) -> AsyncIte
         prompt_tokens += ack.prompt_tokens_delta
         completion_tokens += ack.completion_tokens_delta
         cached_tokens += ack.cached_tokens
+        reasoning_tokens = max(reasoning_tokens, getattr(ack, "reasoning_tokens", 0))
         content_delta = ack.incremental_output
         if reasoning_parser is not None and content_delta:
             reasoning_delta, content_delta = reasoning_parser.parse_stream_chunk(content_delta)
@@ -735,6 +785,7 @@ async def _generate_events_impl(uid: int, spec: GenSpec, state: Any) -> AsyncIte
     yield GenDone(
         finish_reason, prompt_tokens, completion_tokens,
         matched_stop=engine_matched_stop, cached_tokens=cached_tokens,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -745,6 +796,7 @@ async def _generate_full_impl(uid: int, spec: GenSpec, state: Any) -> GenResult:
     prompt_tokens = 0
     completion_tokens = 0
     cached_tokens = 0
+    reasoning_tokens = 0
     engine_finish_reason: str | None = None
     engine_matched_stop: str | None = None
     async for ack in state.wait_for_ack(uid):
@@ -753,6 +805,7 @@ async def _generate_full_impl(uid: int, spec: GenSpec, state: Any) -> GenResult:
         prompt_tokens += ack.prompt_tokens_delta
         completion_tokens += ack.completion_tokens_delta
         cached_tokens += ack.cached_tokens
+        reasoning_tokens = max(reasoning_tokens, getattr(ack, "reasoning_tokens", 0))
         full_content += ack.incremental_output
         if ack.finished:
             engine_finish_reason = getattr(ack, "finish_reason", None)
@@ -779,4 +832,5 @@ async def _generate_full_impl(uid: int, spec: GenSpec, state: Any) -> GenResult:
         completion_tokens=completion_tokens,
         matched_stop=engine_matched_stop,
         cached_tokens=cached_tokens,
+        reasoning_tokens=reasoning_tokens,
     )

--- a/python/freetoken/server/openai_api.py
+++ b/python/freetoken/server/openai_api.py
@@ -14,6 +14,9 @@ from freetoken.message import TokenizeMsg
 from freetoken.tokenizer.effort import EFFORT_SCALE, KNOWN_REASONING_EFFORTS
 
 from .api_models import (
+    MAX_N,
+    DetokenizeRequest,
+    TokenizeRequest,
     ChatCompletionRequest,
     CompletionRequest,
     ModelCard,
@@ -66,17 +69,11 @@ def chat_request_to_genspec(
     thinking_type = _thinking_type(req)
     if req.reasoning_effort or thinking_type:
         ctk = effort_toggle_kwargs(req.reasoning_effort, ctk, thinking_type=thinking_type)
+    if req.continue_final_message:
+        ctk = {**ctk, "continue_final_message": True}
     return GenSpec(
         messages=render_messages([m.model_dump(exclude_none=True) for m in req.messages]),
-        sampling_params=resolve_sampling(
-            temperature=req.temperature,
-            top_k=req.top_k,
-            top_p=req.top_p,
-            max_tokens=req.max_tokens,
-            ignore_eos=req.ignore_eos,
-            model_sampling=model_sampling,
-            stop=req.stop,
-        ),
+        sampling_params=_resolve_sampling(req, model_sampling),
         chat_template_kwargs=ctk,
         template_tools=_tools_for_template(req),
         parser_tools=(_all_tool_dicts(req.tools) if _should_parse_tools(req) else None),
@@ -128,6 +125,16 @@ def register_openai_routes(
             return gate
         return await handle_completion(req, request, state, get_model_sampling())
 
+    @app.post("/tokenize")
+    @app.post("/v1/tokenize")
+    async def tokenize(req: TokenizeRequest):
+        return await handle_tokenize(req, get_state())
+
+    @app.post("/detokenize")
+    @app.post("/v1/detokenize")
+    async def detokenize(req: DetokenizeRequest):
+        return await handle_detokenize(req, get_state())
+
     @app.get("/v1/models")
     async def v1_models():
         state = get_state()
@@ -152,15 +159,13 @@ async def handle_chat_completion(
 ):
     if req.function_call is not None:
         return create_error_response("function_call is not supported; use tools/tool_choice instead")
-    if req.logit_bias is not None:
-        return create_error_response("logit_bias is not supported")
     if _response_format_unsupported(req.response_format):
         return create_error_response(
             "response_format json_object/json_schema is not supported (no constrained decoding)",
             param="response_format",
         )
-    if req.n != 1:
-        return create_error_response("Only n=1 is supported", param="n")
+    if not 1 <= req.n <= MAX_N:
+        return create_error_response(f"n must be between 1 and {MAX_N}", param="n")
     # Case/whitespace and the "off" disable synonym stay accepted here because
     # effort_toggle_kwargs normalizes and honors them downstream.
     effort = req.reasoning_effort.strip().lower() if isinstance(req.reasoning_effort, str) else None
@@ -190,40 +195,58 @@ async def handle_chat_completion(
         if err is not None:
             return create_error_response(str(err), code=err.code)
 
-    uid = await submit_generation(spec, state)
+    # n > 1: one generation per choice, submitted together (the prefix cache serves the
+    # shared prompt after the first prefill).
+    uids = [await submit_generation(spec, state) for _ in range(req.n)]
+    uid = uids[0]
 
     if req.stream:
-        chunks = stream_chat_completion_chunks(uid, req, state, spec)
+        if req.n == 1:
+            chunks = stream_chat_completion_chunks(uid, req, state, spec)
+        else:
+            chunks = _merge_streams(
+                [
+                    stream_chat_completion_chunks(u, req, state, spec, index=i, terminal=False)
+                    for i, u in enumerate(uids)
+                ],
+                lambda: _chat_chunk(req, uid, []),
+                include_usage=bool(req.stream_options and req.stream_options.include_usage),
+                state=state,
+            )
         if request is not None:
-            chunks = state.stream_with_cancellation(chunks, request, uid)
+            chunks = state.stream_with_cancellation(chunks, request, uids)
         return StreamingResponse(chunks, media_type="text/event-stream")
 
     try:
-        result = await generate_full(uid, spec, state, source="/v1/chat/completions")
+        results = await asyncio.gather(
+            *(generate_full(u, spec, state, source="/v1/chat/completions") for u in uids)
+        )
     except GenerationError as exc:
+        for u in uids:
+            await state.abort_user(u)
         return create_error_response(str(exc), code=exc.code)
-    message: dict[str, Any] = {"role": "assistant", "content": result.content}
-    if result.reasoning:
-        message["reasoning_content"] = result.reasoning
-    if result.tool_calls:
-        message["tool_calls"] = _tool_calls_to_openai(result.tool_calls)
+    choices: list[dict[str, Any]] = []
+    for index, result in enumerate(results):
+        message: dict[str, Any] = {"role": "assistant", "content": result.content}
+        if result.reasoning:
+            message["reasoning_content"] = result.reasoning
+        if result.tool_calls:
+            message["tool_calls"] = _tool_calls_to_openai(result.tool_calls)
+        choices.append({"index": index, "message": message, "finish_reason": result.finish_reason})
 
+    first = results[0]
     return {
-        "id": f"chatcmpl-{uid}",
+        "id": _response_id("chatcmpl", req, uid),
         "object": "chat.completion",
         "created": int(time.time()),
         "model": req.model,
-        "choices": [
-            {
-                "index": 0,
-                "message": message,
-                "finish_reason": result.finish_reason,
-            }
-        ],
+        "system_fingerprint": None,
+        "choices": choices,
         "usage": _usage(
-            result.prompt_tokens,
-            result.completion_tokens,
-            _reported_cached(state, result.cached_tokens),
+            first.prompt_tokens,
+            sum(r.completion_tokens for r in results),
+            _reported_cached(state, max(r.cached_tokens for r in results)),
+            reasoning_tokens=sum(r.reasoning_tokens for r in results),
         ),
     }
 
@@ -233,21 +256,28 @@ async def stream_chat_completion_chunks(
     req: ChatCompletionRequest,
     state: Any,
     spec: GenSpec | None = None,
+    index: int = 0,
+    terminal: bool = True,
 ) -> AsyncIterator[bytes]:
-    """Format generate_events() into the OpenAI chat.completion.chunk SSE stream."""
+    """Format generate_events() into the OpenAI chat.completion.chunk SSE stream.
+
+    ``index`` is the choice index (``n > 1`` runs one of these per choice); with
+    ``terminal=False`` the usage chunk and ``[DONE]`` are left to the merger, which reads
+    this stream's usage from the ``_StreamUsage`` yielded last."""
     if spec is None:
         spec = chat_request_to_genspec(req, {})
     yield _sse(
         _chat_chunk(
             req,
             uid,
-            [{"delta": {"role": "assistant", "content": ""}, "index": 0, "finish_reason": None}],
+            [{"delta": {"role": "assistant", "content": ""}, "index": index, "finish_reason": None}],
         )
     )
 
     prompt_tokens = 0
     completion_tokens = 0
     cached_tokens = 0
+    reasoning_tokens = 0
     tool_calls_sent = 0
     open_tool: dict[str, Any] | None = None
     events = generate_events(uid, spec, state, source="/v1/chat/completions")
@@ -268,7 +298,7 @@ async def stream_chat_completion_chunks(
                 _chat_chunk(
                     req,
                     uid,
-                    [{"delta": {"reasoning_content": ev.text}, "index": 0, "finish_reason": None}],
+                    [{"delta": {"reasoning_content": ev.text}, "index": index, "finish_reason": None}],
                 )
             )
         elif isinstance(ev, ContentDelta):
@@ -276,7 +306,7 @@ async def stream_chat_completion_chunks(
                 _chat_chunk(
                     req,
                     uid,
-                    [{"delta": {"content": ev.text}, "index": 0, "finish_reason": None}],
+                    [{"delta": {"content": ev.text}, "index": index, "finish_reason": None}],
                 )
             )
         elif isinstance(ev, ToolCallStart):
@@ -296,7 +326,7 @@ async def stream_chat_completion_chunks(
                             "type": "function",
                             "function": {"name": ev.name, "arguments": ""},
                         }]},
-                        "index": 0, "finish_reason": None,
+                        "index": index, "finish_reason": None,
                     }],
                 )
             )
@@ -313,7 +343,7 @@ async def stream_chat_completion_chunks(
                                 "index": open_tool["index"],
                                 "function": {"arguments": ev.fragment},
                             }]},
-                            "index": 0, "finish_reason": None,
+                            "index": index, "finish_reason": None,
                         }],
                     )
                 )
@@ -337,7 +367,7 @@ async def stream_chat_completion_chunks(
                                         "index": open_tool["index"],
                                         "function": {"arguments": remainder},
                                     }]},
-                                    "index": 0, "finish_reason": None,
+                                    "index": index, "finish_reason": None,
                                 }],
                             )
                         )
@@ -349,7 +379,7 @@ async def stream_chat_completion_chunks(
                     yield _sse(
                         _chat_chunk(
                             req, uid,
-                            [{"delta": {"tool_calls": [delta]}, "index": 0, "finish_reason": None}],
+                            [{"delta": {"tool_calls": [delta]}, "index": index, "finish_reason": None}],
                         )
                     )
                 tool_calls_sent += 1
@@ -357,21 +387,18 @@ async def stream_chat_completion_chunks(
             prompt_tokens = ev.prompt_tokens
             completion_tokens = ev.completion_tokens
             cached_tokens = ev.cached_tokens
-            yield _sse(_chat_chunk(req, uid, [{"delta": {}, "index": 0, "finish_reason": ev.finish_reason}]))
+            reasoning_tokens = ev.reasoning_tokens
+            yield _sse(_chat_chunk(req, uid, [{"delta": {}, "index": index, "finish_reason": ev.finish_reason}]))
 
+    usage = _usage(
+        prompt_tokens, completion_tokens, _reported_cached(state, cached_tokens),
+        reasoning_tokens=reasoning_tokens,
+    )
+    if not terminal:
+        yield _StreamUsage(usage)
+        return
     if req.stream_options and req.stream_options.include_usage:
-        yield _sse(
-            {
-                "id": f"chatcmpl-{uid}",
-                "object": "chat.completion.chunk",
-                "created": int(time.time()),
-                "model": req.model,
-                "choices": [],
-                "usage": _usage(
-                    prompt_tokens, completion_tokens, _reported_cached(state, cached_tokens)
-                ),
-            }
-        )
+        yield _sse({**_chat_chunk(req, uid, []), "usage": usage})
 
     yield b"data: [DONE]\n\n"
 
@@ -385,34 +412,60 @@ async def handle_completion(
     unsupported = _completion_unsupported_reason(req)
     if unsupported is not None:
         return create_error_response(unsupported)
-    try:  # surfaces an out-of-range max_tokens as a 400 rather than a 500 from the worker
-        _resolve_sampling(req, model_sampling)
+    if not 1 <= req.n <= MAX_N:
+        return create_error_response(f"n must be between 1 and {MAX_N}", param="n")
+    try:  # surfaces an out-of-range value as a 400 rather than a 500 from the worker
+        sampling = _resolve_sampling(req, model_sampling)
     except ValueError as exc:
-        return create_error_response(str(exc), param="max_tokens")
+        return create_error_response(str(exc))
 
     prompts = [req.prompt] if isinstance(req.prompt, str) else req.prompt
     assert isinstance(prompts, list)
+    if req.suffix is not None:
+        markers = await _fim_markers(state)
+        if markers is None:
+            return create_error_response(
+                "suffix needs a model with fill-in-the-middle tokens "
+                "(<|fim_prefix|> / <|fim_suffix|> / <|fim_middle|>)",
+                param="suffix",
+            )
+        prompts = [_fim_prompt(p, req.suffix, markers) for p in prompts]
+    echo_texts = list(prompts) if req.echo else [""] * len(prompts)
+    if req.suffix is not None and req.echo:
+        # echo returns what the client sent, not the FIM-wrapped prompt
+        echo_texts = [req.prompt] if isinstance(req.prompt, str) else list(req.prompt)
+
+    # choices are ordered prompt-major: prompt i, sample k -> index i * n + k (OpenAI)
+    uids: list[int] = []
+    for prompt in prompts:
+        for _ in range(req.n):
+            uid = state.new_user()
+            await state.send_one(TokenizeMsg(uid=uid, text=prompt, sampling_params=sampling))
+            uids.append(uid)
+
     if req.stream:
-        if len(prompts) != 1:
-            return create_error_response("Streaming completions only support a single text prompt")
-        uid = state.new_user()
-        await state.send_one(
-            TokenizeMsg(uid=uid, text=prompts[0], sampling_params=_resolve_sampling(req, model_sampling))
-        )
-        chunks = stream_completion_chunks(uid, req, state)
+        if len(uids) == 1:
+            chunks = stream_completion_chunks(uids[0], req, state, echo_text=echo_texts[0])
+        else:
+            chunks = _merge_streams(
+                [
+                    stream_completion_chunks(
+                        u, req, state, index=i, terminal=False, echo_text=echo_texts[i // req.n]
+                    )
+                    for i, u in enumerate(uids)
+                ],
+                lambda: _completion_chunk(req, uids[0], []),
+                include_usage=bool(req.stream_options and req.stream_options.include_usage),
+                state=state,
+            )
         if request is not None:
-            chunks = state.stream_with_cancellation(chunks, request, uid)
+            chunks = state.stream_with_cancellation(chunks, request, uids)
         return StreamingResponse(chunks, media_type="text/event-stream")
 
-    choices: list[dict[str, Any]] = []
-    prompt_tokens = 0
-    completion_tokens = 0
-    cached_tokens = 0
-    for index, prompt in enumerate(prompts):
-        uid = state.new_user()
-        await state.send_one(TokenizeMsg(uid=uid, text=prompt, sampling_params=_resolve_sampling(req, model_sampling)))
+    async def _drain_one(uid: int, index: int) -> dict[str, Any] | JSONResponse:
         text = ""
         finish_reason = "stop"
+        prompt_tokens = completion_tokens = cached_tokens = 0
         async for ack in state.wait_for_ack(uid):
             if getattr(ack, "error", None):
                 return create_error_response(ack.error)
@@ -423,75 +476,223 @@ async def handle_completion(
             if ack.finished:
                 finish_reason = getattr(ack, "finish_reason", None) or "stop"
                 break
-        choices.append({"index": index, "text": text, "finish_reason": finish_reason, "logprobs": None})
+        return {
+            "index": index,
+            "text": echo_texts[index // req.n] + text,
+            "finish_reason": finish_reason,
+            "logprobs": None,
+            "_usage": (prompt_tokens, completion_tokens, cached_tokens),
+        }
+
+    drained = await asyncio.gather(*(_drain_one(u, i) for i, u in enumerate(uids)))
+    choices: list[dict[str, Any]] = []
+    prompt_tokens = completion_tokens = cached_tokens = 0
+    for choice in drained:
+        if isinstance(choice, JSONResponse):
+            return choice
+        p, c, cached = choice.pop("_usage")
+        # the prompt is counted once per prompt, not once per sample of it
+        if choice["index"] % req.n == 0:
+            prompt_tokens += p
+        completion_tokens += c
+        cached_tokens = max(cached_tokens, cached)
+        choices.append(choice)
 
     return {
-        "id": f"cmpl-{uuid.uuid4().hex}",
+        "id": _response_id("cmpl", req, uuid.uuid4().hex),
         "object": "text_completion",
         "created": int(time.time()),
         "model": req.model,
+        "system_fingerprint": None,
         "choices": choices,
         "usage": _usage(prompt_tokens, completion_tokens, _reported_cached(state, cached_tokens)),
     }
 
 
-async def stream_completion_chunks(uid: int, req: CompletionRequest, state: Any) -> AsyncIterator[bytes]:
+def _completion_chunk(req: CompletionRequest, uid: Any, choices: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "id": _response_id("cmpl", req, uid),
+        "object": "text_completion.chunk",
+        "created": int(time.time()),
+        "model": req.model,
+        "choices": choices,
+    }
+
+
+async def stream_completion_chunks(
+    uid: int,
+    req: CompletionRequest,
+    state: Any,
+    index: int = 0,
+    terminal: bool = True,
+    echo_text: str = "",
+) -> AsyncIterator[bytes]:
     prompt_tokens = 0
     completion_tokens = 0
     cached_tokens = 0
     finish_reason = "stop"
+    if echo_text:
+        # echo: the prompt leads the stream (vLLM sends it in the first chunk)
+        yield _sse(_completion_chunk(req, uid, [{"text": echo_text, "index": index, "finish_reason": None, "logprobs": None}]))
     async for ack in state.wait_for_ack(uid):
         if getattr(ack, "error", None):
             yield _sse({"error": {"message": ack.error, "type": "invalid_request_error", "code": None}})
-            yield b"data: [DONE]\n\n"
+            if terminal:
+                yield b"data: [DONE]\n\n"
             return
         prompt_tokens += ack.prompt_tokens_delta
         completion_tokens += ack.completion_tokens_delta
         cached_tokens += ack.cached_tokens
         if ack.incremental_output:
             yield _sse(
-                {
-                    "id": f"cmpl-{uid}",
-                    "object": "text_completion.chunk",
-                    "created": int(time.time()),
-                    "model": req.model,
-                    "choices": [
-                        {
-                            "text": ack.incremental_output,
-                            "index": 0,
-                            "finish_reason": None,
-                            "logprobs": None,
-                        }
-                    ],
-                }
+                _completion_chunk(
+                    req, uid,
+                    [{"text": ack.incremental_output, "index": index, "finish_reason": None, "logprobs": None}],
+                )
             )
         if ack.finished:
             finish_reason = getattr(ack, "finish_reason", None) or "stop"
             break
 
-    yield _sse(
-        {
-            "id": f"cmpl-{uid}",
-            "object": "text_completion.chunk",
-            "created": int(time.time()),
-            "model": req.model,
-            "choices": [{"text": "", "index": 0, "finish_reason": finish_reason, "logprobs": None}],
-        }
-    )
+    yield _sse(_completion_chunk(req, uid, [{"text": "", "index": index, "finish_reason": finish_reason, "logprobs": None}]))
+    usage = _usage(prompt_tokens, completion_tokens, _reported_cached(state, cached_tokens))
+    if not terminal:
+        yield _StreamUsage(usage)
+        return
     if req.stream_options and req.stream_options.include_usage:
-        yield _sse(
-            {
-                "id": f"cmpl-{uid}",
-                "object": "text_completion.chunk",
-                "created": int(time.time()),
-                "model": req.model,
-                "choices": [],
-                "usage": _usage(
-                    prompt_tokens, completion_tokens, _reported_cached(state, cached_tokens)
-                ),
-            }
-        )
+        yield _sse({**_completion_chunk(req, uid, []), "usage": usage})
     yield b"data: [DONE]\n\n"
+
+
+class _StreamUsage:
+    """Yielded last by a non-terminal sub-stream: its usage dict for the merger."""
+
+    __slots__ = ("usage",)
+
+    def __init__(self, usage: dict[str, Any]) -> None:
+        self.usage = usage
+
+
+async def _merge_streams(
+    streams: list[AsyncIterator[Any]],
+    envelope: Callable[[], dict[str, Any]],
+    *,
+    include_usage: bool,
+    state: Any,
+) -> AsyncIterator[bytes]:
+    """Interleave the SSE chunks of several choice streams into one response (``n > 1``),
+    then one usage chunk (prompt counted once, completions summed) and one ``[DONE]``."""
+    queue: asyncio.Queue[tuple[int, Any]] = asyncio.Queue()
+    usages: dict[int, dict[str, Any]] = {}
+
+    async def pump(slot: int, stream: AsyncIterator[Any]) -> None:
+        try:
+            async for item in stream:
+                if isinstance(item, _StreamUsage):
+                    usages[slot] = item.usage
+                else:
+                    await queue.put((slot, item))
+        finally:
+            await queue.put((slot, None))
+
+    tasks = [asyncio.create_task(pump(i, st)) for i, st in enumerate(streams)]
+    try:
+        open_slots = len(streams)
+        while open_slots:
+            slot, item = await queue.get()
+            if item is None:
+                open_slots -= 1
+                continue
+            yield item
+    finally:
+        for task in tasks:
+            task.cancel()
+    if include_usage and usages:
+        first = usages[min(usages)]
+        merged = _usage(
+            first["prompt_tokens"],
+            sum(u["completion_tokens"] for u in usages.values()),
+            max(u.get("prompt_tokens_details", {}).get("cached_tokens", 0) for u in usages.values()),
+            reasoning_tokens=sum(
+                u.get("completion_tokens_details", {}).get("reasoning_tokens", 0) for u in usages.values()
+            ),
+        )
+        yield _sse({**envelope(), "usage": merged})
+    yield b"data: [DONE]\n\n"
+
+
+_FIM_TOKENS = ("<|fim_prefix|>", "<|fim_suffix|>", "<|fim_middle|>")
+
+
+async def _fim_markers(state: Any) -> tuple[str, str, str] | None:
+    """The model's fill-in-the-middle marker strings when its vocabulary has them
+    (Qwen / DeepSeek-Coder style), else None."""
+    build = getattr(state, "frontend_tokenizer", None)
+    if build is None:
+        return None
+    try:
+        manager = await asyncio.to_thread(build)
+        tok = manager.tokenizer
+        unk = getattr(tok, "unk_token_id", None)
+        for name in _FIM_TOKENS:
+            tid = tok.convert_tokens_to_ids(name)
+            if not isinstance(tid, int) or tid < 0 or tid == unk:
+                return None
+    except Exception:  # noqa: BLE001 -- no tokenizer here means no FIM
+        return None
+    return _FIM_TOKENS
+
+
+def _fim_prompt(prompt: str, suffix: str, markers: tuple[str, str, str]) -> str:
+    """The prefix-suffix-middle prompt of OpenAI's ``suffix`` (llama.cpp's /infill)."""
+    prefix_tok, suffix_tok, middle_tok = markers
+    return f"{prefix_tok}{prompt}{suffix_tok}{suffix}{middle_tok}"
+
+
+async def handle_tokenize(req: TokenizeRequest, state: Any):
+    """``POST /tokenize``: the vLLM / SGLang shape. A raw ``prompt`` is encoded as is; chat
+    ``messages`` are rendered through the model's chat template first (the exact prompt a
+    generation would tokenize)."""
+    if (req.prompt is None) == (req.messages is None):
+        return create_error_response("pass exactly one of prompt or messages")
+    build = getattr(state, "frontend_tokenizer", None)
+    if build is None:
+        return create_error_response("no tokenizer on this server", status_code=503, err_type="api_error")
+    try:
+        manager = await asyncio.to_thread(build)
+        if req.prompt is not None:
+            ids = await asyncio.to_thread(
+                manager.tokenizer.encode, req.prompt, add_special_tokens=req.add_special_tokens
+            )
+        else:
+            messages = render_messages([m.model_dump(exclude_none=True) for m in req.messages])
+            ctk = dict(req.chat_template_kwargs)
+            if not req.add_generation_prompt:
+                ctk["continue_final_message"] = True
+            msg = TokenizeMsg(uid=-1, text=messages, sampling_params=SamplingParams(), chat_template_kwargs=ctk)
+            text = await asyncio.to_thread(manager.render_prompt, msg)
+            ids = await asyncio.to_thread(manager.tokenizer.encode, text, add_special_tokens=False)
+    except ValueError as exc:
+        return create_error_response(str(exc))
+    body: dict[str, Any] = {
+        "count": len(ids),
+        "max_model_len": _model_context_length(state),
+        "tokens": [int(t) for t in ids],
+    }
+    if req.return_token_strs:
+        body["token_strs"] = manager.tokenizer.convert_ids_to_tokens(ids)
+    return body
+
+
+async def handle_detokenize(req: DetokenizeRequest, state: Any):
+    build = getattr(state, "frontend_tokenizer", None)
+    if build is None:
+        return create_error_response("no tokenizer on this server", status_code=503, err_type="api_error")
+    manager = await asyncio.to_thread(build)
+    text = await asyncio.to_thread(
+        manager.tokenizer.decode, req.tokens, skip_special_tokens=req.skip_special_tokens
+    )
+    return {"prompt": text}
 
 
 def create_error_response(
@@ -526,7 +727,23 @@ def _resolve_sampling(
         ignore_eos=req.ignore_eos,
         model_sampling=model_sampling,
         stop=req.stop,
+        min_p=req.min_p,
+        presence_penalty=req.presence_penalty,
+        frequency_penalty=req.frequency_penalty,
+        repetition_penalty=req.repetition_penalty,
+        logit_bias=req.logit_bias,
+        min_tokens=req.min_tokens,
+        stop_token_ids=req.stop_token_ids,
+        include_stop_str_in_output=req.include_stop_str_in_output,
+        skip_special_tokens=req.skip_special_tokens,
     )
+
+
+def _response_id(prefix: str, req: Any, fallback: Any) -> str:
+    """``request_id`` from the client when given (vLLM request_id / SGLang rid), else the
+    server's own id."""
+    rid = getattr(req, "request_id", None)
+    return f"{prefix}-{rid}" if rid else f"{prefix}-{fallback}"
 
 
 def _tools_for_template(req: ChatCompletionRequest) -> list[dict[str, Any]] | None:
@@ -589,10 +806,11 @@ def _tool_call_id(name: str | None, index: int) -> str:
 
 def _chat_chunk(req: ChatCompletionRequest, uid: int, choices: list[dict[str, Any]]) -> dict[str, Any]:
     return {
-        "id": f"chatcmpl-{uid}",
+        "id": _response_id("chatcmpl", req, uid),
         "object": "chat.completion.chunk",
         "created": int(time.time()),
         "model": req.model,
+        "system_fingerprint": None,
         "choices": choices,
     }
 
@@ -606,7 +824,9 @@ def _reported_cached(state: Any, cached_tokens: int) -> int:
     return cached_tokens if getattr(state.config, "enable_cache_report", False) else 0
 
 
-def _usage(prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0) -> dict[str, Any]:
+def _usage(
+    prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0, reasoning_tokens: int = 0
+) -> dict[str, Any]:
     usage: dict[str, Any] = {
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
@@ -616,6 +836,10 @@ def _usage(prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0) -
     # disabled report and a 0-token hit serialize identically.
     if cached_tokens > 0:
         usage["prompt_tokens_details"] = {"cached_tokens": cached_tokens}
+    # OpenAI's completion_tokens_details.reasoning_tokens: tokens up to and including the
+    # reasoning end tag, only when the model emitted one.
+    if reasoning_tokens > 0:
+        usage["completion_tokens_details"] = {"reasoning_tokens": reasoning_tokens}
     return usage
 
 
@@ -629,12 +853,6 @@ def _completion_unsupported_reason(req: CompletionRequest) -> str | None:
         return "OpenAI token-id prompt inputs are not supported; pass text prompt strings instead"
     if req.logprobs is not None:
         return "logprobs is not supported"
-    if req.echo:
-        return "echo is not supported"
-    if req.suffix is not None:
-        return "suffix is not supported"
-    if req.logit_bias is not None:
-        return "logit_bias is not supported"
     if _response_format_unsupported(req.response_format):
         return "response_format json_object/json_schema is not supported (no constrained decoding)"
     return None

--- a/python/freetoken/server/stats.py
+++ b/python/freetoken/server/stats.py
@@ -174,3 +174,44 @@ def build_stats(state: Any, p95_ms: int, ttft_mean_ms: int) -> dict:
             "completion_tokens_total": tr.completion_tokens_total,
         },
     }
+
+
+
+def prometheus_text(doc: dict) -> str:
+    """The /v1/stats document as Prometheus text exposition (gauges and counters)."""
+    lines: list[str] = []
+
+    def gauge(name: str, value, help_text: str, kind: str = "gauge") -> None:
+        if value is None:
+            return
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} {kind}")
+        lines.append(f"{name} {value}")
+
+    model = doc.get("model") or {}
+    model_id = str(model.get("id") or model.get("name") or "").replace('"', "'")
+    lines.append("# HELP freetoken_info Server identity.")
+    lines.append("# TYPE freetoken_info gauge")
+    lines.append(f'freetoken_info{{instance_id="{doc.get("instance_id")}",model="{model_id}"}} 1')
+    gauge("freetoken_uptime_seconds", doc.get("uptime_s"), "Seconds since the server became ready.")
+    req = doc.get("requests") or {}
+    gauge("freetoken_requests_active", req.get("active"), "Requests in flight.")
+    gauge("freetoken_requests_completed_total", req.get("completed"), "Requests completed.", "counter")
+    gauge("freetoken_request_latency_p95_milliseconds", req.get("p95_ms"), "p95 request latency over the recent window.")
+    gauge("freetoken_ttft_mean_milliseconds", req.get("ttft_mean_ms"), "Mean time to first token over the recent window.")
+    gauge("freetoken_prompt_tokens_total", req.get("prompt_tokens_total"), "Prompt tokens processed.", "counter")
+    gauge("freetoken_completion_tokens_total", req.get("completion_tokens_total"), "Tokens generated.", "counter")
+    tp = doc.get("throughput") or {}
+    gauge("freetoken_decode_tokens_per_second", tp.get("decode_tps"), "Decode throughput, sliding window.")
+    gauge("freetoken_prefill_tokens_per_second", tp.get("prefill_tps"), "Prefill throughput, sliding window.")
+    for pool in ("kv", "swa"):
+        p = doc.get(pool)
+        if p:
+            gauge(f"freetoken_{pool}_pages_used", p.get("used_pages"), f"{pool} pages in use.")
+            gauge(f"freetoken_{pool}_pages_total", p.get("total_pages"), f"{pool} pages in the pool.")
+    mamba = doc.get("mamba")
+    if mamba:
+        gauge("freetoken_mamba_slots_used", mamba.get("used_slots"), "GDN state slots in use.")
+        gauge("freetoken_mamba_slots_total", mamba.get("total_slots"), "GDN state slots in the pool.")
+    gauge("freetoken_vram_bytes", doc.get("vram_bytes"), "GPU memory in use by the engine.")
+    return "\n".join(lines) + "\n"

--- a/python/freetoken/tokenizer/detokenize.py
+++ b/python/freetoken/tokenizer/detokenize.py
@@ -71,11 +71,16 @@ class DecodeStatus:
     read_offset: int  # length of read ids
     surr_offset: int  # length of surr ids
     sent_offset: int  # length of sent out string
+    skip_special: bool = False  # decode this request with skip_special_tokens
+    think_end_at: int | None = None  # generated tokens up to and incl. the reasoning end tag
 
 
 class DetokenizeManager:
     def __init__(
-        self, tokenizer: PreTrainedTokenizerBase, eos_token_ids: FrozenSet[int] | None = None
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        eos_token_ids: FrozenSet[int] | None = None,
+        think_end_id: int | None = None,
     ) -> None:
         # uid -> DecodeStatus
         self.decode_map: Dict[int, DecodeStatus] = {}
@@ -83,6 +88,9 @@ class DetokenizeManager:
         self.eos_token_ids = (
             eos_token_ids if eos_token_ids is not None else frozenset({tokenizer.eos_token_id})
         )
+        # The reasoning end tag's id (e.g. ``</think>``): tokens generated up to and
+        # including it are reported as usage.completion_tokens_details.reasoning_tokens.
+        self.think_end_id = think_end_id if think_end_id is None else int(think_end_id)
 
     def discard(self, uid: int) -> None:
         """Drop a uid's decode state without a finished DetokenizeMsg. An aborted or errored
@@ -91,8 +99,26 @@ class DetokenizeManager:
         self.decode_map.pop(uid, None)
 
     def detokenize(self, msgs: List[DetokenizeMsg]) -> List[str]:
+        return self.detokenize_with_meta(msgs)[0]
+
+    def _batch_decode(self, ids: List[List[int]], skip: List[bool]) -> List[str]:
+        """batch_decode honouring a per-request skip_special_tokens flag (one call per
+        distinct flag value, results back in order)."""
+        out: List[str | None] = [None] * len(ids)
+        for flag in (False, True):
+            idx = [i for i, f in enumerate(skip) if f == flag]
+            if idx:
+                texts = self.tokenizer.batch_decode([ids[i] for i in idx], skip_special_tokens=flag)
+                for i, t in zip(idx, texts, strict=True):
+                    out[i] = t
+        return [t if t is not None else "" for t in out]
+
+    def detokenize_with_meta(self, msgs: List[DetokenizeMsg]) -> tuple[List[str], List[int]]:
+        """Incremental text per message plus, for a finished message, its reasoning token
+        count (0 otherwise or when the model emitted no reasoning end tag)."""
         read_ids: List[List[int]] = []
         surr_ids: List[List[int]] = []
+        skip: List[bool] = []
         for msg in msgs:
             if msg.uid not in self.decode_map:
                 self.decode_map[msg.uid] = DecodeStatus(
@@ -101,17 +127,26 @@ class DetokenizeManager:
                     read_offset=0,
                     surr_offset=0,
                     sent_offset=0,
+                    skip_special=bool(getattr(msg, "skip_special_tokens", False)),
                 )
             s = self.decode_map[msg.uid]
             if not (msg.finished and msg.next_token in self.eos_token_ids):
                 s.decoded_ids.append(msg.next_token)
+            if (
+                self.think_end_id is not None
+                and s.think_end_at is None
+                and msg.next_token == self.think_end_id
+            ):
+                s.think_end_at = len(s.decoded_ids)
             read_ids.append(s.decoded_ids[s.surr_offset :])
             surr_ids.append(s.decoded_ids[s.surr_offset : s.read_offset])
+            skip.append(s.skip_special)
 
-        read_texts = self.tokenizer.batch_decode(read_ids)
-        surr_texts = self.tokenizer.batch_decode(surr_ids)
+        read_texts = self._batch_decode(read_ids, skip)
+        surr_texts = self._batch_decode(surr_ids, skip)
 
         incremental_strs: List[str] = []
+        reasoning_tokens: List[int] = []
         for msg, read_str, surr_str in zip(msgs, read_texts, surr_texts, strict=True):
             s = self.decode_map[msg.uid]
             new_text = read_str[len(surr_str) :]
@@ -127,10 +162,16 @@ class DetokenizeManager:
 
             prev_sent = s.sent_offset
             if msg.finished:
-                # Generation is over: flush everything, trimming at the matched stop string.
+                # Generation is over: flush everything, trimming at the matched stop string
+                # (or keeping it, for include_stop_str_in_output).
                 if msg.matched_stop:
                     cut = output_str.find(msg.matched_stop)
-                    emit_end = cut if cut >= 0 else len(output_str)
+                    if cut < 0:
+                        emit_end = len(output_str)
+                    elif getattr(msg, "keep_stop_str", False):
+                        emit_end = cut + len(msg.matched_stop)
+                    else:
+                        emit_end = cut
                 else:
                     emit_end = len(output_str)
             elif msg.stop_strs:
@@ -141,7 +182,8 @@ class DetokenizeManager:
             incremental_output = output_str[prev_sent:emit_end] if emit_end > prev_sent else ""
             s.sent_offset = max(prev_sent, emit_end)
             incremental_strs.append(incremental_output)
+            reasoning_tokens.append((s.think_end_at or 0) if msg.finished else 0)
             if msg.finished:
                 del self.decode_map[msg.uid]
 
-        return incremental_strs
+        return incremental_strs, reasoning_tokens

--- a/python/freetoken/tokenizer/server.py
+++ b/python/freetoken/tokenizer/server.py
@@ -80,6 +80,19 @@ def _send_generation_replies(
     _put_user_replies(send_frontend, terminal_errors)
 
 
+def _reasoning_end_id(tokenizer) -> int | None:
+    """The id of the reasoning end tag when the vocabulary has one (``</think>`` for the
+    Qwen / DeepSeek / GLM families), else None. Only used to count reasoning tokens."""
+    for tag in ("</think>", "<|end_of_thinking|>"):
+        try:
+            tid = tokenizer.convert_tokens_to_ids(tag)
+        except Exception:  # noqa: BLE001 -- a tokenizer without the tag answers unk or raises
+            continue
+        if isinstance(tid, int) and tid >= 0 and tid != getattr(tokenizer, "unk_token_id", -1):
+            return tid
+    return None
+
+
 def _tokenize_requests(
     tokenize_manager: Any,
     messages: List[TokenizeMsg],
@@ -149,7 +162,9 @@ def tokenize_worker(
 
     tokenize_manager = TokenizeManager(tokenizer)
     detokenize_manager = DetokenizeManager(
-        tokenizer, load_eos_token_ids(tokenizer_path, tokenizer)
+        tokenizer,
+        load_eos_token_ids(tokenizer_path, tokenizer),
+        think_end_id=_reasoning_end_id(tokenizer),
     )
 
     if ack_queue is not None:
@@ -207,7 +222,7 @@ def tokenize_worker(
             )
             sampled_replies: List[UserReply] = []
             if len(detokenize_msg) > 0:
-                replies = detokenize_manager.detokenize(detokenize_msg)
+                replies, reasoning_counts = detokenize_manager.detokenize_with_meta(detokenize_msg)
                 sampled_replies = [
                     UserReply(
                         uid=msg.uid,
@@ -215,6 +230,7 @@ def tokenize_worker(
                         finished=msg.finished,
                         finish_reason=msg.finish_reason,
                         matched_stop=msg.matched_stop,
+                        reasoning_tokens=reasoning_tokens,
                         completion_tokens_delta=1,
                         kv_used_pages=msg.kv_used_pages,
                         kv_total_pages=msg.kv_total_pages,
@@ -224,7 +240,9 @@ def tokenize_worker(
                         swa_total_tokens=msg.swa_total_tokens,
                         gpu_mem_bytes=msg.gpu_mem_bytes,
                     )
-                    for msg, reply in zip(detokenize_msg, replies, strict=True)
+                    for msg, reply, reasoning_tokens in zip(
+                        detokenize_msg, replies, reasoning_counts, strict=True
+                    )
                 ]
 
             # An error reply and a client abort are both terminal for their uid, and neither

--- a/python/freetoken/tokenizer/tokenize.py
+++ b/python/freetoken/tokenizer/tokenize.py
@@ -112,11 +112,12 @@ class TokenizeManager:
         # message is an assistant prefix the model must continue, so no generation prompt.
         chat_template_kwargs = dict(chat_template_kwargs)
         continue_final = bool(chat_template_kwargs.pop("continue_final_message", False))
+        if continue_final:
+            chat_template_kwargs["continue_final_message"] = True
         prompt = self.tokenizer.apply_chat_template(
             messages,
             tokenize=False,
             add_generation_prompt=not continue_final,
-            continue_final_message=continue_final,
             **chat_template_kwargs,
         )
         assert isinstance(prompt, str)

--- a/python/freetoken/tokenizer/tokenize.py
+++ b/python/freetoken/tokenizer/tokenize.py
@@ -108,10 +108,15 @@ class TokenizeManager:
             )
         if tools is not None:
             chat_template_kwargs = {**chat_template_kwargs, "tools": tools}
+        # continue_final_message (an OpenAI-compatible extra, as in vLLM / SGLang): the last
+        # message is an assistant prefix the model must continue, so no generation prompt.
+        chat_template_kwargs = dict(chat_template_kwargs)
+        continue_final = bool(chat_template_kwargs.pop("continue_final_message", False))
         prompt = self.tokenizer.apply_chat_template(
             messages,
             tokenize=False,
-            add_generation_prompt=True,
+            add_generation_prompt=not continue_final,
+            continue_final_message=continue_final,
             **chat_template_kwargs,
         )
         assert isinstance(prompt, str)

--- a/tests/engine/test_logits_processors.py
+++ b/tests/engine/test_logits_processors.py
@@ -125,7 +125,7 @@ def test_prepare_builds_no_plan_without_processors_and_a_plan_with_them():
                 4,
                 presence_penalty=1.0,
                 repetition_penalty=1.5,
-                logit_bias={5: 2.0},
+                logit_bias=[[5, 2.0]],
             ),
             _req([4], [], 4, min_tokens=2, min_tokens_stop_ids=[0, 7]),
             _req(

--- a/tests/engine/test_logits_processors.py
+++ b/tests/engine/test_logits_processors.py
@@ -1,0 +1,152 @@
+"""The logits processors behind min_p, the penalties, logit_bias and min_tokens: pure
+torch on the CPU, so the math is checked without a GPU or the sampling kernels."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from freetoken.core import SamplingParams
+from freetoken.engine.sample import LogitsPlan, Sampler, apply_logits_processors
+
+V = 8
+CPU = torch.device("cpu")
+
+
+def _plan(rows, **fields) -> LogitsPlan:
+    plan = LogitsPlan(
+        rows=torch.tensor(rows, dtype=torch.int64),
+        temps=torch.ones((len(rows), 1), dtype=torch.float32),
+    )
+    for k, v in fields.items():
+        setattr(plan, k, v)
+    return plan
+
+
+def _ids(rows: list[list[int]]) -> torch.Tensor:
+    width = max(len(r) for r in rows)
+    out = torch.full((len(rows), width), V, dtype=torch.int64)
+    for i, r in enumerate(rows):
+        out[i, : len(r)] = torch.tensor(r)
+    return out
+
+
+def test_presence_and_frequency_penalties_count_generated_tokens():
+    logits = torch.zeros((2, V))
+    plan = _plan(
+        [1],
+        hist_ids=_ids([[3, 3, 5]]),
+        presence=torch.tensor([[0.5]]),
+        frequency=torch.tensor([[0.25]]),
+    )
+    out = apply_logits_processors(logits, plan, V)
+    assert torch.equal(out[0], logits[0])  # row outside the plan untouched
+    assert out[1, 3].item() == -(0.5 + 2 * 0.25)
+    assert out[1, 5].item() == -(0.5 + 0.25)
+    assert out[1, 0].item() == 0.0
+
+
+def test_repetition_penalty_covers_prompt_and_output_with_hf_semantics():
+    logits = torch.tensor([[2.0, -2.0, 2.0, -2.0, 1.0, 1.0, 1.0, 1.0]])
+    plan = _plan(
+        [0],
+        hist_ids=_ids([[0, 1]]),  # generated: 0 (positive), 1 (negative)
+        prompt_ids=_ids([[2, 3]]),  # prompt: 2 (positive), 3 (negative)
+        repetition=torch.tensor([[2.0]]),
+    )
+    out = apply_logits_processors(logits, plan, V)
+    assert out[0, 0].item() == 1.0 and out[0, 2].item() == 1.0  # divided
+    assert out[0, 1].item() == -4.0 and out[0, 3].item() == -4.0  # multiplied
+    assert out[0, 4].item() == 1.0  # unseen
+
+
+def test_logit_bias_adds_per_row():
+    logits = torch.zeros((2, V))
+    plan = _plan(
+        [0, 1],
+        bias_rows=torch.tensor([0, 1, 1]),
+        bias_ids=torch.tensor([2, 2, 6]),
+        bias_vals=torch.tensor([5.0, -100.0, 1.5]),
+    )
+    out = apply_logits_processors(logits, plan, V)
+    assert (
+        out[0, 2].item() == 5.0
+        and out[1, 2].item() == -100.0
+        and out[1, 6].item() == 1.5
+    )
+
+
+def test_min_tokens_masks_the_stop_ids_of_the_row_only():
+    logits = torch.zeros((2, V))
+    plan = _plan([0, 1], min_rows=torch.tensor([1]), min_ids=_ids([[0, 7]]))
+    out = apply_logits_processors(logits, plan, V)
+    assert out[1, 0].item() == float("-inf") and out[1, 7].item() == float("-inf")
+    assert out[1, 3].item() == 0.0
+    assert torch.isfinite(out[0]).all()
+
+
+def test_min_p_drops_tokens_below_the_fraction_of_the_top_probability():
+    logits = torch.log(torch.tensor([[0.5, 0.3, 0.1, 0.05, 0.03, 0.01, 0.005, 0.005]]))
+    plan = _plan([0], min_p=torch.tensor([[0.2]]))
+    out = apply_logits_processors(logits, plan, V)
+    kept = torch.isfinite(out[0])
+    assert kept.tolist() == [True, True, True, False, False, False, False, False]
+    # a row with min_p 0 is left alone
+    plan0 = _plan([0], min_p=torch.tensor([[0.0]]))
+    assert torch.isfinite(apply_logits_processors(logits, plan0, V)[0]).all()
+
+
+def _req(
+    prompt: list[int], generated: list[int], max_tokens: int, **sp
+) -> SimpleNamespace:
+    ids = torch.tensor(prompt + generated, dtype=torch.int32)
+    return SimpleNamespace(
+        input_ids=ids,
+        output_len=max_tokens,
+        max_device_len=len(prompt) + max_tokens,
+        sampling_params=SamplingParams(**sp),
+    )
+
+
+def test_prepare_builds_no_plan_without_processors_and_a_plan_with_them():
+    sampler = Sampler(CPU, V)
+    plain = SimpleNamespace(reqs=[_req([1, 2], [3], 4, temperature=0.7)])
+    assert sampler.prepare(plain).plan is None
+
+    batch = SimpleNamespace(
+        reqs=[
+            _req([1, 2], [3], 4, temperature=0.7),
+            _req(
+                [1, 2],
+                [3, 3],
+                4,
+                presence_penalty=1.0,
+                repetition_penalty=1.5,
+                logit_bias={5: 2.0},
+            ),
+            _req([4], [], 4, min_tokens=2, min_tokens_stop_ids=[0, 7]),
+            _req(
+                [4], [6, 6], 4, min_tokens=2, min_tokens_stop_ids=[0]
+            ),  # already past min_tokens
+        ]
+    )
+    args = sampler.prepare(batch)
+    plan = args.plan
+    assert plan is not None
+    assert plan.rows.tolist() == [1, 2, 3]
+    assert plan.hist_ids[0].tolist()[:2] == [3, 3]  # row 1's generated tokens
+    assert plan.prompt_ids[0].tolist()[:2] == [1, 2]
+    assert plan.bias_rows.tolist() == [0] and plan.bias_ids.tolist() == [5]
+    assert plan.min_rows.tolist() == [1]  # local row of the third request only
+    assert plan.min_ids[0].tolist() == [0, 7]
+
+    logits = torch.zeros((4, V))
+    out = apply_logits_processors(logits, plan, V)
+    assert (
+        out[1, 3].item() == -1.0
+    )  # presence on the repeated 3 (repetition on 0 is a no-op)
+    assert out[1, 5].item() == 2.0
+    assert out[2, 0].item() == float("-inf") and out[2, 7].item() == float("-inf")
+    assert torch.isfinite(out[3]).all()
+    # greedy path: argmax over the processed logits
+    assert sampler.sample(logits, args)[1].item() == 5

--- a/tests/engine/test_logits_processors.py
+++ b/tests/engine/test_logits_processors.py
@@ -87,7 +87,9 @@ def test_min_tokens_masks_the_stop_ids_of_the_row_only():
 
 def test_min_p_drops_tokens_below_the_fraction_of_the_top_probability():
     logits = torch.log(torch.tensor([[0.5, 0.3, 0.1, 0.05, 0.03, 0.01, 0.005, 0.005]]))
-    plan = _plan([0], min_p=torch.tensor([[0.2]]))
+    plan = _plan(
+        [0], min_p=torch.tensor([[0.15]])
+    )  # threshold 0.075, between 0.1 and 0.05
     out = apply_logits_processors(logits, plan, V)
     kept = torch.isfinite(out[0])
     assert kept.tolist() == [True, True, True, False, False, False, False, False]
@@ -110,12 +112,13 @@ def _req(
 
 def test_prepare_builds_no_plan_without_processors_and_a_plan_with_them():
     sampler = Sampler(CPU, V)
-    plain = SimpleNamespace(reqs=[_req([1, 2], [3], 4, temperature=0.7)])
+    plain = SimpleNamespace(reqs=[_req([1, 2], [3], 4)])
     assert sampler.prepare(plain).plan is None
 
+    # all greedy: the argmax path runs on the CPU, the sampling kernels need a GPU
     batch = SimpleNamespace(
         reqs=[
-            _req([1, 2], [3], 4, temperature=0.7),
+            _req([1, 2], [3], 4),
             _req(
                 [1, 2],
                 [3, 3],

--- a/tests/server/test_openai_extras.py
+++ b/tests/server/test_openai_extras.py
@@ -240,7 +240,7 @@ def test_sampling_extras_reach_sampling_params():
     sp = spec.sampling_params
     assert sp.min_p == 0.1 and sp.repetition_penalty == 1.2
     assert sp.presence_penalty == 0.5 and sp.frequency_penalty == 0.3
-    assert sp.logit_bias == {5: 100.0, 7: -3.0}  # clamped to the OpenAI range
+    assert sp.logit_bias == [[5, 100.0], [7, -3.0]]  # clamped to the OpenAI range
     assert sp.min_tokens == 3 and sp.stop_token_ids == [9]
     assert sp.include_stop_str_in_output is True and sp.skip_special_tokens is True
     assert sp.needs_logits_processing

--- a/tests/server/test_openai_extras.py
+++ b/tests/server/test_openai_extras.py
@@ -1,0 +1,383 @@
+"""OpenAI protocol coverage: n > 1 fan-out, echo and suffix (FIM) on completions, the
+sampling extras reaching SamplingParams, request_id, usage details, and the tokenize /
+detokenize routes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from freetoken.message import TokenizeMsg, UserReply
+from freetoken.server.api_models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    DetokenizeRequest,
+    TokenizeRequest,
+)
+from freetoken.server.openai_api import (
+    _usage,
+    chat_request_to_genspec,
+    handle_chat_completion,
+    handle_completion,
+    handle_detokenize,
+    handle_tokenize,
+)
+from freetoken.server.stats import prometheus_text
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeState:
+    """Distinct uids per generation; every uid gets the same two-ack reply."""
+
+    def __init__(self, text=("hel", "lo"), reasoning_tokens=0, tokenizer=None):
+        self.config = SimpleNamespace(
+            model_path="/models/unit-model",
+            served_model_name="unit-model",
+            tool_call_parser="llama3",
+            reasoning_parser=None,
+            max_seq_len=4096,
+        )
+        self.text = text
+        self.reasoning_tokens = reasoning_tokens
+        self._next = 100
+        self.sent: list[TokenizeMsg] = []
+        self.aborted: list[int] = []
+        if tokenizer is not None:
+            manager = SimpleNamespace(
+                tokenizer=tokenizer,
+                render_prompt=lambda msg: "RENDERED:" + json.dumps(msg.text),
+            )
+            self.frontend_tokenizer = lambda: manager
+
+    def new_user(self) -> int:
+        self._next += 1
+        return self._next
+
+    async def send_one(self, msg):
+        self.sent.append(msg)
+
+    async def abort_user(self, uid):
+        self.aborted.append(uid)
+
+    async def wait_for_ack(self, uid: int):
+        yield UserReply(
+            uid=uid, incremental_output="", finished=False, prompt_tokens_delta=5
+        )
+        for i, piece in enumerate(self.text):
+            last = i == len(self.text) - 1
+            yield UserReply(
+                uid=uid,
+                incremental_output=piece,
+                finished=last,
+                completion_tokens_delta=1,
+                finish_reason="stop" if last else None,
+                reasoning_tokens=self.reasoning_tokens if last else 0,
+            )
+
+
+def chat(**kwargs) -> ChatCompletionRequest:
+    body = {"model": "unit-model", "messages": [{"role": "user", "content": "hi"}]}
+    body.update(kwargs)
+    return ChatCompletionRequest(**body)
+
+
+def parse_sse(chunks: list[bytes]) -> list:
+    out = []
+    for chunk in chunks:
+        for line in chunk.decode().split("\n"):
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: ") :]
+            out.append("[DONE]" if payload == "[DONE]" else json.loads(payload))
+    return out
+
+
+async def _collect(generator):
+    return [item async for item in generator]
+
+
+# ---- n > 1 ------------------------------------------------------------------------------
+
+
+def test_chat_n_returns_one_choice_per_generation_and_counts_the_prompt_once():
+    state = FakeState(reasoning_tokens=2)
+    body = run(handle_chat_completion(chat(n=2), None, state, {}))
+    assert [c["index"] for c in body["choices"]] == [0, 1]
+    assert all(c["message"]["content"] == "hello" for c in body["choices"])
+    assert len(state.sent) == 2 and len({m.uid for m in state.sent}) == 2
+    usage = body["usage"]
+    assert (
+        usage["prompt_tokens"] == 5
+        and usage["completion_tokens"] == 4
+        and usage["total_tokens"] == 9
+    )
+    assert usage["completion_tokens_details"] == {"reasoning_tokens": 4}
+    assert body["system_fingerprint"] is None
+
+
+def test_chat_n_stream_interleaves_choice_indices_and_ends_once():
+    state = FakeState()
+    response = run(
+        handle_chat_completion(
+            chat(n=2, stream=True, stream_options={"include_usage": True}),
+            None,
+            state,
+            {},
+        )
+    )
+    events = parse_sse(run(_collect(response.body_iterator)))
+    assert events.count("[DONE]") == 1 and events[-1] == "[DONE]"
+    indices = {c["index"] for ev in events[:-1] for c in ev.get("choices", [])}
+    assert indices == {0, 1}
+    usage_chunks = [ev for ev in events[:-1] if ev.get("usage")]
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0]["usage"]["prompt_tokens"] == 5
+    assert usage_chunks[0]["usage"]["completion_tokens"] == 4
+    finals = [
+        c for ev in events[:-1] for c in ev.get("choices", []) if c.get("finish_reason")
+    ]
+    assert len(finals) == 2
+
+
+def test_n_out_of_range_is_400():
+    for n in (0, 17):
+        body = run(handle_chat_completion(chat(n=n), None, FakeState(), {}))
+        assert body.status_code == 400
+        assert json.loads(body.body)["error"]["param"] == "n"
+
+
+# ---- completions: echo, suffix, n ---------------------------------------------------------
+
+
+def test_completion_echo_prepends_the_prompt():
+    state = FakeState()
+    req = CompletionRequest(model="unit-model", prompt="Once upon", echo=True)
+    body = run(handle_completion(req, None, state, {}))
+    assert body["choices"][0]["text"] == "Once uponhello"
+
+
+def test_completion_echo_streams_the_prompt_first():
+    state = FakeState()
+    req = CompletionRequest(
+        model="unit-model", prompt="Once upon", echo=True, stream=True
+    )
+    response = run(handle_completion(req, None, state, {}))
+    events = parse_sse(run(_collect(response.body_iterator)))
+    assert events[0]["choices"][0]["text"] == "Once upon"
+    assert events[-1] == "[DONE]"
+
+
+class _FimTokenizer:
+    unk_token_id = -1
+
+    def convert_tokens_to_ids(self, name):
+        return {"<|fim_prefix|>": 10, "<|fim_suffix|>": 11, "<|fim_middle|>": 12}.get(
+            name, -1
+        )
+
+
+class _NoFimTokenizer:
+    unk_token_id = 3
+
+    def convert_tokens_to_ids(self, name):
+        return 3
+
+
+def test_completion_suffix_builds_a_fill_in_the_middle_prompt():
+    state = FakeState(tokenizer=_FimTokenizer())
+    req = CompletionRequest(model="unit-model", prompt="def f(", suffix="    return 1")
+    run(handle_completion(req, None, state, {}))
+    assert (
+        state.sent[0].text
+        == "<|fim_prefix|>def f(<|fim_suffix|>    return 1<|fim_middle|>"
+    )
+
+
+def test_completion_suffix_needs_fim_tokens():
+    state = FakeState(tokenizer=_NoFimTokenizer())
+    req = CompletionRequest(model="unit-model", prompt="def f(", suffix="x")
+    body = run(handle_completion(req, None, state, {}))
+    assert (
+        body.status_code == 400 and json.loads(body.body)["error"]["param"] == "suffix"
+    )
+
+
+def test_completion_n_orders_choices_prompt_major():
+    state = FakeState()
+    req = CompletionRequest(model="unit-model", prompt=["a", "b"], n=2)
+    body = run(handle_completion(req, None, state, {}))
+    assert [c["index"] for c in body["choices"]] == [0, 1, 2, 3]
+    assert [m.text for m in state.sent] == ["a", "a", "b", "b"]
+    assert body["usage"]["prompt_tokens"] == 10  # two prompts, each counted once
+    assert body["usage"]["completion_tokens"] == 8
+
+
+# ---- sampling extras --------------------------------------------------------------------
+
+
+def test_sampling_extras_reach_sampling_params():
+    spec = chat_request_to_genspec(
+        chat(
+            min_p=0.1,
+            repetition_penalty=1.2,
+            presence_penalty=0.5,
+            frequency_penalty=0.3,
+            logit_bias={"5": 150, "7": -3},
+            min_tokens=3,
+            stop_token_ids=[9],
+            include_stop_str_in_output=True,
+            skip_special_tokens=True,
+            seed=7,
+            user="u1",
+        ),
+        {},
+    )
+    sp = spec.sampling_params
+    assert sp.min_p == 0.1 and sp.repetition_penalty == 1.2
+    assert sp.presence_penalty == 0.5 and sp.frequency_penalty == 0.3
+    assert sp.logit_bias == {5: 100.0, 7: -3.0}  # clamped to the OpenAI range
+    assert sp.min_tokens == 3 and sp.stop_token_ids == [9]
+    assert sp.include_stop_str_in_output is True and sp.skip_special_tokens is True
+    assert sp.needs_logits_processing
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        {"min_p": 1.5},
+        {"presence_penalty": 3.0},
+        {"frequency_penalty": -2.5},
+        {"repetition_penalty": 0.0},
+        {"logit_bias": {"x": 1.0}},
+        {"min_tokens": -1},
+        {"stop_token_ids": [-1]},
+    ],
+)
+def test_bad_sampling_extras_are_400(field):
+    body = run(handle_chat_completion(chat(**field), None, FakeState(), {}))
+    assert body.status_code == 400, field
+
+
+def test_continue_final_message_needs_an_assistant_tail_and_reaches_the_template():
+    spec = chat_request_to_genspec(
+        chat(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Sure,"},
+            ],
+            continue_final_message=True,
+        ),
+        {},
+    )
+    assert spec.chat_template_kwargs["continue_final_message"] is True
+    with pytest.raises(ValueError):
+        chat(continue_final_message=True)
+
+
+# ---- ids and usage ------------------------------------------------------------------------
+
+
+def test_request_id_becomes_the_response_id():
+    state = FakeState()
+    body = run(handle_chat_completion(chat(request_id="abc-1"), None, state, {}))
+    assert body["id"] == "chatcmpl-abc-1"
+    response = run(
+        handle_chat_completion(chat(request_id="abc-2", stream=True), None, state, {})
+    )
+    events = parse_sse(run(_collect(response.body_iterator)))
+    assert events[0]["id"] == "chatcmpl-abc-2"
+
+
+def test_usage_details_appear_only_when_nonzero():
+    assert "completion_tokens_details" not in _usage(10, 5)
+    assert _usage(10, 5, reasoning_tokens=3)["completion_tokens_details"] == {
+        "reasoning_tokens": 3
+    }
+    assert _usage(10, 5, cached_tokens=4)["prompt_tokens_details"] == {
+        "cached_tokens": 4
+    }
+
+
+# ---- tokenize / detokenize / metrics -----------------------------------------------------
+
+
+class _Tokenizer:
+    def encode(self, text, add_special_tokens=True):
+        ids = [ord(c) for c in text]
+        return ([1] + ids) if add_special_tokens else ids
+
+    def decode(self, ids, skip_special_tokens=False):
+        return "".join(chr(i) for i in ids if not (skip_special_tokens and i == 1))
+
+    def convert_ids_to_tokens(self, ids):
+        return [chr(i) for i in ids]
+
+
+def test_tokenize_prompt_and_messages_and_detokenize():
+    state = FakeState(tokenizer=_Tokenizer())
+    body = run(handle_tokenize(TokenizeRequest(prompt="ab"), state))
+    assert body == {"count": 3, "max_model_len": 4096, "tokens": [1, 97, 98]}
+    body = run(
+        handle_tokenize(
+            TokenizeRequest(
+                prompt="ab", add_special_tokens=False, return_token_strs=True
+            ),
+            state,
+        )
+    )
+    assert body["tokens"] == [97, 98] and body["token_strs"] == ["a", "b"]
+    body = run(
+        handle_tokenize(
+            TokenizeRequest(messages=[{"role": "user", "content": "x"}]), state
+        )
+    )
+    assert body["count"] == len(
+        "RENDERED:" + json.dumps([{"role": "user", "content": "x"}])
+    )
+    bad = run(
+        handle_tokenize(
+            TokenizeRequest(prompt="a", messages=[{"role": "user", "content": "x"}]),
+            state,
+        )
+    )
+    assert bad.status_code == 400
+    body = run(
+        handle_detokenize(
+            DetokenizeRequest(tokens=[1, 104, 105], skip_special_tokens=True), state
+        )
+    )
+    assert body == {"prompt": "hi"}
+
+
+def test_metrics_exposition_lists_the_stats_document():
+    doc = {
+        "instance_id": "abc",
+        "model": {"id": "unit-model"},
+        "uptime_s": 12,
+        "kv": {"used_pages": 3, "total_pages": 10, "page_size": 64},
+        "mamba": {"used_slots": 1, "total_slots": 4},
+        "swa": None,
+        "vram_bytes": 123,
+        "throughput": {"decode_tps": 99.5, "prefill_tps": 1000.0},
+        "requests": {
+            "active": 1,
+            "completed": 7,
+            "p95_ms": 50,
+            "ttft_mean_ms": 20,
+            "prompt_tokens_total": 100,
+            "completion_tokens_total": 40,
+        },
+    }
+    text = prometheus_text(doc)
+    assert 'freetoken_info{instance_id="abc",model="unit-model"} 1' in text
+    assert "freetoken_requests_active 1" in text
+    assert "freetoken_requests_completed_total 7" in text
+    assert "freetoken_kv_pages_total 10" in text
+    assert "freetoken_mamba_slots_used 1" in text
+    assert "freetoken_decode_tokens_per_second 99.5" in text
+    assert "# TYPE freetoken_prompt_tokens_total counter" in text

--- a/tests/tokenizer/test_detokenize_extras.py
+++ b/tests/tokenizer/test_detokenize_extras.py
@@ -1,0 +1,81 @@
+"""Per-request detokenizer options: include_stop_str_in_output, skip_special_tokens, and
+the reasoning token count reported on the finished reply."""
+
+from __future__ import annotations
+
+from freetoken.message import DetokenizeMsg
+from freetoken.tokenizer.detokenize import DetokenizeManager
+
+EOS, SPECIAL, THINK_END = 0, 99, 7
+
+
+class _Tok:
+    """Token ids decode to letters; 99 is a special marker, 7 the reasoning end tag."""
+
+    eos_token_id = EOS
+    unk_token_id = -1
+
+    def decode(self, ids, skip_special_tokens=False):
+        out = []
+        for t in ids:
+            if t == SPECIAL:
+                if not skip_special_tokens:
+                    out.append("<s>")
+            elif t == THINK_END:
+                out.append("</think>")
+            else:
+                out.append(chr(ord("a") + t))
+        return "".join(out)
+
+    def batch_decode(self, ids_list, skip_special_tokens=False):
+        return [self.decode(ids, skip_special_tokens) for ids in ids_list]
+
+
+def _run(manager, uid, tokens, *, finished_kwargs=None, **msg_kwargs):
+    text = ""
+    meta = 0
+    for i, t in enumerate(tokens):
+        last = i == len(tokens) - 1
+        kwargs = dict(msg_kwargs)
+        if last and finished_kwargs:
+            kwargs.update(finished_kwargs)
+        strs, counts = manager.detokenize_with_meta(
+            [DetokenizeMsg(uid=uid, next_token=t, finished=last, **kwargs)]
+        )
+        text += strs[0]
+        meta = counts[0]
+    return text, meta
+
+
+def test_stop_string_is_trimmed_by_default_and_kept_on_request():
+    manager = DetokenizeManager(_Tok(), frozenset({EOS}))
+    trimmed, _ = _run(
+        manager, 1, [1, 2, 3], stop_strs=["cd"], finished_kwargs={"matched_stop": "cd"}
+    )
+    assert trimmed == "b"
+    kept, _ = _run(
+        manager,
+        2,
+        [1, 2, 3],
+        stop_strs=["cd"],
+        keep_stop_str=True,
+        finished_kwargs={"matched_stop": "cd"},
+    )
+    assert kept == "bcd"
+
+
+def test_skip_special_tokens_is_per_request():
+    manager = DetokenizeManager(_Tok(), frozenset({EOS}))
+    shown, _ = _run(manager, 1, [1, SPECIAL, 2, EOS])
+    hidden, _ = _run(manager, 2, [1, SPECIAL, 2, EOS], skip_special_tokens=True)
+    assert shown == "b<s>c"
+    assert hidden == "bc"
+
+
+def test_reasoning_tokens_count_up_to_the_end_tag():
+    manager = DetokenizeManager(_Tok(), frozenset({EOS}), think_end_id=THINK_END)
+    text, reasoning = _run(manager, 1, [1, 2, THINK_END, 3, 4, EOS])
+    assert text == "bc</think>de"
+    assert reasoning == 3  # b, c and the tag itself
+    _, none = _run(manager, 2, [1, 2, EOS])
+    assert none == 0


### PR DESCRIPTION
## Summary

Closes the most common gaps between FreeToken's OpenAI-compatible surface and vLLM / SGLang / llama.cpp's server. `docs/openai_api.md` has the four-way table of endpoints, request parameters and response fields (honoured / accepted / 400), and lists what is deliberately not implemented.

**Sampling extras** (`/v1/chat/completions` and `/v1/completions`): `min_p`, `presence_penalty`, `frequency_penalty` (over generated tokens), `repetition_penalty` (prompt + generated, HF semantics), `logit_bias` (token id → bias, clamped to [-100, 100]), `min_tokens` (no EOS / stop token before N generated tokens), `stop_token_ids`, `include_stop_str_in_output`, `skip_special_tokens` (per request; default off here because the reasoning and tool parsers read the tags). Out-of-range values answer 400 with the field named.

Implemented as logits processors (`engine/sample.py`): `Sampler.prepare` builds a per-batch `LogitsPlan` on the host from the requests' `SamplingParams` and token histories, only for the rows that asked; `apply_logits_processors` applies it to a float32 copy of the logits before the sampling kernel (repetition → presence → frequency → logit_bias → min_tokens mask → min_p, vLLM's order). A batch without them takes exactly the old path, and sampling already runs outside the CUDA graph, so no capture changes. Cost measured on an Ada card with a 3k-token history: 0.97 ms per step for a batch that uses them (0.32 ms on the device), 0.08 ms on the plain path.

**`n` (1..16)** on both routes: one generation per choice submitted together (the prefix cache serves the shared prompt), results gathered; streams interleaved into one SSE response with the choice index, one usage chunk (prompt counted once, completions summed) and one `[DONE]`; a client disconnect aborts every uid of the fan-out.

**Completions**: `echo` (the prompt leads the text, or the first chunk), `suffix` as a fill-in-the-middle prompt on models whose vocabulary has the FIM tokens (Qwen family; 400 otherwise).

**Chat**: `continue_final_message` (the final assistant message is continued, no generation prompt), `request_id` echoed as the response id, `seed` / `user` accepted, `system_fingerprint: null` in responses and chunks.

**Usage**: `completion_tokens_details.reasoning_tokens` — the detokenizer counts the tokens up to and including the reasoning end tag and reports it on the finished reply.

**Routes**: `POST /tokenize` and `/detokenize` (also under `/v1/`; the vLLM / SGLang shape, `messages` render through the chat template so `count` equals a generation's `prompt_tokens`), `GET /metrics` (Prometheus text of `/v1/stats`), `GET /version`.

Not in this PR, on purpose: constrained decoding (`response_format` json / json_schema, grammars: needs a grammar engine on the sampling path), prompt logprobs and `echo` + `logprobs` (prefill logits), a per-request `seed` (one batched sampling kernel), embeddings / rerank / score / audio.

## Test plan

- [x] `tests/engine/test_logits_processors.py` (pure torch on the CPU: each processor, the plan builder, the greedy path), `tests/tokenizer/test_detokenize_extras.py` (stop-string keep, per-request `skip_special_tokens`, reasoning token count), `tests/server/test_openai_extras.py` (n fan-out non-stream and stream, echo, suffix with and without FIM tokens, prompt-major choice order, the extras reaching `SamplingParams`, 400s, `continue_final_message`, `request_id`, usage details, tokenize / detokenize, metrics exposition)
- [x] `tests/server`, `tests/tokenizer`, `tests/scheduler`, `tests/engine`: 790 passed on the CPU
- [x] GPU micro-check of the processors and the sampler with the real vocabulary (248,320) on RTX 6000 Ada
- [x] Served Qwen3.8-Flash-Next (RadixArk NVFP4, offload backend, TP=1) from this branch and ran a live probe of every field and route: 24/24 (penalties change a repetitive output, logit_bias steers the answer, min_tokens forces 2 → 35 tokens, stop_token_ids on `.` stops at 18 tokens, include_stop_str_in_output keeps the stop word, min_p / seed / user accepted, n=2 non-stream and stream, echo, suffix as FIM (`return a + b`), continue_final_message, request_id as the response id, reasoning_tokens 39 of 44 completion tokens with thinking on, tokenize / detokenize round trip and a rendered-messages count equal to the generation's prompt_tokens, /metrics, /version, five 400s), 8-question quality probe unchanged (6/8), decode unchanged (61.7 tok/s single-stream / 166 at 8 concurrent, the same as main on that card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173pf9k9fSVtwbm3f898HDt
