### PR TITLE
fix(qwen3_5_moe): accept a per-channel fp8 weight_scale in the dense loader

### DIFF
--- a/python/freetoken/models/qwen3_5_moe/weight.py
+++ b/python/freetoken/models/qwen3_5_moe/weight.py
@@ -311,9 +311,30 @@ _PT_BF16_FUSE: dict[str, tuple[str, ...]] = {
 }
 
 
-def _per_row_scale(scalar: torch.Tensor, rows: int) -> torch.Tensor:
-    """Per-tensor scalar -> per-output-row fp32 vector ``[rows]`` (exact broadcast)."""
-    return scalar.reshape(1).to(torch.float32).expand(rows)
+def _per_row_scale(scale: torch.Tensor, rows: int) -> torch.Tensor:
+    """FP8 weight scale -> per-output-row fp32 vector ``[rows]``, which is what
+    ``Fp8PerTensorLinear.weight_scale`` wants whichever on-disk shape arrives:
+
+    * **per-tensor** (``strategy: "tensor"``) -- one scalar for the whole weight, broadcast
+      across the rows. Exact.
+    * **per-channel** (``strategy: "channel"``) -- ``[rows, 1]``, already one scalar per row,
+      so the reshape alone is enough. This case is why the per-tensor ``reshape(1)`` cannot be
+      unconditional: on a per-channel checkpoint it raises ``RuntimeError: shape '[1]' is
+      invalid for input of size <rows>``.
+
+    Any other element count is raised on rather than broadcast: a silently mis-shaped scale
+    would be applied to the wrong output rows and produce plausible garbage.
+    """
+    flat = scale.reshape(-1).to(torch.float32)
+    if flat.numel() == 1:
+        return flat.expand(rows)
+    if flat.numel() != rows:
+        raise ValueError(
+            f"fp8 weight_scale has {flat.numel()} elements for a weight with {rows} output "
+            f"rows (shape {tuple(scale.shape)}); expected either 1 (per-tensor) or {rows} "
+            "(per-channel)"
+        )
+    return flat
 
 
 def _pt_fp8_fuse(base: str, weight: torch.Tensor, scalar: torch.Tensor,

--- a/tests/models/test_qwen3_5_moe_weight.py
+++ b/tests/models/test_qwen3_5_moe_weight.py
@@ -1,0 +1,54 @@
+"""qwen3_5_moe dense weight-loader helpers: the fp8 ``weight_scale`` shape contract.
+
+``_per_row_scale`` is what turns whatever ``weight_scale`` a compressed-tensors or modelopt
+checkpoint puts on disk into the per-output-row fp32 vector ``Fp8PerTensorLinear.weight_scale``
+declares. Both on-disk granularities are exercised, plus the refusal that keeps a mis-shaped
+scale from being applied to the wrong output rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from freetoken.models.qwen3_5_moe.weight import _per_row_scale
+
+_ROWS = 7
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 1)])
+def test_per_tensor_scale_broadcasts_to_every_row(shape):
+    """``strategy: "tensor"`` -- one scalar for the whole weight."""
+    out = _per_row_scale(torch.full(shape, 0.25), _ROWS)
+    assert out.shape == (_ROWS,)
+    assert out.dtype == torch.float32
+    assert out.tolist() == [0.25] * _ROWS
+
+
+@pytest.mark.parametrize("shape", [(_ROWS, 1), (1, _ROWS), (_ROWS,)])
+def test_per_channel_scale_keeps_row_order(shape):
+    """``strategy: "channel"`` -- already one scalar per row; order must survive the reshape.
+
+    Order is asserted with distinct values rather than a set/sum: permuting the scales would
+    keep every aggregate identical while silently scaling each output row by another row's
+    factor.
+    """
+    values = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]
+    out = _per_row_scale(torch.tensor(values).reshape(shape), _ROWS)
+    assert out.shape == (_ROWS,)
+    assert out.dtype == torch.float32
+    assert out.tolist() == values
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])
+def test_scale_is_promoted_to_fp32_from_any_storage_dtype(dtype):
+    out = _per_row_scale(torch.ones(_ROWS, 1, dtype=dtype), _ROWS)
+    assert out.dtype == torch.float32
+
+
+@pytest.mark.parametrize("shape", [(3, 1), (_ROWS + 1, 1), (2, 3)])
+def test_a_mismatched_scale_raises_instead_of_broadcasting(shape):
+    """Neither 1 nor ``rows`` elements: raise. Broadcasting row 0 over every output row would
+    load without error and serve fluent, wrong tokens."""
+    with pytest.raises(ValueError, match="expected either 1"):
+        _per_row_scale(torch.ones(shape), _ROWS)


### PR DESCRIPTION
Hit this while trying to load a compressed-tensors FP8 checkpoint that uses per-channel weight scales. `_per_row_scale` assumes the scale is always a single scalar:

```python
return scalar.reshape(1).to(torch.float32).expand(rows)
```

That's right for `strategy: "tensor"`, but llm-compressor also emits `strategy: "channel"` -- one scalar per output row, stored as `[rows, 1]`. On that shape the reshape blows up:

```
RuntimeError: shape '[1]' is invalid for input of size 248320
```

Since `Fp8PerTensorLinear.weight_scale` is already declared per output row, there's nothing to change downstream -- a genuine per-tensor weight just stores the same scalar in every row. So this reshapes to `[-1]` and branches on the element count: 1 broadcasts exactly as before, `rows` passes straight through.

The part I'd push back on if I were reviewing: the third branch raises instead of doing something lenient. That's deliberate. If a mis-shaped scale broadcast row 0's factor across all 248320 output rows, the model would load happily and generate fluent nonsense. I'd much rather it fail at load with a message naming both counts.

### Reachability, since it affects how you want to review this

You can't trigger this on `main` today. The only checkpoints that reach `_iter_weights_attn_fp8` are ModelOpt ones, and those use a per-tensor scale. So on `main` this is hardening plus a prerequisite -- it becomes load-bearing once a per-channel checkpoint can actually route there, which needs the compressed-tensors detection from #390 plus a one-token widening to accept `"channel"`.

I mention it so you can weigh it as "small safe change that unblocks a checkpoint class" rather than "fixes a bug users are hitting", because the latter would be overselling it.

### Tests

Adds `tests/models/test_qwen3_5_moe_weight.py`, modelled on `tests/models/test_glm5_next_config.py`. Covers both on-disk granularities, fp32 promotion from every storage dtype, and the mismatch raising. The per-channel case asserts row *order* with distinct values rather than a sum or a set -- permuting the scales would keep every aggregate identical while silently scaling each row by the wrong factor.

There were no `test_qwen3_5_moe_*` files before this, so nothing is replaced.

### Testing done

Verified against `unsloth/Qwen3.6-35B-A3B-NVFP4-Fast` and `nvidia/Qwen3.6-35B-A3B-NVFP4` on an RTX 4080 SUPER (16 GiB, sm_89, TP=1). Full background and measurements in #252.

