### PR TITLE
fix(models): serve qwen4_exp FTW checkpoints with PLE streamed from source

### DIFF
--- a/python/freetoken/models/qwen4_exp/weight.py
+++ b/python/freetoken/models/qwen4_exp/weight.py
@@ -215,6 +215,21 @@ def _ple_table_files(folder: str) -> list[str]:
     """Shards holding a piece of the n-gram table, from the index when there is one."""
     index = os.path.join(folder, "model.safetensors.index.json")
     if not os.path.exists(index):
+        # FTW checkpoints carry no safetensors index -- and the converter never
+        # writes the PLE table (iter_weights skips ngram_embedding.*). Stream it
+        # from the conversion source recorded in the FTW index instead.
+        from freetoken.checkpoint.ftw import INDEX_NAME, is_ftw_checkpoint
+
+        if is_ftw_checkpoint(folder):
+            with open(os.path.join(folder, INDEX_NAME), encoding="utf-8") as fh:
+                src = json.load(fh).get("source_model_path")
+            if src and os.path.isdir(src):
+                return _ple_table_files(src)
+            raise ValueError(
+                f"FTW checkpoint {folder} holds no PLE n-gram table and its "
+                f"conversion source {src!r} is missing; re-convert with the "
+                "source present or serve the safetensors checkpoint directly"
+            )
         return sorted(iter_weight_files(folder))
     with open(index, encoding="utf-8") as fh:
         weight_map = json.load(fh)["weight_map"]


### PR DESCRIPTION
Problem: serving a converted FTW checkpoint of Qwen3.8-Flash-Next-NVFP4 fails during load_host_tables with ValueError: PLE shard indices are not contiguous 0..N-1: []. The conversion itself succeeds.

Root cause: convert_checkpoint stores dense weights and expert banks only. qwen4_exp iter_weights deliberately skips ngram_embedding.* (the table loads via load_ple_table), and the safetensors index is intentionally not copied. So _ple_table_files finds no index and no *.safetensors in the FTW dir and resolves zero files, for both the disk (resolve_row_source) and pinned (load_ple_table) paths.

Change (python/freetoken/models/qwen4_exp/weight.py, _ple_table_files only): when the folder is an FTW checkpoint, read source_model_path from freetoken_weight.json and resolve the PLE shards from the conversion source. Missing source raises an actionable error instead of the empty-list message.

Verification: _ple_table_files on the nvidia safetensors dir still resolves the single model-fp8-mtp-ple.safetensors file; a synthetic FTW dir pointing at it resolves identically; a dangling source raises the new error; plain non-index dirs keep the legacy fallback. tests/models/qwen4_exp/test_config.py: 8 passed.

Scope: qwen4_exp PLE resolution only. No Laguna changes.