### PR TITLE
qwen4_exp: build o_proj row-parallel, as every other family does

### DIFF
--- a/python/freetoken/models/qwen4_exp/attention.py
+++ b/python/freetoken/models/qwen4_exp/attention.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import torch
 from freetoken.core import get_global_ctx
-from freetoken.layers import BaseOP, GemmaPlusOneRMSNorm, LinearColParallelMerged, LinearReplicated
+from freetoken.layers import BaseOP, GemmaPlusOneRMSNorm, LinearColParallelMerged, LinearOProj, LinearReplicated
 from freetoken.layers.rotary import get_rope
 from freetoken.utils import nvtx_annotate
 
@@ -128,7 +128,11 @@ class Qwen4ExpAttention(BaseOP):
             config.hidden_size, self._qkv_split, has_bias=False,
             quant_config=config.quant, prefix=f"{prefix}.qkv_proj",
         )
-        self.o_proj = LinearReplicated(
+        # Row-parallel, as every other family builds o_proj: qkv_proj is column-parallel, so a
+        # rank's attention output is its local head slice and the partial sums need an
+        # all-reduce. At TP=1 this is LinearReplicated exactly -- div_even(x, 1) == x and the
+        # all-reduce is skipped -- so it is a no-op today and correct when #385 lands.
+        self.o_proj = LinearOProj(
             self.qo_attn_dim, config.hidden_size, has_bias=False,
             quant_config=config.quant, prefix=f"{prefix}.o_proj",
         )


### PR DESCRIPTION
`qwen4_exp` is the only family that builds its attention `o_proj` as `LinearReplicated`. llama, gpt_oss and minimax_m2 all use `LinearOProj`.

That is correct at TP=1 and wrong under TP>1 in three ways at once. `qkv_proj` is column-parallel, so a rank's attention output is its local head slice rather than the full `qo_attn_dim`; `o_proj` therefore has to take the sharded input dim; and the partial sums need an all-reduce. `LinearReplicated` keeps the full `[hidden, qo_attn_dim]` weight, expects the unsharded input, and reduces nothing. The loader already assumes the row-parallel layout — `_shard` puts `o_proj` on dim 1.

It also fails quietly. A missing all-reduce leaves each rank holding a partial sum that still decodes to fluent-looking text, so there is no crash to catch it.

`LinearOProj` degenerates to exactly `LinearReplicated` at TP=1: `div_even(x, 1) == x`, and the all-reduce is skipped when `tp_size == 1`. So this is a no-op for `main` as it stands, and only changes what #385 finds when the two meet. It adds no constraint from calling `get_tp_info()` in `__init__` either — the same constructor already reaches it two lines up through `LinearColParallelMerged`, so that path was engine-only before and still is.

The comment above the branch also promised a row-parallel `o_proj` that the code did not build; it now describes what is there.

Verified at TP=1 on an RTX PRO 4000 Blackwell: the built `o_proj` is a `LinearOProj` with weight `[hidden, qo_attn_dim]` and `local_input_size == qo_attn_dim`, and its forward is bit-identical (max |diff| = 0.0) to a `LinearReplicated` carrying the same weight, on CPU and on CUDA. `tests/models/qwen4_exp/` shows the same pass/fail set with and without the change.

Raised by @gdevenyi on #392 as a merge hazard against #385. Split out here so it can land on its own — #392's reader half is superseded by #428.
