### PR TITLE
refactor(quant): hand the checkpoint QuantConfig to the weight readers

### DIFF
--- a/python/freetoken/engine/config.py
+++ b/python/freetoken/engine/config.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, List
 
 import torch
 from freetoken.distributed import DistributedInfo
-from freetoken.models.register import _load_attr, get_model_spec
+from freetoken.layers.quantization import set_quant_config
+from freetoken.models.register import _load_attr, checkpoint_quant_config, get_model_spec
 from freetoken.utils import cached_load_hf_config, init_logger
-from freetoken.utils.hf import optional_hf_file
 
 if TYPE_CHECKING:
     from freetoken.models import ModelConfig
@@ -104,9 +104,10 @@ class EngineConfig:
     @cached_property
     def model_config(self) -> ModelConfig:
         spec = get_model_spec(self.hf_config.architectures[0])
+        quant = checkpoint_quant_config(self.model_path, self.hf_config, spec)
+        set_quant_config(quant)
         parse_config = _load_attr(spec.module, spec.parse_config)
-        model_config = parse_config(self.hf_config)
-        return replace(model_config, quant=checkpoint_quant_config(self.model_path, self.hf_config, spec))
+        return replace(parse_config(self.hf_config), quant=quant)
 
     @property
     def max_seq_len(self) -> int:
@@ -121,25 +122,3 @@ class EngineConfig:
     @property
     def distributed_addr(self) -> str:
         return "tcp://127.0.0.1:2333"
-
-
-def checkpoint_quant_config(model_path: str, hf_config: Any, spec: Any):
-    """The checkpoint's QuantConfig under the family's naming, or None for GGUF, whose native-quant ops the shared parser does not model yet."""
-    from freetoken.layers.quantization import NameMap, QuantConfig
-
-    if spec.parse_config == "parse_gguf_config":
-        return None
-    # NOTE: ModelOpt exports before 0.41 keep the quantization config only in hf_quant_config.json, and the weight download fetches nothing but the safetensors shards, so this sidecar is fetched on its own.
-    hf_quant_config = None
-    sidecar = optional_hf_file(model_path, "hf_quant_config.json")
-    if sidecar is not None:
-        import json
-
-        with open(sidecar) as f:
-            hf_quant_config = json.load(f)
-    return QuantConfig.from_hf(
-        hf_config,
-        name_map=NameMap(roots=spec.checkpoint_roots, segments=spec.checkpoint_segments, packed=spec.packed_modules_mapping),
-        unquantized=spec.unquantized_modules,
-        hf_quant_config=hf_quant_config,
-    )

