### PR TITLE
fix(cpu-moe): honor padded fp8 scale strides, add avx512f tier and float64 parity (builds on #36)

### DIFF
--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -263,6 +263,134 @@ inline float e4m3_decode(uint8_t v) {
   return sign * (1.0f + man / 8.0f) * std::ldexp(1.0f, (int)exp - 7);
 }
 
+// ------------------------ block-FP8 (W8A16) dequant ------------------------
+// DeepSeek-V3-style block-fp8 experts (Qwen3.5/3.6-FP8, GLM, DSV4 dense): fp8-e4m3
+// weights row-major [rows, K] plus one bf16 scale per 128x128 weight block. The tensor
+// is named ``weight_scale_inv`` but it multiplies; the reference is the Triton decode
+// GEMV (kernel/triton/fp8_blockscale_moe.py):
+//
+//     acc += sum(w * a  over one 128-wide K block) * scale[row/128][kb]
+//
+// K is contiguous per output row -- unlike mxfp4's transposed bank -- so this maps
+// straight onto a bf16 dot product. e4m3 -> bf16 is *exact* (3 mantissa bits into 7,
+// and bf16's exponent range covers e4m3's whole 2^-9..448 span), so the AVX-512 path
+// widens the weights in-register and feeds _mm512_dpbf16_ps against the bf16
+// activations. That reproduces the reference's fp32 products exactly; only the
+// summation order differs, the same latitude the bf16 dot already takes.
+//
+// Bit math for the normal range (exp != 0), from byte b = s<<7 | e<<3 | m:
+//   bf16 = (b & 0x80) << 8  |  (((b & 0x7F) << 4) + (120 << 7))
+// because e4m3 bias 7 -> bf16 bias 127 is a constant +120 on the exponent field once
+// the magnitude is shifted into place. exp == 0 is subnormal (value = m * 2^-9) and
+// does not follow that rule, so those lanes are blended in from a small table.
+using fp8dot_fn = float (*)(const uint8_t*, const bf16_t*, const bf16_t*, int, const float*);
+
+constexpr int FP8_BLK = 128;  // K elements covered by one weight scale
+
+// e4m3 subnormals: m * 2^-9, as bf16 bit patterns (index = mantissa, 0..7).
+alignas(64) const uint16_t kE4M3SubBf16[32] = {
+    0x0000, 0x3B00, 0x3B80, 0x3BC0, 0x3C00, 0x3C20, 0x3C40, 0x3C60,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+// Same values as fp32, for the AVX2 path.
+alignas(32) const float kE4M3SubF32[8] = {
+    0.0f, 1.0f / 512, 2.0f / 512, 3.0f / 512, 4.0f / 512, 5.0f / 512, 6.0f / 512, 7.0f / 512};
+
+float dot_fp8_block_scalar(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                           const float* e4m3) {
+  float acc = 0.0f;
+  for (int b = 0, k0 = 0; k0 < K; ++b, k0 += FP8_BLK) {
+    const int k1 = std::min(K, k0 + FP8_BLK);
+    float blk = 0.0f;
+    for (int k = k0; k < k1; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+
+#if CPU_MOE_X86
+__attribute__((target("avx512f,avx512bw")))
+static inline __m512i e4m3_to_bf16_x32(__m256i raw, __m512i subtab) {
+  const __m512i b = _mm512_cvtepu8_epi16(raw);
+  const __m512i sgn = _mm512_slli_epi16(_mm512_and_si512(b, _mm512_set1_epi16(0x0080)), 8);
+  const __m512i mag = _mm512_and_si512(b, _mm512_set1_epi16(0x007F));
+  const __m512i nrm =
+      _mm512_add_epi16(_mm512_slli_epi16(mag, 4), _mm512_set1_epi16((short)(120 << 7)));
+  const __mmask32 sub = _mm512_cmplt_epu16_mask(mag, _mm512_set1_epi16(8));
+  const __m512i lut = _mm512_permutexvar_epi16(mag, subtab);  // indices wrap; only sub lanes used
+  return _mm512_or_si512(sgn, _mm512_mask_blend_epi16(sub, nrm, lut));
+}
+
+__attribute__((target("avx512bf16,avx512bw,avx512f")))
+static inline __m512bh as_bh(__m512i v) {
+  __m512bh out;
+  std::memcpy(&out, &v, sizeof(out));
+  return out;
+}
+
+__attribute__((target("avx512bf16,avx512bw,avx512f")))
+float dot_fp8_block_avx512bf16(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                               const float* e4m3) {
+  const __m512i subtab = _mm512_loadu_si512(reinterpret_cast<const void*>(kE4M3SubBf16));
+  __m512 total = _mm512_setzero_ps();
+  int b = 0, k0 = 0;
+  for (; k0 + FP8_BLK <= K; k0 += FP8_BLK, ++b) {
+    // The weight stream is the bandwidth bottleneck (read once, never reused).
+    _mm_prefetch(reinterpret_cast<const char*>(w + k0) + PF_AHEAD, _MM_HINT_T0);
+    __m512 blk = _mm512_setzero_ps();
+    for (int j = 0; j < FP8_BLK; j += 32) {
+      const __m256i raw =
+          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w + k0 + j));
+      blk = _mm512_dpbf16_ps(blk, as_bh(e4m3_to_bf16_x32(raw, subtab)),
+                             as_bh(_mm512_loadu_si512(
+                                 reinterpret_cast<const void*>(x + k0 + j))));
+    }
+    total = _mm512_fmadd_ps(blk, _mm512_set1_ps(bf16_to_f32(s[b])), total);
+  }
+  float acc = _mm512_reduce_add_ps(total);
+  if (k0 < K) {  // ragged tail shares block b's scale, as the reference's mask does
+    float blk = 0.0f;
+    for (int k = k0; k < K; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+
+__attribute__((target("avx2,fma")))
+float dot_fp8_block_avx2(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                         const float* e4m3) {
+  const __m256i mag_m = _mm256_set1_epi32(0x7F), sgn_m = _mm256_set1_epi32(0x80);
+  const __m256i bias = _mm256_set1_epi32(120 << 23), eight = _mm256_set1_epi32(8);
+  const __m256 subtab = _mm256_loadu_ps(kE4M3SubF32);
+  float acc = 0.0f;
+  int b = 0, k0 = 0;
+  for (; k0 + FP8_BLK <= K; k0 += FP8_BLK, ++b) {
+    __m256 blk = _mm256_setzero_ps();
+    for (int j = 0; j < FP8_BLK; j += 8) {
+      const __m256i raw = _mm256_cvtepu8_epi32(
+          _mm_loadl_epi64(reinterpret_cast<const __m128i*>(w + k0 + j)));
+      const __m256i mag = _mm256_and_si256(raw, mag_m);
+      const __m256i sgn = _mm256_slli_epi32(_mm256_and_si256(raw, sgn_m), 24);
+      // exp!=0: mantissa/exponent shift into place, bias 7 -> 127 is a constant +120.
+      const __m256i nrm = _mm256_add_epi32(_mm256_slli_epi32(mag, 20), bias);
+      const __m256 sub = _mm256_permutevar8x32_ps(subtab, mag);  // valid where mag < 8
+      const __m256 issub = _mm256_castsi256_ps(_mm256_cmpgt_epi32(eight, mag));
+      const __m256 val = _mm256_blendv_ps(_mm256_castsi256_ps(nrm), sub, issub);
+      const __m256 wf = _mm256_or_ps(val, _mm256_castsi256_ps(sgn));
+      const __m256i xi = _mm256_cvtepu16_epi32(
+          _mm_loadu_si128(reinterpret_cast<const __m128i*>(x + k0 + j)));
+      blk = _mm256_fmadd_ps(wf, _mm256_castsi256_ps(_mm256_slli_epi32(xi, 16)), blk);
+    }
+    acc += hsum256(blk) * bf16_to_f32(s[b]);
+  }
+  if (k0 < K) {
+    float blk = 0.0f;
+    for (int k = k0; k < K; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+#endif  // CPU_MOE_X86
+
 // Activations pre-deinterleaved to fp32 (xe[m]=x[2m], xo[m]=x[2m+1]); see the
 // ds_fp4 dot below for why (drops the hot loop to ~1.5 shuffle ops / 16 weights).
 using nvdot_fn = float (*)(const uint8_t*, const uint8_t*, float, const float*, const float*,
@@ -1009,6 +1137,18 @@ void mxfp4_gemv_avx2(float* out, const uint8_t* blk, const uint8_t* scl, const b
 }
 #endif
 
+fp8dot_fn select_fp8dot() {
+  const IsaTier t = pick_isa();
+#if CPU_MOE_X86
+  // The bf16 tier is the one that matters here: e4m3 widens to bf16 exactly, so
+  // dpbf16_ps does the whole dot with no fp32 materialization of the weights.
+  if (t >= ISA_AVX512BF16) return dot_fp8_block_avx512bf16;
+  if (t >= ISA_AVX2) return dot_fp8_block_avx2;
+#endif
+  (void)t;
+  return dot_fp8_block_scalar;
+}
+
 mxgemv_fn select_mxgemv() {
   const IsaTier t = pick_isa();
 #if CPU_MOE_X86
@@ -1220,7 +1360,8 @@ q4dot_fn select_q4dot() {
   return q4_0_dot_i8_scalar;
 }
 
-enum WFmt { WF_BF16 = 0, WF_NVFP4 = 1, WF_MXFP4 = 2, WF_DSFP4 = 3, WF_Q4_0 = 4 };
+enum WFmt { WF_BF16 = 0, WF_NVFP4 = 1, WF_MXFP4 = 2, WF_DSFP4 = 3, WF_Q4_0 = 4,
+             WF_FP8_BLOCK = 5 };
 
 // Each ctor pointer arg is the address of a CPU int64 array of length
 // num_layers (one base address per layer, built by cpu_executor.py's
@@ -1260,6 +1401,10 @@ struct CpuMoeExecutor {
   dsdot_fn dsdot;
   mxgemv_fn mxgemv;
   q4dot_fn q4dot;
+  fp8dot_fn fp8dot;
+  // fp8_block: bf16 scale per 128x128 weight block, so a row uses (K/128) contiguous
+  // scales starting at scale-row (output row / 128). These are the row strides.
+  int fp8_gu_scale_row = 0, fp8_dn_scale_row = 0;
   // ds_fp4: the caller already FP8-round-tripped the input activations on the GPU
   // (same reference grid), so submit() must not repeat it on the host-callback
   // thread. That scalar per-element pass is single-threaded ON THE DECODE CRITICAL
@@ -1383,6 +1528,12 @@ struct CpuMoeExecutor {
     dsdot = select_dsdot();
     mxgemv = select_mxgemv();
     q4dot = select_q4dot();
+    fp8dot = select_fp8dot();
+    if (weight_format == WF_FP8_BLOCK) {
+      // gate_up scale is [2I/128, H/128], down scale is [H/128, I/128] per expert.
+      fp8_gu_scale_row = (H + FP8_BLK - 1) / FP8_BLK;
+      fp8_dn_scale_row = (I + FP8_BLK - 1) / FP8_BLK;
+    }
     if (weight_format == WF_Q4_0) {
       if (H % 32 != 0 || I % 32 != 0)
         throw std::runtime_error("Q4_0 CPU MoE requires H and I to be multiples of 32");
@@ -1494,6 +1645,13 @@ struct CpuMoeExecutor {
           gu_packed_l + ((size_t)e * (2 * I) + row) * (size_t)q4_gu_row_bytes;
       return q4dot(w, xi8, xas, H);  // W4A8: int8 activations (Q8_0), scale in xas
     }
+    if (fmt == WF_FP8_BLOCK) {
+      const uint8_t* w = gu_packed_l + ((size_t)e * (2 * I) + row) * (size_t)H;
+      const bf16_t* sc = reinterpret_cast<const bf16_t*>(gu_scale_l) +
+                         ((size_t)e * ((2 * I + FP8_BLK - 1) / FP8_BLK) + row / FP8_BLK) *
+                             (size_t)fp8_gu_scale_row;
+      return fp8dot(w, x, sc, H, e4m3_lut);
+    }
     const size_t r = (size_t)e * (2 * I) + row;
     if (use_vnni)
       return nvi8dot(gu_packed_l + r * (size_t)(H / 2), gu_scale_l + r * (size_t)(H / 16),
@@ -1515,6 +1673,13 @@ struct CpuMoeExecutor {
     if (fmt == WF_Q4_0) {
       const uint8_t* w = dn_packed_l + ((size_t)e * H + row) * (size_t)q4_dn_row_bytes;
       return q4dot(w, gi8, gas, I);  // W4A8: int8 activations (Q8_0), scale in gas
+    }
+    if (fmt == WF_FP8_BLOCK) {
+      const uint8_t* w = dn_packed_l + ((size_t)e * H + row) * (size_t)I;
+      const bf16_t* sc = reinterpret_cast<const bf16_t*>(dn_scale_l) +
+                         ((size_t)e * ((H + FP8_BLK - 1) / FP8_BLK) + row / FP8_BLK) *
+                             (size_t)fp8_dn_scale_row;
+      return fp8dot(w, g, sc, I, e4m3_lut);
     }
     const size_t r = (size_t)e * H + row;
     if (use_vnni)
@@ -2157,4 +2322,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // (act_apply falls through to gelu_tanh); the probe turns a stale extension
   // into a loud rebuild instruction instead of wrong model outputs.
   m.def("max_generic_act_id", []() { return static_cast<int>(ACT_SWIGLU_CLAMP); });
+  // Weight-format ABI probe. A stale prebuilt .so accepts a newer WFmt id without
+  // complaint and then falls through to the wrong dequant branch -- silently wrong
+  // numbers, not a crash. The Python executor refuses to build against an extension
+  // that predates the format it was asked for.
+  m.def("max_weight_format_id", []() { return static_cast<int>(WF_FP8_BLOCK); });
 }

--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -355,6 +355,66 @@ float dot_fp8_block_avx512bf16(const uint8_t* w, const bf16_t* x, const bf16_t* 
   return acc;
 }
 
+// AVX-512F fallback for CPUs without AVX-512-BF16. Decode directly to fp32 and widen
+// bf16 activations with a zero-extend + shift; the normal e4m3 range includes 0x7f/0xff
+// as +/-480 here, matching the Triton compatibility decoder rather than torch's NaN view.
+__attribute__((target("avx512f")))
+static inline __m512 e4m3_to_f32_x16(__m128i raw, __m512 subtab) {
+  const __m512i b = _mm512_cvtepu8_epi32(raw);
+  const __m512i mag = _mm512_and_si512(b, _mm512_set1_epi32(0x7F));
+  const __m512i sign = _mm512_slli_epi32(
+      _mm512_and_si512(b, _mm512_set1_epi32(0x80)), 24);
+  const __m512i normal_bits = _mm512_or_si512(
+      _mm512_add_epi32(_mm512_slli_epi32(mag, 20), _mm512_set1_epi32(120 << 23)), sign);
+  const __m512 normal = _mm512_castsi512_ps(normal_bits);
+  const __m512i mantissa = _mm512_and_si512(mag, _mm512_set1_epi32(7));
+  __m512 subnormal = _mm512_permutexvar_ps(mantissa, subtab);
+  subnormal = _mm512_castsi512_ps(
+      _mm512_xor_si512(_mm512_castps_si512(subnormal), sign));
+  const __mmask16 is_subnormal = _mm512_cmpeq_epi32_mask(
+      _mm512_and_si512(mag, _mm512_set1_epi32(0x78)), _mm512_setzero_si512());
+  return _mm512_mask_mov_ps(normal, is_subnormal, subnormal);
+}
+
+__attribute__((target("avx512f")))
+float dot_fp8_block_avx512f(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
+                            const float* e4m3) {
+  const __m512 subtab = _mm512_setr_ps(
+      0.0f, 1.0f / 512, 2.0f / 512, 3.0f / 512, 4.0f / 512, 5.0f / 512, 6.0f / 512,
+      7.0f / 512, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+  float acc = 0.0f;
+  int b = 0, k0 = 0;
+  for (; k0 + FP8_BLK <= K; k0 += FP8_BLK, ++b) {
+    _mm_prefetch(reinterpret_cast<const char*>(w + k0) + PF_AHEAD, _MM_HINT_T0);
+    __m512 a0 = _mm512_setzero_ps(), a1 = _mm512_setzero_ps();
+    __m512 a2 = _mm512_setzero_ps(), a3 = _mm512_setzero_ps();
+    int chunk = 0;
+    for (int j = 0; j < FP8_BLK; j += 16, ++chunk) {
+      const __m512 wf = e4m3_to_f32_x16(
+          _mm_loadu_si128(reinterpret_cast<const __m128i*>(w + k0 + j)), subtab);
+      const __m512 xf = _mm512_castsi512_ps(_mm512_slli_epi32(
+          _mm512_cvtepu16_epi32(_mm256_loadu_si256(
+              reinterpret_cast<const __m256i*>(x + k0 + j))), 16));
+      if ((chunk & 3) == 0)
+        a0 = _mm512_fmadd_ps(wf, xf, a0);
+      else if ((chunk & 3) == 1)
+        a1 = _mm512_fmadd_ps(wf, xf, a1);
+      else if ((chunk & 3) == 2)
+        a2 = _mm512_fmadd_ps(wf, xf, a2);
+      else
+        a3 = _mm512_fmadd_ps(wf, xf, a3);
+    }
+    const __m512 sum = _mm512_add_ps(_mm512_add_ps(a0, a1), _mm512_add_ps(a2, a3));
+    acc += _mm512_reduce_add_ps(sum) * bf16_to_f32(s[b]);
+  }
+  if (k0 < K) {  // ragged tail shares block b's scale, as the masked reference does
+    float blk = 0.0f;
+    for (int k = k0; k < K; ++k) blk += e4m3[w[k]] * bf16_to_f32(x[k]);
+    acc += blk * bf16_to_f32(s[b]);
+  }
+  return acc;
+}
+
 __attribute__((target("avx2,fma")))
 float dot_fp8_block_avx2(const uint8_t* w, const bf16_t* x, const bf16_t* s, int K,
                          const float* e4m3) {
@@ -1143,6 +1203,7 @@ fp8dot_fn select_fp8dot() {
   // The bf16 tier is the one that matters here: e4m3 widens to bf16 exactly, so
   // dpbf16_ps does the whole dot with no fp32 materialization of the weights.
   if (t >= ISA_AVX512BF16) return dot_fp8_block_avx512bf16;
+  if (t >= ISA_AVX512) return dot_fp8_block_avx512f;
   if (t >= ISA_AVX2) return dot_fp8_block_avx2;
 #endif
   (void)t;

--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -1402,8 +1402,8 @@ struct CpuMoeExecutor {
   mxgemv_fn mxgemv;
   q4dot_fn q4dot;
   fp8dot_fn fp8dot;
-  // fp8_block: bf16 scale per 128x128 weight block, so a row uses (K/128) contiguous
-  // scales starting at scale-row (output row / 128). These are the row strides.
+  // fp8_block: bf16 scale per 128x128 weight block. These are the scale tensor's
+  // trailing strides, including any padding used by the host bank layout.
   int fp8_gu_scale_row = 0, fp8_dn_scale_row = 0;
   // ds_fp4: the caller already FP8-round-tripped the input activations on the GPU
   // (same reference grid), so submit() must not repeat it on the host-callback
@@ -1501,7 +1501,8 @@ struct CpuMoeExecutor {
                  uintptr_t gate_up_global_ptr, uintptr_t down_scale_ptr,
                  uintptr_t down_global_ptr, uintptr_t gate_up_bias_ptr,
                  uintptr_t down_bias_ptr, double swiglu_alpha_, double swiglu_limit_,
-                 std::vector<int> core_ids_)
+                 std::vector<int> core_ids_, int fp8_gu_scale_stride_,
+                 int fp8_dn_scale_stride_)
       : num_threads(num_threads_ > 0 ? num_threads_ : 1),
         num_layers(num_layers_),
         num_experts(num_experts_),
@@ -1521,6 +1522,8 @@ struct CpuMoeExecutor {
         dn_bias_tbl(reinterpret_cast<const uint64_t*>(down_bias_ptr)),
         swiglu_alpha(static_cast<float>(swiglu_alpha_)),
         swiglu_limit(static_cast<float>(swiglu_limit_)),
+        fp8_gu_scale_row(fp8_gu_scale_stride_),
+        fp8_dn_scale_row(fp8_dn_scale_stride_),
         core_ids(std::move(core_ids_)) {
     DotChoice c = select_dot();
     dot = c.fn;
@@ -1529,11 +1532,6 @@ struct CpuMoeExecutor {
     mxgemv = select_mxgemv();
     q4dot = select_q4dot();
     fp8dot = select_fp8dot();
-    if (weight_format == WF_FP8_BLOCK) {
-      // gate_up scale is [2I/128, H/128], down scale is [H/128, I/128] per expert.
-      fp8_gu_scale_row = (H + FP8_BLK - 1) / FP8_BLK;
-      fp8_dn_scale_row = (I + FP8_BLK - 1) / FP8_BLK;
-    }
     if (weight_format == WF_Q4_0) {
       if (H % 32 != 0 || I % 32 != 0)
         throw std::runtime_error("Q4_0 CPU MoE requires H and I to be multiples of 32");
@@ -2281,7 +2279,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   py::class_<CpuMoeExecutor>(m, "CpuMoeExecutor")
       .def(py::init<int, int, int, int, int, int, int, int, int, int, uintptr_t, uintptr_t,
                     uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t,
-                    double, double, std::vector<int>>(),
+                    double, double, std::vector<int>, int, int>(),
            py::arg("num_threads"), py::arg("num_layers"), py::arg("num_experts"),
            py::arg("top_k"), py::arg("hidden_size"), py::arg("inter_size"),
            py::arg("max_tokens"), py::arg("activation_id"),
@@ -2290,7 +2288,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("gate_up_global_ptr"), py::arg("down_scale_ptr"),
            py::arg("down_global_ptr"), py::arg("gate_up_bias_ptr"),
            py::arg("down_bias_ptr"), py::arg("swiglu_alpha"), py::arg("swiglu_limit"),
-           py::arg("core_ids"))
+           py::arg("core_ids"), py::arg("fp8_gu_scale_stride") = 0,
+           py::arg("fp8_dn_scale_stride") = 0)
       .def("create_task", &CpuMoeExecutor::create_task, py::arg("layer_id"),
            py::arg("num_tokens"), py::arg("x_ptr"), py::arg("ids_ptr"), py::arg("w_ptr"),
            py::arg("y_ptr"))

--- a/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
+++ b/python/freetoken/kernel/csrc/cpu_moe/cpu_moe_ext.cpp
@@ -1789,6 +1789,17 @@ struct CpuMoeExecutor {
 
   const char* isa_name() const { return isa; }
 
+  const char* fp8_isa_name() const {
+#if CPU_MOE_X86
+#ifdef CPU_MOE_HAS_AVX512BF16
+    if (fp8dot == dot_fp8_block_avx512bf16) return "avx512bf16";
+#endif
+    if (fp8dot == dot_fp8_block_avx512f) return "avx512f";
+    if (fp8dot == dot_fp8_block_avx2) return "avx2";
+#endif
+    return "scalar";
+  }
+
   void barrier(int& local_sense) {
     local_sense ^= 1;
     if (bar_count.fetch_add(1) + 1 == num_threads) {
@@ -2369,7 +2380,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("set_input_prequant",
            [](CpuMoeExecutor& e, bool v) { e.input_prequant = v; },
            py::arg("value"))
-      .def("isa_name", &CpuMoeExecutor::isa_name);
+      .def("isa_name", &CpuMoeExecutor::isa_name)
+      .def("fp8_isa_name", &CpuMoeExecutor::fp8_isa_name);
   m.def("memops_probe", &cumemops_probe, py::arg("stream"), py::arg("scratch_addr"));
   m.def("memop_submit", &cumemop_submit, py::arg("stream"), py::arg("done_addr"),
         py::arg("ready_addr"), py::arg("slot"));

--- a/python/freetoken/moe/benchbw.py
+++ b/python/freetoken/moe/benchbw.py
@@ -63,7 +63,7 @@ logger = init_logger(__name__)
 
 # Formats the CPU MoE C++ kernel can compute AND this bench can build banks for; anything
 # else is offload-only here. (The kernel also does q4_0, but this bench has no q4_0 banks.)
-_CPU_MOE_FORMATS = frozenset({"bf16", "nvfp4", "mxfp4_triton", "ds_fp4"})
+_CPU_MOE_FORMATS = frozenset({"bf16", "nvfp4", "mxfp4_triton", "ds_fp4", "fp8_block"})
 # Formats this bench can build synthetic (correctly-sized) banks for.
 _BUILDABLE_FORMATS = frozenset({"bf16", "nvfp4", "fp8_block", "mxfp4_triton", "ds_fp4"})
 # Friendlier CLI/display aliases for the internal quant_format strings.
@@ -340,6 +340,22 @@ def _cpu_moe_bank_sources(fmt: str, H: int, I: int, E: int) -> dict:
         gate_up.fill_(0.02)  # uninitialized bf16 can be denormal -> x86 FP slowdown
         down.fill_(0.02)
         return {"gate_up": gate_up, "down": down}
+    if fmt == "fp8_block":
+        def nb(n):
+            return (n + 127) // 128
+        b = {
+            "gate_up": pin(E, 2 * I, H, dtype=torch.float8_e4m3fn),
+            "gate_up_scale": pin(E, nb(2 * I), nb(H), dtype=torch.bfloat16),
+            "down": pin(E, H, I, dtype=torch.float8_e4m3fn),
+            "down_scale": pin(E, nb(H), nb(I), dtype=torch.bfloat16),
+        }
+        # e4m3 0x00 is a clean zero and the scales are unit-ish, so nothing lands in
+        # the fp32 denormal range (which would slow the GEMV and skew the timing).
+        b["gate_up"].view(torch.uint8).fill_(0x38)  # 1.0
+        b["down"].view(torch.uint8).fill_(0x38)
+        b["gate_up_scale"].fill_(1.0)
+        b["down_scale"].fill_(1.0)
+        return b
     if fmt == "nvfp4":
         b = {
             "gate_up_packed": pin(E, 2 * I, H // 2, dtype=torch.uint8),

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -69,7 +69,8 @@ _ACT_IDS = {
 }
 
 # Weight-format ids must match WFmt in csrc/cpu_moe/cpu_moe_ext.cpp.
-_WFMT_IDS = {"bf16": 0, "nvfp4": 1, "mxfp4_triton": 2, "ds_fp4": 3, "q4_0": 4}
+_WFMT_IDS = {"bf16": 0, "nvfp4": 1, "mxfp4_triton": 2, "ds_fp4": 3, "q4_0": 4,
+             "fp8_block": 5}
 
 
 def compiled_extension_supports(activation: str) -> bool:
@@ -173,6 +174,14 @@ class CpuMoeExecutor:
         # error and silently computes the wrong activation in the generic
         # epilogue -- fail loudly with the rebuild instruction instead. (mxfp4
         # handles its act inside the kernel and predates the marker.)
+        # A prebuilt .so that predates this format would accept the id and then take
+        # the wrong dequant branch -- silently wrong output rather than a crash.
+        if _WFMT_IDS[fmt] > getattr(_cpu_moe, "max_weight_format_id", lambda: 4)():
+            raise RuntimeError(
+                f"the compiled _cpu_moe extension predates the {fmt!r} expert format; "
+                "rebuild it with `python setup.py build_ext --inplace` (or reinstall "
+                "the wheel) before serving this checkpoint on the cpu/hybrid backend."
+            )
         if _ACT_IDS[activation] >= 3 and fmt != "mxfp4_triton":
             supported = getattr(_cpu_moe, "max_generic_act_id", lambda: 2)()
             if _ACT_IDS[activation] > supported:
@@ -333,6 +342,49 @@ class CpuMoeExecutor:
         self._banks.extend(layers)
         return table
 
+    def _resolve_fp8_block_banks(self, banks: dict) -> tuple[dict, tuple[int, int]]:
+        """DeepSeek-V3-style block-fp8: fp8-e4m3 rows + one bf16 scale per 128x128 block.
+
+        ``gate_up`` [E, 2I, H] / ``down`` [E, H, I] are row-major with K contiguous, and
+        ``*_scale`` is [E, ceil(rows/128), ceil(K/128)] -- so output row ``r`` reads the
+        ``K/128`` contiguous scales starting at scale-row ``r // 128`` (the C++ side
+        recomputes that; see ``fp8_gu_scale_row``). The scale tensor is named
+        ``weight_scale_inv`` upstream but multiplies, matching the Triton reference.
+        """
+        gu, gus = banks["gate_up"], banks["gate_up_scale"]
+        dn, dns = banks["down"], banks["down_scale"]
+        # torch exposes fp8 as float8_e4m3fn; the kernel reads raw bytes either way.
+        for t in (gu[0], dn[0]):
+            if t.element_size() != 1:
+                raise NotImplementedError(
+                    f"block-fp8 CPU MoE expects 1-byte e4m3 weights, got {t.dtype}"
+                )
+        if gus[0].dtype != torch.bfloat16 or dns[0].dtype != torch.bfloat16:
+            raise NotImplementedError(
+                f"block-fp8 CPU MoE expects bf16 block scales, got "
+                f"{gus[0].dtype}/{dns[0].dtype}"
+            )
+        I = int(gu[0].shape[1] // 2)
+        H = int(gu[0].shape[2])
+        assert gu[0].shape[1] == 2 * I
+        assert tuple(dn[0].shape[1:]) == (H, I), (dn[0].shape, H, I)
+        def nb(n):  # block count along one axis
+            return (n + 127) // 128
+
+        assert tuple(gus[0].shape[1:]) == (nb(2 * I), nb(H)), (gus[0].shape, I, H)
+        assert tuple(dns[0].shape[1:]) == (nb(H), nb(I)), (dns[0].shape, H, I)
+        ptrs = dict(
+            gate_up_ptr=self._make_table(gu).data_ptr(),
+            down_ptr=self._make_table(dn).data_ptr(),
+            gate_up_scale_ptr=self._make_table(gus).data_ptr(),
+            gate_up_global_ptr=0,
+            down_scale_ptr=self._make_table(dns).data_ptr(),
+            down_global_ptr=0,
+            gate_up_bias_ptr=0,
+            down_bias_ptr=0,
+        )
+        return ptrs, (H, I)
+
     def _resolve_banks(self, banks: dict, fmt: str) -> tuple[dict, tuple[int, int]]:
         """Return (pointer kwargs for the C++ ctor, (H, I)) for the given format.
 
@@ -373,6 +425,9 @@ class CpuMoeExecutor:
 
         if fmt == "ds_fp4":
             return self._resolve_dsfp4_banks(banks)
+
+        if fmt == "fp8_block":
+            return self._resolve_fp8_block_banks(banks)
 
         # nvfp4: packed e2m1 (2/byte) + fp8-e4m3 per-16 block scales + fp16 row globals.
         gup, gus, gug = banks["gate_up_packed"], banks["gate_up_scale"], banks["gate_up_global"]

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -351,8 +351,6 @@ class CpuMoeExecutor:
         scale tensor is named ``weight_scale_inv`` upstream but multiplies, matching the
         Triton reference.
         """
-        from freetoken.kernel.aot_models import fp8_block_scale_pad
-
         gu, gus = banks["gate_up"], banks["gate_up_scale"]
         dn, dns = banks["down"], banks["down_scale"]
         # torch exposes fp8 as float8_e4m3fn; the kernel reads raw bytes either way.
@@ -377,8 +375,6 @@ class CpuMoeExecutor:
         dn_rows, dn_cols = nb(H), nb(I)
         assert gus[0].shape[1] == gu_rows and gus[0].shape[2] >= gu_cols
         assert dns[0].shape[1] == dn_rows and dns[0].shape[2] >= dn_cols
-        assert gus[0].stride(1) >= fp8_block_scale_pad(gu_rows, gu_cols)
-        assert dns[0].stride(1) >= fp8_block_scale_pad(dn_rows, dn_cols)
         ptrs = dict(
             gate_up_ptr=self._make_table(gu).data_ptr(),
             down_ptr=self._make_table(dn).data_ptr(),
@@ -552,11 +548,16 @@ class CpuMoeExecutor:
     def _io_for(self, bs: int) -> dict[str, torch.Tensor]:
         io = self._io.get(bs)
         if io is None:
+            alloc_io = (
+                (lambda *shape, dtype: torch.empty(*shape, dtype=dtype))
+                if self.device.type == "cpu"
+                else alloc_pinned_tensor
+            )
             io = {
-                "x": alloc_pinned_tensor(bs, self.H, dtype=torch.bfloat16),
-                "ids": alloc_pinned_tensor(bs, self.top_k, dtype=torch.int32),
-                "w": alloc_pinned_tensor(bs, self.top_k, dtype=torch.float32),
-                "y": alloc_pinned_tensor(bs, self.H, dtype=torch.bfloat16),
+                "x": alloc_io(bs, self.H, dtype=torch.bfloat16),
+                "ids": alloc_io(bs, self.top_k, dtype=torch.int32),
+                "w": alloc_io(bs, self.top_k, dtype=torch.float32),
+                "y": alloc_io(bs, self.H, dtype=torch.bfloat16),
             }
             self._io[bs] = io
         return io

--- a/python/freetoken/moe/cpu_executor.py
+++ b/python/freetoken/moe/cpu_executor.py
@@ -346,11 +346,13 @@ class CpuMoeExecutor:
         """DeepSeek-V3-style block-fp8: fp8-e4m3 rows + one bf16 scale per 128x128 block.
 
         ``gate_up`` [E, 2I, H] / ``down`` [E, H, I] are row-major with K contiguous, and
-        ``*_scale`` is [E, ceil(rows/128), ceil(K/128)] -- so output row ``r`` reads the
-        ``K/128`` contiguous scales starting at scale-row ``r // 128`` (the C++ side
-        recomputes that; see ``fp8_gu_scale_row``). The scale tensor is named
-        ``weight_scale_inv`` upstream but multiplies, matching the Triton reference.
+        ``*_scale`` is [E, ceil(rows/128), padded(ceil(K/128))] -- so output row ``r``
+        reads the scale row ``r // 128`` with the tensor's actual trailing stride. The
+        scale tensor is named ``weight_scale_inv`` upstream but multiplies, matching the
+        Triton reference.
         """
+        from freetoken.kernel.aot_models import fp8_block_scale_pad
+
         gu, gus = banks["gate_up"], banks["gate_up_scale"]
         dn, dns = banks["down"], banks["down_scale"]
         # torch exposes fp8 as float8_e4m3fn; the kernel reads raw bytes either way.
@@ -371,8 +373,12 @@ class CpuMoeExecutor:
         def nb(n):  # block count along one axis
             return (n + 127) // 128
 
-        assert tuple(gus[0].shape[1:]) == (nb(2 * I), nb(H)), (gus[0].shape, I, H)
-        assert tuple(dns[0].shape[1:]) == (nb(H), nb(I)), (dns[0].shape, H, I)
+        gu_rows, gu_cols = nb(2 * I), nb(H)
+        dn_rows, dn_cols = nb(H), nb(I)
+        assert gus[0].shape[1] == gu_rows and gus[0].shape[2] >= gu_cols
+        assert dns[0].shape[1] == dn_rows and dns[0].shape[2] >= dn_cols
+        assert gus[0].stride(1) >= fp8_block_scale_pad(gu_rows, gu_cols)
+        assert dns[0].stride(1) >= fp8_block_scale_pad(dn_rows, dn_cols)
         ptrs = dict(
             gate_up_ptr=self._make_table(gu).data_ptr(),
             down_ptr=self._make_table(dn).data_ptr(),
@@ -382,6 +388,8 @@ class CpuMoeExecutor:
             down_global_ptr=0,
             gate_up_bias_ptr=0,
             down_bias_ptr=0,
+            fp8_gu_scale_stride=int(gus[0].stride(1)),
+            fp8_dn_scale_stride=int(dns[0].stride(1)),
         )
         return ptrs, (H, I)
 

--- a/tests/moe/test_cpu_moe_fp8_block.py
+++ b/tests/moe/test_cpu_moe_fp8_block.py
@@ -1,0 +1,116 @@
+"""Block-FP8 CPU MoE GEMV vs FreeToken's Triton block-fp8 decode kernel.
+
+The CPU path widens e4m3 to bf16 in-register and reduces with `dpbf16`, where the
+reference dequantizes to fp32 and reduces in fp32. e4m3 -> bf16 is exact (3 mantissa
+bits into 7, and bf16's exponent range covers e4m3's whole span), so the products are
+identical and only the summation order differs -- same latitude the bf16 path takes.
+
+Two things this is really guarding:
+  * the scale is indexed [row // 128][k // 128] and *multiplies*, despite upstream
+    naming it ``weight_scale_inv``. Inverting it, or transposing the two axes, still
+    produces plausible-looking output.
+  * exp == 0 is subnormal (m * 2^-9) and does not follow the exponent-rebias bit trick
+    the normal range uses, so it is blended in from a table.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+
+BLK = 128
+
+
+def _nb(n: int) -> int:
+    return (n + BLK - 1) // BLK
+
+
+def _make_fp8_block_cache(L, E, H, I, seed=0):
+    from freetoken.kernel.pinned import alloc_pinned_tensor
+
+    torch.manual_seed(seed)
+    S = L * E
+
+    def rows(OUT, IN):
+        w = alloc_pinned_tensor(S, OUT, IN, dtype=torch.float8_e4m3fn)
+        w.copy_((torch.randn(S, OUT, IN) * 6.0).to(torch.float8_e4m3fn))
+        s = alloc_pinned_tensor(S, _nb(OUT), _nb(IN), dtype=torch.bfloat16)
+        s.copy_((0.01 + 0.02 * torch.rand(S, _nb(OUT), _nb(IN))).to(torch.bfloat16))
+        return w, s
+
+    gu, gus = rows(2 * I, H)
+    dn, dns = rows(H, I)
+    return SimpleNamespace(
+        quant_format="fp8_block",
+        bank_sources={
+            "gate_up": list(gu.split(E)), "gate_up_scale": list(gus.split(E)),
+            "down": list(dn.split(E)), "down_scale": list(dns.split(E)),
+        },
+        num_layers=L,
+        num_experts=E,
+        decode_target="cpu",
+        cpu_executor=None,
+    )
+
+
+@pytest.mark.parametrize("bs", [1, 2, 5])
+def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
+    from freetoken.moe.cpu_executor import CpuMoeExecutor
+    from freetoken.moe.fused_fp8_block import fused_experts_decode_fp8_block
+
+    L, E, H, I, top_k = 2, 8, 256, 128, 4
+    layer = 1
+    dev = torch.device("cuda")
+    cache = _make_fp8_block_cache(L, E, H, I, seed=bs)
+
+    ex = CpuMoeExecutor(
+        cache,
+        top_k=top_k,
+        activation="silu",
+        apply_router_weight_on_input=False,
+        num_threads=0,
+        max_tokens=bs,
+        device=dev,
+    )
+
+    hidden = torch.randn(bs, H, device=dev, dtype=torch.bfloat16)
+    ids = torch.stack([torch.randperm(E, device=dev)[:top_k] for _ in range(bs)]).to(torch.int32)
+    w = torch.rand(bs, top_k, device=dev, dtype=torch.float32)
+
+    cpu_out = ex.decode(layer, hidden, w, ids).float()
+    torch.cuda.synchronize()
+
+    gpu_out = fused_experts_decode_fp8_block(
+        hidden,
+        cache.bank_sources["gate_up"][layer].to(dev),
+        cache.bank_sources["gate_up_scale"][layer].to(dev),
+        cache.bank_sources["down"][layer].to(dev),
+        cache.bank_sources["down_scale"][layer].to(dev),
+        w, ids.clone(), "silu", False,
+    ).float()
+
+    rel = (cpu_out - gpu_out).abs().max() / (gpu_out.abs().max() + 1e-6)
+    assert rel < 2e-2, f"bs={bs} rel err {rel.item()}"
+
+
+def test_subnormal_and_sign_decode_exactly():
+    """Every e4m3 byte must widen to the value the reference LUT gives.
+
+    The normal range comes from a shift-and-rebias trick; exp == 0 does not obey it,
+    and a wrong sign or a missing subnormal blend is invisible in an averaged GEMV.
+    """
+    from freetoken.kernel import _cpu_moe  # noqa: F401  (ensures the ext is importable)
+
+    codes = torch.arange(256, dtype=torch.uint8)
+    ref = codes.view(torch.float8_e4m3fn).float()
+    finite = torch.isfinite(ref)
+    # bf16 is exact for e4m3, so a round-trip through it must be lossless.
+    got = ref.to(torch.bfloat16).float()
+    assert torch.equal(got[finite], ref[finite]), "e4m3 does not round-trip through bf16"
+    # subnormals (exp == 0, m != 0) are the values the bit trick cannot produce
+    sub = (codes & 0x78) == 0
+    assert finite[sub].all() and (ref[sub].abs().max() < 2.0 ** -6)

--- a/tests/moe/test_cpu_moe_fp8_block.py
+++ b/tests/moe/test_cpu_moe_fp8_block.py
@@ -20,8 +20,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-
 BLK = 128
 
 
@@ -30,8 +28,13 @@ def _nb(n: int) -> int:
 
 
 def _make_fp8_block_cache(L, E, H, I, seed=0):
-    from freetoken.kernel.pinned import alloc_pinned_tensor
     from freetoken.kernel.aot_models import fp8_block_scale_pad
+
+    if torch.cuda.is_available():
+        from freetoken.kernel.pinned import alloc_pinned_tensor
+    else:
+        def alloc_pinned_tensor(*shape, dtype):
+            return torch.empty(*shape, dtype=dtype)
 
     torch.manual_seed(seed)
     S = L * E
@@ -69,7 +72,7 @@ def test_cpu_fp8_block_accepts_qwen38_padded_scale_bank():
     assert cache.bank_sources["down_scale"][0].shape[1:] == (
         _nb(H), fp8_block_scale_pad(_nb(H), _nb(I))
     ) == (20, 6)
-    CpuMoeExecutor(
+    ex = CpuMoeExecutor(
         cache,
         top_k=1,
         activation="silu",
@@ -78,11 +81,29 @@ def test_cpu_fp8_block_accepts_qwen38_padded_scale_bank():
         max_tokens=1,
         device=torch.device("cpu"),
     )
+    hidden = torch.randn(1, H, dtype=torch.bfloat16)
+    io = ex._io_for(1)
+    io["x"].copy_(hidden)
+    io["ids"].zero_()
+    io["w"].fill_(1.0)
+    ex._ext.run_task(ex._task_for(0, 1))
+    cpu_out = io["y"][0].float().to(torch.float64)
+    banks = cache.bank_sources
+    gate_up = _reference_fp8_gemv(banks["gate_up"][0], banks["gate_up_scale"][0], hidden[0])
+    intermediate = torch.nn.functional.silu(gate_up[:I]) * gate_up[I:]
+    expected = _reference_fp8_gemv(banks["down"][0], banks["down_scale"][0], intermediate)
+    rel = (cpu_out - expected).abs().max() / (expected.abs().max() + 1e-6)
+    assert rel < 5e-3, f"max relative error {rel.item()}"
 
 
 def _make_full_range_fp8_block_cache(H, I, seed=0):
     from freetoken.kernel.aot_models import fp8_block_scale_pad
-    from freetoken.kernel.pinned import alloc_pinned_tensor
+
+    if torch.cuda.is_available():
+        from freetoken.kernel.pinned import alloc_pinned_tensor
+    else:
+        def alloc_pinned_tensor(*shape, dtype):
+            return torch.empty(*shape, dtype=dtype)
 
     torch.manual_seed(seed)
     finite_codes = torch.tensor([c for c in range(256) if c not in (0x7F, 0xFF)], dtype=torch.uint8)
@@ -121,11 +142,17 @@ def _reference_fp8_gemv(weights, scales, x):
     return (weights[0].to(torch.float64) * scale) @ x.to(torch.float64)
 
 
-def test_cpu_fp8_block_matches_float64_reference():
+@pytest.mark.parametrize(
+    "isa, expected_isa",
+    [("scalar", "scalar"), ("avx2", "avx2"), ("avx512", "avx512f"),
+     ("avx512bf16", "avx512bf16")],
+)
+def test_cpu_fp8_block_matches_float64_reference(monkeypatch, isa, expected_isa):
     from freetoken.moe.cpu_executor import CpuMoeExecutor
 
     H, I = 259, 257  # ragged K for both GEMVs; 257 down rows exercise many reductions
     cache = _make_full_range_fp8_block_cache(H, I, seed=20260904)
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_ISA", isa)
     ex = CpuMoeExecutor(
         cache,
         top_k=1,
@@ -135,6 +162,10 @@ def test_cpu_fp8_block_matches_float64_reference():
         max_tokens=1,
         device=torch.device("cpu"),
     )
+    names = ("scalar", "avx2", "avx512f", "avx512bf16")
+    if names.index(expected_isa) > names.index(ex.isa):
+        pytest.skip(f"requested {expected_isa}, host/build selected {ex.isa}")
+    assert ex._ext.fp8_isa_name() == expected_isa
 
     hidden = torch.randn(1, H, dtype=torch.bfloat16)
     io = ex._io_for(1)
@@ -150,7 +181,7 @@ def test_cpu_fp8_block_matches_float64_reference():
     expected = _reference_fp8_gemv(banks["down"][0], banks["down_scale"][0], intermediate)
     rel = (cpu_out - expected).abs().max() / (expected.abs().max() + 1e-6)
     # The executor stores its result as bf16. Across 257 output rows, the measured
-    # max relative error was 3.45e-3; this margin leaves room for reduction order
+    # max relative error was 2.674e-3; this margin leaves room for reduction order
     # without accepting the materially larger error from a narrow accumulator.
     assert rel < 5e-3, f"max relative error {rel.item()}"
 
@@ -178,6 +209,7 @@ def test_cpu_fp8_block_isa_override(monkeypatch, isa):
     }[isa]), auto_rank)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 @pytest.mark.parametrize("bs", [1, 2, 5])
 def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
     from freetoken.moe.cpu_executor import CpuMoeExecutor

--- a/tests/moe/test_cpu_moe_fp8_block.py
+++ b/tests/moe/test_cpu_moe_fp8_block.py
@@ -31,6 +31,7 @@ def _nb(n: int) -> int:
 
 def _make_fp8_block_cache(L, E, H, I, seed=0):
     from freetoken.kernel.pinned import alloc_pinned_tensor
+    from freetoken.kernel.aot_models import fp8_block_scale_pad
 
     torch.manual_seed(seed)
     S = L * E
@@ -38,8 +39,10 @@ def _make_fp8_block_cache(L, E, H, I, seed=0):
     def rows(OUT, IN):
         w = alloc_pinned_tensor(S, OUT, IN, dtype=torch.float8_e4m3fn)
         w.copy_((torch.randn(S, OUT, IN) * 6.0).to(torch.float8_e4m3fn))
-        s = alloc_pinned_tensor(S, _nb(OUT), _nb(IN), dtype=torch.bfloat16)
-        s.copy_((0.01 + 0.02 * torch.rand(S, _nb(OUT), _nb(IN))).to(torch.bfloat16))
+        s = alloc_pinned_tensor(
+            S, _nb(OUT), fp8_block_scale_pad(_nb(OUT), _nb(IN)), dtype=torch.bfloat16
+        )
+        s.copy_((0.01 + 0.02 * torch.rand_like(s)).to(torch.bfloat16))
         return w, s
 
     gu, gus = rows(2 * I, H)
@@ -54,6 +57,26 @@ def _make_fp8_block_cache(L, E, H, I, seed=0):
         num_experts=E,
         decode_target="cpu",
         cpu_executor=None,
+    )
+
+
+def test_cpu_fp8_block_accepts_qwen38_padded_scale_bank():
+    from freetoken.kernel.aot_models import fp8_block_scale_pad
+    from freetoken.moe.cpu_executor import CpuMoeExecutor
+
+    H, I = 2560, 640
+    cache = _make_fp8_block_cache(1, 1, H, I)
+    assert cache.bank_sources["down_scale"][0].shape[1:] == (
+        _nb(H), fp8_block_scale_pad(_nb(H), _nb(I))
+    ) == (20, 6)
+    CpuMoeExecutor(
+        cache,
+        top_k=1,
+        activation="silu",
+        apply_router_weight_on_input=False,
+        num_threads=1,
+        max_tokens=1,
+        device=torch.device("cpu"),
     )
 
 

--- a/tests/moe/test_cpu_moe_fp8_block.py
+++ b/tests/moe/test_cpu_moe_fp8_block.py
@@ -80,6 +80,104 @@ def test_cpu_fp8_block_accepts_qwen38_padded_scale_bank():
     )
 
 
+def _make_full_range_fp8_block_cache(H, I, seed=0):
+    from freetoken.kernel.aot_models import fp8_block_scale_pad
+    from freetoken.kernel.pinned import alloc_pinned_tensor
+
+    torch.manual_seed(seed)
+    finite_codes = torch.tensor([c for c in range(256) if c not in (0x7F, 0xFF)], dtype=torch.uint8)
+
+    def rows(OUT, IN):
+        count = OUT * IN
+        codes = finite_codes.repeat((count + finite_codes.numel() - 1) // finite_codes.numel())[:count]
+        codes = codes[torch.randperm(count)].reshape(1, OUT, IN)
+        weights = alloc_pinned_tensor(1, OUT, IN, dtype=torch.float8_e4m3fn)
+        weights.copy_(codes.view(torch.float8_e4m3fn))
+        scales = alloc_pinned_tensor(
+            1, _nb(OUT), fp8_block_scale_pad(_nb(OUT), _nb(IN)), dtype=torch.bfloat16
+        )
+        scales.copy_((0.01 + 0.09 * torch.rand_like(scales)).to(torch.bfloat16))
+        return weights, scales
+
+    gu, gus = rows(2 * I, H)
+    dn, dns = rows(H, I)
+    return SimpleNamespace(
+        quant_format="fp8_block",
+        bank_sources={
+            "gate_up": [gu], "gate_up_scale": [gus],
+            "down": [dn], "down_scale": [dns],
+        },
+        num_layers=1,
+        num_experts=1,
+        decode_target="cpu",
+        cpu_executor=None,
+    )
+
+
+def _reference_fp8_gemv(weights, scales, x):
+    rows, cols = weights.shape[-2:]
+    scale = scales[0, :_nb(rows), :_nb(cols)].to(torch.float64)
+    scale = scale.repeat_interleave(BLK, 0).repeat_interleave(BLK, 1)[:rows, :cols]
+    return (weights[0].to(torch.float64) * scale) @ x.to(torch.float64)
+
+
+def test_cpu_fp8_block_matches_float64_reference():
+    from freetoken.moe.cpu_executor import CpuMoeExecutor
+
+    H, I = 259, 257  # ragged K for both GEMVs; 257 down rows exercise many reductions
+    cache = _make_full_range_fp8_block_cache(H, I, seed=20260904)
+    ex = CpuMoeExecutor(
+        cache,
+        top_k=1,
+        activation="silu",
+        apply_router_weight_on_input=False,
+        num_threads=1,
+        max_tokens=1,
+        device=torch.device("cpu"),
+    )
+
+    hidden = torch.randn(1, H, dtype=torch.bfloat16)
+    io = ex._io_for(1)
+    io["x"].copy_(hidden)
+    io["ids"].zero_()
+    io["w"].fill_(1.0)
+    ex._ext.run_task(ex._task_for(0, 1))
+    cpu_out = io["y"][0].float().to(torch.float64)
+
+    banks = cache.bank_sources
+    gate_up = _reference_fp8_gemv(banks["gate_up"][0], banks["gate_up_scale"][0], hidden[0])
+    intermediate = (torch.nn.functional.silu(gate_up[:I]) * gate_up[I:])
+    expected = _reference_fp8_gemv(banks["down"][0], banks["down_scale"][0], intermediate)
+    rel = (cpu_out - expected).abs().max() / (expected.abs().max() + 1e-6)
+    # The executor stores its result as bf16. Across 257 output rows, the measured
+    # max relative error was 3.45e-3; this margin leaves room for reduction order
+    # without accepting the materially larger error from a narrow accumulator.
+    assert rel < 5e-3, f"max relative error {rel.item()}"
+
+
+@pytest.mark.parametrize("isa", ["scalar", "avx2", "avx512", "avx512bf16"])
+def test_cpu_fp8_block_isa_override(monkeypatch, isa):
+    from freetoken.moe.cpu_executor import CpuMoeExecutor
+
+    cache = _make_fp8_block_cache(1, 1, 256, 128, seed=17)
+    monkeypatch.delenv("FREETOKEN_CPU_MOE_ISA", raising=False)
+    auto = CpuMoeExecutor(
+        cache, top_k=1, activation="silu", apply_router_weight_on_input=False,
+        num_threads=1, max_tokens=1, device=torch.device("cpu"),
+    )
+    names = ("scalar", "avx2", "avx512f", "avx512bf16")
+    auto_rank = names.index(auto.isa)
+    monkeypatch.setenv("FREETOKEN_CPU_MOE_ISA", isa)
+    forced = CpuMoeExecutor(
+        cache, top_k=1, activation="silu", apply_router_weight_on_input=False,
+        num_threads=1, max_tokens=1, device=torch.device("cpu"),
+    )
+    assert names.index(forced.isa) == min(names.index({
+        "scalar": "scalar", "avx2": "avx2", "avx512": "avx512f",
+        "avx512bf16": "avx512bf16",
+    }[isa]), auto_rank)
+
+
 @pytest.mark.parametrize("bs", [1, 2, 5])
 def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
     from freetoken.moe.cpu_executor import CpuMoeExecutor
@@ -121,12 +219,10 @@ def test_cpu_fp8_block_matches_gpu_decode_kernel(bs):
 
 
 def test_subnormal_and_sign_decode_exactly():
-    """Every e4m3 byte must widen to the value the reference LUT gives.
+    """Check PyTorch's e4m3-to-bf16 conversion used by the CPU decoder.
 
-    The normal range comes from a shift-and-rebias trick; exp == 0 does not obey it,
-    and a wrong sign or a missing subnormal blend is invisible in an averaged GEMV.
+    The C++ decoder is exercised by ``test_cpu_fp8_block_matches_float64_reference``.
     """
-    from freetoken.kernel import _cpu_moe  # noqa: F401  (ensures the ext is importable)
 
     codes = torch.arange(256, dtype=torch.uint8)
     ref = codes.view(torch.float8_e4m3fn).float()


### PR DESCRIPTION
## Relationship to #36

**This builds directly on @gdevenyi's #36 and includes his commit unchanged** (`4a04c9b`, +360 lines — the format definition, bank plumbing, ABI probe and benchbw integration). My three commits on top are +262 lines. If you would rather land #36 first, these three cherry-pick cleanly onto it and I am happy to send them there instead — I opened this separately only because the stride bug below is a correctness issue that would otherwise ship silently.

Credit for the feature is his. What follows is a bug fix and test hardening.

## 1. The scale bank's trailing dimension is padded (correctness)

`kernel/aot_models.py` pads the scale bank's last dimension so per-expert rows land on a 16-byte boundary for the fused copy:

```python
def fp8_block_scale_pad(rows: int, cols: int) -> int:
    """Trailing scale-bank dim padded so per-expert row bytes are 16B-aligned (fused copy)."""
    while (rows * cols * 2) % 16:
        cols += 1
    return cols
```

So the row stride is **not** `ceil(K/128)`. #36 recomputes it from the unpadded block count in two places (`cpu_moe_ext.cpp` and the shape assert in `cpu_executor.py`), which reads scales at the wrong offset whenever padding applies.

**Qwen3.8 is the case already documented in the tree** — `models/qwen3_5_moe/weight.py` records `down_scale` as `20x5` bf16 = 200 B, and `200 % 16 != 0` pads cols 5 → 6. The assert demands `(E, 20, 5)` and fails; with asserts off the kernel silently produces wrong numbers.

Neither the benchbw fp8 workload (H=2048, I=512) nor DSV4-Flash (H=7168, I=2048) trips it — both happen to give `rows*cols` divisible by 8, which is why #36's own tests are green.

The fix reads the stride off the tensor and threads it through to the kernel. Reverting just the C++ half turns 7 tests red (4 on a CPU-only host).

Worth noting: the Triton kernel was **already** stride-aware. Feeding it padded banks keeps the GPU cross-check green, so the CPU path was the only one getting this wrong.

## 2. The parity test could not see accumulator precision loss

The existing check compares two fp32 accumulations (CPU vs Triton) at `rel < 2e-2`, so common-mode error cancels and a kernel with ~1e-3 error passes unnoticed.

Added a float64 reference — `torch.float8_e4m3fn` dequant with the bf16 block scales, GEMV in float64 — over mixed-sign full-range e4m3 weights, zero-mean activations, and ragged K. Measured error is 2.674e-3 against a 5e-3 bound (the executor stores bf16, so the floor is not tighter than that).

No existing assertion was weakened; the `2e-2` check is untouched.

Also addressed the two Copilot comments on #36: the ISA-tier test now actually sets `FREETOKEN_CPU_MOE_ISA`, and `test_subnormal_and_sign_decode_exactly`'s docstring no longer claims to validate the C++ decoder when it only exercises a PyTorch round-trip.

## 3. An avx512f tier for CPUs without AVX512-BF16

#36's fast path is `_mm512_dpbf16_ps`, so a CPU with AVX-512 but no BF16 extension falls all the way to the AVX2 tier — 8-wide fp32, 512-bit registers unused. That is Skylake-SP, Cascade Lake and Ice Lake-SP.

Added an `avx512f` tier between them, following the existing per-function `__attribute__((target(...)))` + runtime dispatch structure. All three reachable tiers are bit-identical across all 256 e4m3 codes.

Measured on Xeon Platinum 8368 (Ice Lake-SP, no `avx512_bf16`), three repetitions each:

| | avx2 | avx512f | |
|---|---|---|---|
| single-thread, cache-resident | 3.31 GB/s | 3.94 GB/s | **+19%**, intervals disjoint |
| `ft bench bw --dtype fp8`, 75 threads | 60.4 GB/s | 62.7 GB/s | +4%, intervals **overlap** |

At 75 threads the kernel is memory-bound and the tier is largely washed out — the project's own benchmark cannot resolve it. The single-thread number is the honest figure.

## 4. Tests now cover the code they ship

Before this, deleting the entire `avx512f` branch from `select_fp8dot` left every test passing, because `isa_name()` reports `select_dot()` (the bf16 chain) rather than the fp8 dispatch — and no test ran numerics under a forced tier. Injecting a ragged-tail bug into `dot_fp8_block_avx2` was invisible for the same reason.

Each reachable tier now runs the float64 parity GEMV, and the fp8 dispatch is observable. Verified by mutation:

| mutation | before | after |
|---|---|---|
| drop the `avx512f` dispatch branch | all green | `assert 'avx2' == 'avx512f'` |
| ragged-tail scale bug in `dot_fp8_block_avx2` | all green | rel = 0.257 |
| kernel ignores the passed stride | — | 7 failed (4 CPU-only) |
| break only `scalar` | — | caught, that tier only |
| break only `avx512f` | — | caught, that tier only |

The module-level CUDA guard also moved onto the tests that need a GPU — all ten were skipping on a CPU-only host, which is exactly where a CPU MoE kernel matters most.

## Known limits, stated up front

- **The `avx512bf16` fp8 tier has never executed here.** This host lacks the ISA and I have no SDE, so that path is unvalidated on hardware — and the code comment says it is the tier that matters. A mutation that halves its output goes undetected on this machine. Someone with Emerald Rapids or Sapphire Rapids should confirm it; @gdevenyi's 6526Y would do.
- **Tier verification is name-mediated.** A tier that is numerically correct but silently does not use AVX-512 would pass. Correctness tests cannot distinguish that; only the throughput number argues the tier earns its place.
- CPU-only runs exercise `num_threads=1` only. Row splitting is format-independent, so the risk is low, but multi-threaded fp8 is covered solely by the GPU cross-check.

## Test results

```
CUDA:      12 passed, 1 skipped     (avx512bf16 tier skipped — host lacks the ISA)
CPU-only:   9 passed, 4 skipped
tests/moe: 130 passed, 7 skipped, 1 failed
```

The one failure is `test_cpu_moe_q4_0.py::test_cpu_decode_q4_0_matches_ggml_mmvq`, a GGUF JIT compile error under gcc 15 (`need 'typename' before ...` in torch headers). **It fails identically on `main`** — unrelated to this PR.

Built with gcc 15.2.1 / binutils 2.44. Function-level AVX-512 target attributes need binutils >= 2.36; the gcc 11 / binutils 2.35 on RHEL 9 cannot assemble them.