--- a/python/freetoken/layers/quantization/__init__.py
+++ b/python/freetoken/layers/quantization/__init__.py
@@ -32,8 +32,10 @@ from .configs import (
     Mxfp4Config,
     NoQuantConfig,
     QuantConfig,
+    get_quant_config,
     quant_method_for,
     quantization_config_of,
+    set_quant_config,
 )
 
 __all__ = [
@@ -46,5 +48,5 @@ __all__ = [
     "UnquantizedMoEMethod", "Fp8BlockMoEMethod", "Nvfp4MoEMethod", "Mxfp4MoEMethod", "Mxfp8MoEMethod",
     "QuantBackend", "set_quant_backend", "get_quant_backend", "NameMap",
     "QuantConfig", "NoQuantConfig", "ModelOptConfig", "CompressedTensorsConfig", "Fp8BlockConfig", "Mxfp4Config",
-    "quant_method_for", "quantization_config_of", "finalize_quant",
+    "quant_method_for", "quantization_config_of", "set_quant_config", "get_quant_config", "finalize_quant",
 ]

--- a/python/freetoken/layers/quantization/configs/__init__.py
+++ b/python/freetoken/layers/quantization/configs/__init__.py
@@ -15,8 +15,24 @@ def quant_method_for(quant_config, layer, prefix: str):
     return (quant_config if quant_config is not None else _NO_QUANT).get_quant_method(layer, prefix)
 
 
+_UNSET = object()
+_QUANT_CONFIG = _UNSET
+
+
+def set_quant_config(quant: QuantConfig | None) -> None:
+    """Install the checkpoint's QuantConfig for the weight readers, which only get the model path; EngineConfig sets it once."""
+    global _QUANT_CONFIG
+    _QUANT_CONFIG = quant
+
+
+def get_quant_config() -> QuantConfig | None:
+    if _QUANT_CONFIG is _UNSET:
+        raise RuntimeError("no QuantConfig installed: EngineConfig.model_config sets it before the weights load")
+    return _QUANT_CONFIG
+
+
 __all__ = [
-    "QuantConfig", "quantization_config_of", "quant_method_for",
+    "QuantConfig", "quantization_config_of", "quant_method_for", "set_quant_config", "get_quant_config",
     "NoQuantConfig", "ModelOptConfig", "CompressedTensorsConfig", "Fp8BlockConfig", "Mxfp4Config",
     "compressed_tensors", "fp8", "modelopt", "mxfp4",
 ]

--- a/python/freetoken/models/register.py
+++ b/python/freetoken/models/register.py
@@ -241,10 +241,33 @@ def _load_attr(module_path: str, attr_name: str) -> Any:
     return getattr(module, attr_name)
 
 
+def checkpoint_quant_config(model_path: str, hf_config: Any, spec: ModelSpec):
+    """The checkpoint's QuantConfig under the family's naming, or None for GGUF, whose native-quant ops the shared parser does not model yet."""
+    from freetoken.layers.quantization import NameMap, QuantConfig
+    from freetoken.utils.hf import optional_hf_file
+
+    if spec.parse_config == "parse_gguf_config":
+        return None
+    # NOTE: ModelOpt exports before 0.41 keep the quantization config only in hf_quant_config.json, and the weight download fetches nothing but the safetensors shards, so this sidecar is fetched on its own.
+    hf_quant_config = None
+    sidecar = optional_hf_file(model_path, "hf_quant_config.json")
+    if sidecar is not None:
+        import json
+
+        with open(sidecar) as f:
+            hf_quant_config = json.load(f)
+    return QuantConfig.from_hf(
+        hf_config,
+        name_map=NameMap(roots=spec.checkpoint_roots, segments=spec.checkpoint_segments, packed=spec.packed_modules_mapping),
+        unquantized=spec.unquantized_modules,
+        hf_quant_config=hf_quant_config,
+    )
+
+
 def get_model_class(model_architecture: str, model_config: ModelConfig):
     spec = get_model_spec(model_architecture)
     model_cls = _load_attr(spec.module, spec.model_cls)
     return model_cls(model_config)
 
 
-__all__ = ["ModelSpec", "get_model_spec", "get_model_class"]
+__all__ = ["ModelSpec", "checkpoint_quant_config", "get_model_spec", "get_model_class"]

--- a/tests/models/test_quant_config.py
+++ b/tests/models/test_quant_config.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 
 from freetoken.distributed.info import set_tp_info, try_get_tp_info
-from freetoken.engine.config import EngineConfig, checkpoint_quant_config
+from freetoken.engine.config import EngineConfig
 from freetoken.layers import set_rope_device
 from freetoken.layers.quantization import (
     CompressedTensorsConfig,
@@ -42,7 +42,7 @@ from freetoken.layers.quantization.linear import (
 from freetoken.layers.quantization.moe import Fp8BlockMoEMethod, Mxfp4MoEMethod, Nvfp4MoEMethod, UnquantizedMoEMethod
 from freetoken.models import create_model
 from freetoken.models.gpt_oss.moe import GptOssMoELayer, GptOssOffloadMoELayer
-from freetoken.models.register import get_model_spec
+from freetoken.models.register import checkpoint_quant_config, get_model_spec
 from freetoken.utils.torch_utils import torch_dtype
 
 MODELS = "/mnt/nvme/models"


### PR DESCRIPTION
Weight readers only get the model path and cannot reach the QuantConfig the engine builds. This hands it over without touching reader signatures:

- `checkpoint_quant_config` moves from `engine/config.py` to `models/register.py`, next to the `ModelSpec` fields it interprets.
- `set_quant_config` / `get_quant_config`: `EngineConfig.model_config` installs the checkpoint's QuantConfig before parsing the family config; readers read it. Unset raises; `None` is the GGUF value. One per process, like `set_quant_backend`.

No reader uses it yet, so nothing loads differently.

Prerequisite for the qwen4_exp block-fp8 dense reader.
