### PR TITLE
fix(server): resolve JSON Schema refs and union types in tool arguments

### DIFF
--- a/python/freetoken/server/function_call_parser.py
+++ b/python/freetoken/server/function_call_parser.py
@@ -347,15 +347,84 @@ class BaseFormatDetector(ABC):
                 return i
         return 0
 
+    def _resolve_local_ref(self, schema: Dict, root_schema: Dict) -> Dict:
+        """Resolve local refs such as #/$defs/Foo."""
+        if not isinstance(schema, dict):
+            return schema
+        ref = schema.get("$ref")
+        if not isinstance(ref, str) or not ref.startswith("#/"):
+            return schema
+        node = root_schema
+        try:
+            for part in ref[2:].split("/"):
+                part = part.replace("~1", "/").replace("~0", "~")
+                node = node[part]
+        except (KeyError, TypeError):
+            return schema
+        if not isinstance(node, dict):
+            return schema
+        merged = dict(node)
+        merged.update({k: v for k, v in schema.items() if k != "$ref"})
+        if "$ref" in merged:
+            return self._resolve_local_ref(merged, root_schema)
+        return merged
+
+    def _normalize_param_schema(self, schema: Dict, root_schema: Dict) -> Dict:
+        """Resolve the schema parts needed for tool argument typing."""
+        if not isinstance(schema, dict):
+            return {"type": "string"}
+        schema = self._resolve_local_ref(schema, root_schema)
+        param_type = schema.get("type")
+        if isinstance(param_type, list):
+            non_null = [t for t in param_type if t != "null"]
+            result = dict(schema)
+            result["type"] = non_null[0] if len(non_null) == 1 else "loose"
+            return result
+        if isinstance(param_type, str):
+            return schema
+        for keyword in ("oneOf", "anyOf"):
+            branches = schema.get(keyword)
+            if not isinstance(branches, list):
+                continue
+            types = []
+            for branch in branches:
+                if not isinstance(branch, dict):
+                    continue
+                branch = self._resolve_local_ref(branch, root_schema)
+                branch_type = branch.get("type")
+                if isinstance(branch_type, str) and branch_type != "null":
+                    types.append(branch_type)
+            types = list(dict.fromkeys(types))
+            result = dict(schema)
+            result["type"] = types[0] if len(types) == 1 else "loose"
+            return result
+        if isinstance(schema.get("properties"), dict):
+            result = dict(schema)
+            result["type"] = "object"
+            return result
+        if isinstance(schema.get("items"), (dict, list)):
+            result = dict(schema)
+            result["type"] = "array"
+            return result
+        result = dict(schema)
+        result["type"] = "loose"
+        return result
+
     def _get_param_config(self, func_name: str, tools: List[Tool]) -> Dict:
-        """Extract the parameter properties (JSON schema) for one tool."""
+        """Extract and normalize parameter properties for one tool."""
         for tool in tools:
-            if tool.function.name == func_name and tool.function.parameters:
-                params = tool.function.parameters
-                if isinstance(params, dict) and "properties" in params:
-                    return params["properties"]
-                elif isinstance(params, dict):
-                    return params
+            if tool.function.name != func_name or not tool.function.parameters:
+                continue
+            params = tool.function.parameters
+            if not isinstance(params, dict):
+                return {}
+            properties = params.get("properties")
+            if not isinstance(properties, dict):
+                return params
+            return {
+                name: self._normalize_param_schema(prop, params)
+                for name, prop in properties.items()
+            }
         return {}
 
     def _convert_param_value(self, value: str, param_name: str, param_config: Dict, func_name: str) -> Any:
@@ -392,6 +461,8 @@ class BaseFormatDetector(ABC):
                     return ast.literal_eval(value)
                 except (ValueError, SyntaxError, TypeError):
                     return value
+        elif param_type == "loose":
+            return _parse_loose_json_value(value)
         return value
 
     def _schema_param_type(self, param_name: str, param_config: Dict, missing: str = "string") -> str:

--- a/python/freetoken/server/function_call_parser.py
+++ b/python/freetoken/server/function_call_parser.py
@@ -347,13 +347,24 @@ class BaseFormatDetector(ABC):
                 return i
         return 0
 
-    def _resolve_local_ref(self, schema: Dict, root_schema: Dict) -> Dict:
-        """Resolve local refs such as #/$defs/Foo."""
+    def _resolve_local_ref(self, schema: Dict, root_schema: Dict, _seen: Optional[set[str]] = None,) -> Dict:
+        """
+        Resolve local JSON Schema references.
+
+        Unresolvable or cyclic references are returned unresolved. Their values
+        therefore follow the parser's existing loose/untyped conversion behavior.
+        """
         if not isinstance(schema, dict):
             return schema
         ref = schema.get("$ref")
         if not isinstance(ref, str) or not ref.startswith("#/"):
             return schema
+        if _seen is None:
+            _seen = set()
+        if ref in _seen:
+            # Cyclic ref: stop resolution and preserve the unresolved schema.
+            return schema
+        _seen.add(ref)
         node = root_schema
         try:
             for part in ref[2:].split("/"):
@@ -366,7 +377,7 @@ class BaseFormatDetector(ABC):
         merged = dict(node)
         merged.update({k: v for k, v in schema.items() if k != "$ref"})
         if "$ref" in merged:
-            return self._resolve_local_ref(merged, root_schema)
+            return self._resolve_local_ref(merged, root_schema, _seen)
         return merged
 
     def _normalize_param_schema(self, schema: Dict, root_schema: Dict) -> Dict:

--- a/python/freetoken/server/function_call_parser.py
+++ b/python/freetoken/server/function_call_parser.py
@@ -421,22 +421,27 @@ class BaseFormatDetector(ABC):
         result["type"] = "loose"
         return result
 
-    def _get_param_config(self, func_name: str, tools: List[Tool]) -> Dict:
-        """Extract and normalize parameter properties for one tool."""
+    def _get_tool_schema(self, func_name: str, tools: List[Tool]) -> Dict:
+        """Return the root JSON schema for one tool."""
         for tool in tools:
             if tool.function.name != func_name or not tool.function.parameters:
                 continue
             params = tool.function.parameters
-            if not isinstance(params, dict):
-                return {}
-            properties = params.get("properties")
-            if not isinstance(properties, dict):
-                return params
-            return {
-                name: self._normalize_param_schema(prop, params)
-                for name, prop in properties.items()
-            }
+            return params if isinstance(params, dict) else {}
         return {}
+
+    def _get_param_config(self, func_name: str, tools: List[Tool]) -> Dict:
+        """Extract and normalize parameter properties for one tool."""
+        params = self._get_tool_schema(func_name, tools)
+        if not params:
+            return {}
+        properties = params.get("properties")
+        if not isinstance(properties, dict):
+            return params
+        return {
+            name: self._normalize_param_schema(prop, params)
+            for name, prop in properties.items()
+        }
 
     def _convert_param_value(self, value: str, param_name: str, param_config: Dict, func_name: str) -> Any:
         """Convert parameter value based on schema type. Safe alternative to eval()."""
@@ -2673,18 +2678,23 @@ class MiniMaxM3Detector(BaseFormatDetector):
                     return v
         return raw
 
-    def _nested_value(self, raw: str, schema: Any = None) -> Any:
+    def _nested_value(self, raw: str, schema: Any = None, root_schema: Any = None) -> Any:
+        if isinstance(schema, dict) and isinstance(root_schema, dict):
+            schema = self._normalize_param_schema(schema, root_schema)
         items, stray = self._scan_elements(raw)
         if not items:
             return self._typed_leaf(raw, schema)
-        return self._structure(items, schema, stray=stray)
+        return self._structure(items, schema, root_schema=root_schema, stray=stray)
 
-    def _structure(self, items: List[tuple], schema: Any = None, stray: str = "") -> Any:
+    def _structure(self, items: List[tuple], schema: Any = None, root_schema: Any = None, stray: str = "") -> Any:
         """Composite value from scanned elements, threading the JSON schema down
         (``properties`` / ``items`` / ``additionalProperties``). Only ``<item>``
         children render as a bare array -- the template's array convention;
         repeated siblings under any other tag stay an object with an array-valued
         key. Mixed text+children keeps the text under ``"$text"``."""
+        if isinstance(schema, dict) and isinstance(root_schema, dict):
+            schema = self._normalize_param_schema(schema, root_schema)
+        
         props = schema.get("properties") if isinstance(schema, dict) else None
         item_schema = schema.get("items") if isinstance(schema, dict) else None
 
@@ -2694,11 +2704,13 @@ class MiniMaxM3Detector(BaseFormatDetector):
                 ap = schema.get("additionalProperties")
                 if isinstance(ap, dict):
                     sub = ap
+            if isinstance(sub, dict) and isinstance(root_schema, dict):
+                sub = self._normalize_param_schema(sub, root_schema)
             return sub
 
         names = {k for k, _ in items}
         if names == {"item"}:
-            return [self._nested_value(raw, item_schema) for _, raw in items]
+            return [self._nested_value(raw, item_schema, root_schema=root_schema) for _, raw in items]
         counts: Dict[str, int] = {}
         for k, _ in items:
             counts[k] = counts.get(k, 0) + 1
@@ -2714,7 +2726,7 @@ class MiniMaxM3Detector(BaseFormatDetector):
                 and str(sub.get("type", "")).lower() == "array"
             ):
                 sub = sub.get("items")
-            value = self._nested_value(raw, sub)
+            value = self._nested_value(raw, sub, root_schema=root_schema)
             if key in out:
                 prev = out[key]
                 out[key] = (prev if isinstance(prev, list) else [prev]) + [value]
@@ -2725,16 +2737,19 @@ class MiniMaxM3Detector(BaseFormatDetector):
         return out
 
     def _args_from_items(
-        self, func_name: str, items: List[tuple], tools: List[Tool]
+        self, func_name: str, items: List[tuple], tools: List[Tool],
     ) -> Dict:
+        root_schema = self._get_tool_schema(func_name, tools)
         config = self._get_param_config(func_name, tools)
         args: Dict[str, Any] = {}
         for key, raw in items:
             prop = config.get(key) if isinstance(config, dict) and key in config else None
             nested, stray = self._scan_elements(raw)
             if nested:
-                value: Any = self._structure(nested, prop, stray=stray)
+                value: Any = self._structure(nested, prop, root_schema=root_schema, stray=stray)
             else:
+                if isinstance(prop, dict) and isinstance(root_schema, dict):
+                    prop = self._normalize_param_schema(prop, root_schema)
                 value = self._typed_leaf(raw, prop)
             if key in args:
                 prev = args[key]

--- a/tests/server/test_function_call_parser_schema_resolution.py
+++ b/tests/server/test_function_call_parser_schema_resolution.py
@@ -1,0 +1,703 @@
+"""JSON Schema resolution in schema-aware tool argument parsing
+(server/function_call_parser.py): $ref chains, unions and implicit containers,
+plus MiniMax-M3's recursive nesting -- one-shot and streaming.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from freetoken.server.function_call_parser import Function, FunctionCallParser, Tool
+
+
+# Formats that route parameter values through _convert_param_value(); the rest
+# parse arguments from their own JSON grammar and ignore the declared schema.
+SCHEMA_AWARE_PARSERS = [
+    "glm47",
+    "qwen3_coder",
+    "minimax",
+    "minimax_m3",
+    "muse_glimmer",
+]
+
+MINIMAX_M3_NS = "]<]minimax[>["
+
+
+def _tool(prop_schema: dict, root_extra: dict | None = None, *, param_name: str = "limit") -> list[Tool]:
+    parameters = {
+        "type": "object",
+        "properties": {
+            param_name: prop_schema,
+        },
+    }
+
+    if root_extra:
+        parameters.update(root_extra)
+
+    return [
+        Tool(
+            function=Function(
+                name="schema_test",
+                parameters=parameters,
+            )
+        )
+    ]
+
+
+def _wire(parser_name: str, raw: str, *, param_name: str = "limit") -> str:
+    if parser_name == "qwen3_coder":
+        return (
+            "<tool_call>"
+            "<function=schema_test>"
+            f"<parameter={param_name}>{raw}</parameter>"
+            "</function>"
+            "</tool_call>"
+        )
+
+    if parser_name == "glm47":
+        return (
+            "<tool_call>schema_test"
+            f"<arg_key>{param_name}</arg_key>"
+            f"<arg_value>{raw}</arg_value>"
+            "</tool_call>"
+        )
+
+    if parser_name == "minimax":
+        return (
+            "<minimax:tool_call>"
+            '<invoke name="schema_test">'
+            f'<parameter name="{param_name}">{raw}</parameter>'
+            "</invoke>"
+            "</minimax:tool_call>"
+        )
+
+    if parser_name == "minimax_m3":
+        ns = MINIMAX_M3_NS
+        return (
+            f"{ns}<tool_call>\n"
+            f'{ns}<invoke name="schema_test">'
+            f"{ns}<{param_name}>{raw}{ns}</{param_name}>"
+            f"{ns}</invoke>\n"
+            f"{ns}</tool_call>"
+        )
+
+    if parser_name == "muse_glimmer":
+        return (
+            "<|start|>assistant to=schema_test<|message|>"
+            "<atem:function_calls>\n"
+            '<atem:invoke name="schema_test">\n'
+            f'<atem:parameter name="{param_name}">{raw}</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+            "<|eot|>"
+        )
+
+    raise AssertionError(f"Missing wire fixture for parser {parser_name!r}")
+
+
+def _assemble_streamed_calls(calls) -> list[tuple[str, dict]]:
+    """Reassemble streamed calls the way a client does: a fragment naming a tool
+    opens a call, the argument fragments after it concatenate into its JSON."""
+    assembled: list[list] = []
+
+    for call in calls:
+        if call.name is not None:
+            assembled.append([call.name, []])
+
+        if call.parameters:
+            assert assembled, f"argument fragment before any call name: {call!r}"
+            assembled[-1][1].append(call.parameters)
+
+    return [(name, json.loads("".join(parts) or "{}")) for name, parts in assembled]
+
+
+def _parse_args(parser_name: str, prop_schema: dict, root_extra: dict | None, raw: str, *, streaming: bool, param_name: str = "limit") -> dict:
+    tools = _tool(prop_schema, root_extra, param_name=param_name)
+    text = _wire(parser_name, raw, param_name=param_name)
+
+    parser = FunctionCallParser(tools, tool_call_parser=parser_name)
+
+    if not streaming:
+        result = parser.parse_non_stream(text)
+
+        assert len(result.calls) == 1, result
+        assert result.calls[0].name == "schema_test"
+
+        return json.loads(result.calls[0].parameters)
+
+    calls = []
+
+    # Small chunks deliberately split XML/control markers and parameter values.
+    for i in range(0, len(text), 7):
+        _, emitted = parser.parse_stream_chunk(text[i : i + 7])
+        calls.extend(emitted)
+
+    # Drain any wire-order-deferred output.
+    for _ in range(4):
+        normal, emitted = parser.parse_stream_chunk("")
+        calls.extend(emitted)
+
+        if not normal and not emitted:
+            break
+
+    # End-of-stream hooks in the serving layer's order (generation.py): finalize
+    # closes a call cut off mid-arguments, finish releases held-back text.
+    calls.extend(parser.finalize_stream())
+    parser.finish_stream()
+
+    assembled = _assemble_streamed_calls(calls)
+
+    assert len(assembled) == 1, (parser_name, calls)
+    assert assembled[0][0] == "schema_test"
+
+    return assembled[0][1]
+
+
+SCHEMA_CASES = [
+    # Existing behaviour: direct concrete types.
+    pytest.param(
+        {"type": "integer"},
+        None,
+        "5",
+        5,
+        id="direct-integer",
+    ),
+    pytest.param(
+        {"type": "string"},
+        None,
+        "5",
+        "5",
+        id="direct-string-preserved",
+    ),
+
+    # Single local $ref.
+    pytest.param(
+        {"$ref": "#/$defs/Limit"},
+        {
+            "$defs": {
+                "Limit": {"type": "integer"},
+            }
+        },
+        "5",
+        5,
+        id="ref-integer",
+    ),
+
+    # Chained $ref.
+    pytest.param(
+        {"$ref": "#/$defs/A"},
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"type": "integer"},
+            }
+        },
+        "5",
+        5,
+        id="ref-chain",
+    ),
+
+    # Draft-07 style definitions should work too: the resolver accepts generic
+    # local JSON pointers, not only $defs.
+    pytest.param(
+        {"$ref": "#/definitions/Limit"},
+        {
+            "definitions": {
+                "Limit": {"type": "integer"},
+            }
+        },
+        "5",
+        5,
+        id="legacy-definitions-ref",
+    ),
+
+    # JSON Pointer escaping: ~1 => / and ~0 => ~.
+    pytest.param(
+        {"$ref": "#/$defs/A~1B~0C"},
+        {
+            "$defs": {
+                "A/B~C": {"type": "integer"},
+            }
+        },
+        "5",
+        5,
+        id="json-pointer-escaping",
+    ),
+
+    # oneOf / anyOf concrete type.
+    pytest.param(
+        {
+            "oneOf": [
+                {"type": "integer"},
+            ]
+        },
+        None,
+        "5",
+        5,
+        id="oneof-integer",
+    ),
+    pytest.param(
+        {
+            "anyOf": [
+                {"type": "integer"},
+            ]
+        },
+        None,
+        "5",
+        5,
+        id="anyof-integer",
+    ),
+
+    # Nullable unions.
+    pytest.param(
+        {
+            "oneOf": [
+                {"type": "integer"},
+                {"type": "null"},
+            ]
+        },
+        None,
+        "5",
+        5,
+        id="oneof-nullable-integer",
+    ),
+    pytest.param(
+        {
+            "anyOf": [
+                {"type": "integer"},
+                {"type": "null"},
+            ]
+        },
+        None,
+        "5",
+        5,
+        id="anyof-nullable-integer",
+    ),
+    pytest.param(
+        {
+            "type": ["integer", "null"],
+        },
+        None,
+        "5",
+        5,
+        id="type-array-nullable-integer",
+    ),
+
+    # A union member may itself be a $ref.
+    pytest.param(
+        {
+            "oneOf": [
+                {"$ref": "#/$defs/Limit"},
+                {"type": "null"},
+            ]
+        },
+        {
+            "$defs": {
+                "Limit": {"type": "integer"},
+            }
+        },
+        "5",
+        5,
+        id="oneof-ref-nullable",
+    ),
+
+    # Referenced structured values must remain JSON structures rather than
+    # escaped strings.
+    pytest.param(
+        {"$ref": "#/$defs/Ids"},
+        {
+            "$defs": {
+                "Ids": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                }
+            }
+        },
+        "[1, 2, 3]",
+        [1, 2, 3],
+        id="ref-array",
+    ),
+    pytest.param(
+        {"$ref": "#/$defs/Options"},
+        {
+            "$defs": {
+                "Options": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {"type": "integer"},
+                    },
+                }
+            }
+        },
+        '{"limit": 5}',
+        {"limit": 5},
+        id="ref-object",
+    ),
+
+    # JSON Schema does not require an explicit "type" if structure already
+    # establishes the effective container kind.
+    pytest.param(
+        {
+            "properties": {
+                "limit": {"type": "integer"},
+            }
+        },
+        None,
+        '{"limit": 5}',
+        {"limit": 5},
+        id="implicit-object",
+    ),
+    pytest.param(
+        {
+            "items": {
+                "type": "integer",
+            }
+        },
+        None,
+        "[1, 2]",
+        [1, 2],
+        id="implicit-array",
+    ),
+
+    # The PR intentionally uses loose JSON parsing when no single concrete type
+    # can be inferred.
+    pytest.param(
+        {
+            "oneOf": [
+                {"type": "integer"},
+                {"type": "string"},
+            ]
+        },
+        None,
+        "5",
+        5,
+        id="ambiguous-union-loose-json",
+    ),
+]
+
+
+@pytest.mark.parametrize("parser_name", SCHEMA_AWARE_PARSERS)
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+@pytest.mark.parametrize(
+    ("prop_schema", "root_extra", "raw", "expected"),
+    SCHEMA_CASES,
+)
+def test_schema_aware_parsers_resolve_indirect_schema_types(
+    parser_name,
+    streaming,
+    prop_schema,
+    root_extra,
+    raw,
+    expected,
+):
+    args = _parse_args(
+        parser_name,
+        prop_schema,
+        root_extra,
+        raw,
+        streaming=streaming,
+    )
+
+    assert args == {"limit": expected}
+
+
+# ---------------------------------------------------------------------------
+# Broken / recursive references must never take the request path down.
+# ---------------------------------------------------------------------------
+REF_EDGE_CASES = [
+    pytest.param(
+        {"$ref": "#/$defs/Missing"},
+        None,
+        id="dangling-local-ref",
+    ),
+    pytest.param(
+        {"$ref": "https://example.invalid/schema.json#/Limit"},
+        None,
+        id="external-ref",
+    ),
+    pytest.param(
+        {"$ref": "#/$defs/A"},
+        {
+            "$defs": {
+                "A": "not-a-schema",
+            }
+        },
+        id="ref-to-non-object-def",
+    ),
+    pytest.param(
+        {"$ref": "#/$defs/A/name"},
+        {
+            "$defs": {
+                "A": "not-a-container",
+            }
+        },
+        id="ref-through-non-object-def",
+    ),
+    pytest.param(
+        {"$ref": "#/$defs/A"},
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/A"},
+            }
+        },
+        id="self-referential-ref",
+    ),
+    pytest.param(
+        {"$ref": "#/$defs/A"},
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            }
+        },
+        id="mutually-recursive-ref",
+    ),
+]
+
+
+@pytest.mark.parametrize("parser_name", SCHEMA_AWARE_PARSERS)
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+@pytest.mark.parametrize(
+    ("prop_schema", "root_extra"),
+    REF_EDGE_CASES,
+)
+def test_schema_ref_edge_cases_terminate_without_crashing(parser_name, streaming, prop_schema, root_extra):
+    args = _parse_args(
+        parser_name,
+        prop_schema,
+        root_extra,
+        "5",
+        streaming=streaming,
+    )
+
+    # An unresolvable ref leaves the parameter untyped: the same loose JSON
+    # fallback as an ambiguous union, so "5" -> 5 and never a dropped parameter.
+    assert args == {"limit": 5}
+
+
+# ---------------------------------------------------------------------------
+# Compatibility guards
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("parser_name", SCHEMA_AWARE_PARSERS)
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+def test_explicit_string_schema_never_loose_parses_json_literals(parser_name, streaming):
+    args = _parse_args(
+        parser_name,
+        {"type": "string"},
+        None,
+        "123",
+        streaming=streaming,
+    )
+
+    assert args == {"limit": "123"}
+
+
+@pytest.mark.parametrize("parser_name", SCHEMA_AWARE_PARSERS)
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+def test_nullable_string_schema_preserves_numeric_looking_string(parser_name, streaming):
+    args = _parse_args(
+        parser_name,
+        {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "null"},
+            ]
+        },
+        None,
+        "123",
+        streaming=streaming,
+    )
+
+    assert args == {"limit": "123"}
+
+
+# ---------------------------------------------------------------------------
+# MiniMax-M3 threads the schema through nested XML
+# ---------------------------------------------------------------------------
+def _m3_tools(properties: dict, **root_extra) -> list[Tool]:
+    """One ``schema_test`` tool: ``properties`` plus any extra root keywords."""
+    return [
+        Tool(
+            function=Function(
+                name="schema_test",
+                parameters={"type": "object", "properties": properties, **root_extra},
+            )
+        )
+    ]
+
+
+def _m3_call(body: str) -> str:
+    """Wrap an invoke body in MiniMax-M3's namespace-delimited wire form."""
+    ns = MINIMAX_M3_NS
+
+    return (
+        f"{ns}<tool_call>\n"
+        f'{ns}<invoke name="schema_test">'
+        f"{body}"
+        f"{ns}</invoke>\n"
+        f"{ns}</tool_call>"
+    )
+
+
+_M3_NODE_DEFS = {
+    "$defs": {
+        "Node": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string"},
+                "count": {"type": "integer"},
+                "child": {"$ref": "#/$defs/Node"},
+            },
+        }
+    }
+}
+
+
+def _minimax_m3_recursive_tools() -> list[Tool]:
+    return _m3_tools({"node": {"$ref": "#/$defs/Node"}}, **_M3_NODE_DEFS)
+
+
+def _minimax_m3_recursive_wire() -> str:
+    ns = MINIMAX_M3_NS
+
+    return _m3_call(
+        f"{ns}<node>"
+        f"{ns}<code>1{ns}</code>"
+        f"{ns}<count>2{ns}</count>"
+        f"{ns}<child>"
+        f"{ns}<code>5{ns}</code>"
+        f"{ns}<count>6{ns}</count>"
+        f"{ns}</child>"
+        f"{ns}</node>"
+    )
+
+
+def _parse_minimax_m3(tools: list[Tool], text: str, *, streaming: bool) -> dict:
+    """Parse one MiniMax-M3 call through whichever path is under test."""
+    parser = FunctionCallParser(tools, tool_call_parser="minimax_m3")
+
+    if not streaming:
+        result = parser.parse_non_stream(text)
+
+        assert len(result.calls) == 1, result
+        assert result.calls[0].name == "schema_test"
+
+        return json.loads(result.calls[0].parameters)
+
+    calls = []
+
+    # Small chunks deliberately split NS markers and element boundaries. M3 emits
+    # each call in one piece at its closing marker, so no extra drain is needed.
+    for i in range(0, len(text), 7):
+        _, emitted = parser.parse_stream_chunk(text[i : i + 7])
+        calls.extend(emitted)
+
+    calls.extend(parser.finalize_stream())
+    parser.finish_stream()
+
+    assembled = _assemble_streamed_calls(calls)
+
+    assert len(assembled) == 1, (calls,)
+    assert assembled[0][0] == "schema_test"
+
+    return assembled[0][1]
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+def test_minimax_m3_nested_ref_keeps_nested_schema_typing(streaming):
+    args = _parse_minimax_m3(
+        _minimax_m3_recursive_tools(),
+        _minimax_m3_recursive_wire(),
+        streaming=streaming,
+    )
+
+    assert args == {
+        "node": {
+            "code": "1",
+            "count": 2,
+            "child": {
+                "code": "5",
+                "count": 6,
+            },
+        }
+    }
+
+
+# Below the top level: an array's "items" schema and an implicitly-array nested
+# property both used to lose typing and arrive as the verbatim string.
+MINIMAX_M3_NESTED_CASES = [
+    pytest.param(
+        _m3_tools(
+            {
+                "ids": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/Id"},
+                }
+            },
+            **{"$defs": {"Id": {"type": "integer"}}},
+        ),
+        _m3_call(
+            f"{MINIMAX_M3_NS}<ids>"
+            f"{MINIMAX_M3_NS}<item>1{MINIMAX_M3_NS}</item>"
+            f"{MINIMAX_M3_NS}<item>2{MINIMAX_M3_NS}</item>"
+            f"{MINIMAX_M3_NS}</ids>"
+        ),
+        {"ids": [1, 2]},
+        id="array-items-ref",
+    ),
+    pytest.param(
+        _m3_tools(
+            {
+                "payload": {
+                    "type": "object",
+                    "properties": {
+                        # No explicit "type": only the structure says array.
+                        "cell": {"items": {"type": "integer"}},
+                    },
+                }
+            }
+        ),
+        _m3_call(
+            f"{MINIMAX_M3_NS}<payload>"
+            f"{MINIMAX_M3_NS}<cell>1{MINIMAX_M3_NS}</cell>"
+            f"{MINIMAX_M3_NS}<cell>2{MINIMAX_M3_NS}</cell>"
+            f"{MINIMAX_M3_NS}</payload>"
+        ),
+        {"payload": {"cell": [1, 2]}},
+        id="repeated-key-implicit-array",
+    ),
+]
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+@pytest.mark.parametrize(("tools", "text", "expected"), MINIMAX_M3_NESTED_CASES)
+def test_minimax_m3_nested_schema_typing_below_the_top_level(tools, text, expected, streaming):
+    assert _parse_minimax_m3(tools, text, streaming=streaming) == expected
+
+
+# ---------------------------------------------------------------------------
+# Frontier: only MiniMax-M3 recurses into nested markup
+# ---------------------------------------------------------------------------
+# The other formats read a parameter value as opaque text; pinning that makes
+# teaching them to recurse a deliberate change.
+FLAT_SCHEMA_AWARE_PARSERS = [name for name in SCHEMA_AWARE_PARSERS if name != "minimax_m3"]
+
+
+@pytest.mark.parametrize("parser_name", FLAT_SCHEMA_AWARE_PARSERS)
+@pytest.mark.parametrize("streaming", [False, True], ids=["one-shot", "streaming"])
+def test_nested_markup_in_parameter_value_stays_opaque_outside_minimax_m3(parser_name, streaming):
+    args = _parse_args(
+        parser_name,
+        {
+            "type": "object",
+            "properties": {"code": {"type": "string"}},
+        },
+        None,
+        "<code>1</code>",
+        streaming=streaming,
+        param_name="node",
+    )
+
+    assert args == {"node": "<code>1</code>"}


### PR DESCRIPTION
## Summary

This PR fixes incorrect argument type serialization in the `qwen3_coder` tool-call parser when tool parameter schemas use indirect JSON Schema definitions such as:

- `$ref`
- chained `$ref`
- `oneOf`
- `anyOf`
- nullable unions
- referenced objects
- referenced arrays

Previously, `qwen3_coder` determined the type of a tool parameter primarily from the parameter's direct `type` field.

Schemas such as:

```json
{
  "limit": {
    "$ref": "#/$defs/Limit"
  }
}
```

therefore had no directly available `type`.

The parser fell back to treating the value as a string, even if the referenced schema declared an integer, object, or array.

For example:

```json
{
  "$defs": {
    "Limit": {
      "type": "integer"
    }
  }
}
```

could incorrectly result in:

```json
{
  "limit": "10"
}
```

instead of:

```json
{
  "limit": 10
}
```

This becomes especially problematic when using MCP tools or other tools generated from JSON Schema, where `$ref`, `$defs`, `oneOf`, and `anyOf` are common.

The resulting OpenAI-compatible `function.arguments` payload can be valid JSON while still containing incorrect JSON types, causing downstream schema validation to fail with errors.

## Root cause

The parameter configuration used by the tool-call parser only retained the contents of `properties`.

As a consequence, root-level schema information such as `$defs` was no longer available when determining the effective type of individual parameters.

Additionally, parameter type detection relied on the equivalent of:

```python
prop.get("type", "string")
```

This means schemas using:

```json
{
  "$ref": "#/$defs/Foo"
}
```

or:

```json
{
  "oneOf": [
    {"type": "integer"},
    {"type": "null"}
  ]
}
```

were effectively treated as strings.

For structured values this was particularly harmful.

A referenced object such as:

```json
{
  "options": {
    "$ref": "#/$defs/SearchOptions"
  }
}
```

could previously be serialized as:

```json
{
  "options": "{\"limit\":10,\"language\":\"en\"}"
}
```

instead of:

```json
{
  "options": {
    "limit": 10,
    "language": "en"
  }
}
```

## Changes

This PR adds JSON Schema normalization/resolution before `qwen3_coder` decides how a parameter value should be serialized.

The implementation handles local JSON Pointer references such as:

```text
#/$defs/Foo
```

and preserves access to the root schema so referenced definitions can be resolved.

The effective parameter schema is normalized before tool argument conversion.

The new behavior includes support for:

### `$ref`

```json
{
  "limit": {
    "$ref": "#/$defs/Limit"
  }
}
```

with:

```json
{
  "$defs": {
    "Limit": {
      "type": "integer"
    }
  }
}
```

is resolved as an integer.

### Chained `$ref`

References pointing to another reference are followed until the effective schema is found.

For example:

```text
LimitAlias -> Limit -> integer
```

is correctly resolved as an integer.

### Referenced objects

Object schemas referenced through `$ref` are treated as objects rather than JSON-encoded strings.

### Referenced arrays

Array schemas referenced through `$ref` preserve their array representation.

### `oneOf` and `anyOf`

Simple union schemas are normalized when they contain a single effective non-null type.

For example:

```json
{
  "oneOf": [
    {"type": "integer"},
    {"type": "null"}
  ]
}
```

is treated as an integer for tool argument parsing.

The same behavior applies to equivalent `anyOf` schemas.

### Nullable type arrays

Schemas such as:

```json
{
  "type": ["object", "null"]
}
```

can resolve to their non-null effective type.

### Ambiguous schemas

Schemas for which a single concrete type cannot safely be inferred use loose JSON parsing instead of automatically coercing the argument to a string.

Explicit string schemas continue to remain strings.

This is important so values that look like JSON but are intentionally declared as strings are not unexpectedly converted.

## Why this matters for MCP

MCP servers frequently expose tool `inputSchema` definitions generated by libraries such as Pydantic, Zod, TypeBox, or other JSON Schema generators.

These schemas commonly make use of `$defs`, `$ref`, `oneOf`, and `anyOf`.

Before this fix, a model could produce a semantically correct tool call, but FreeToken could change its types while translating the Qwen XML tool-call representation into OpenAI-compatible `function.arguments`.

For example, the model could effectively generate:

```xml
<parameter=options>
{"limit": 10, "language": "en"}
</parameter>
```

but the downstream API could receive:

```json
{
  "options": "{\"limit\": 10, \"language\": \"en\"}"
}
```

This PR preserves the intended JSON structure and types.

---

# Validation

The fix was tested against a running FreeToken server on using Qwen3.6-35B-A3B-FP8 with the `qwen3_coder` tool-call parser.

Both non-streaming and streaming OpenAI-compatible responses were validated.

## Test 1 — Direct integer type

Schema:

```json
{
  "limit": {
    "type": "integer"
  }
}
```

Result:

```json
{
  "query": "foo=bar",
  "limit": 10
}
```

Status: PASS

This verifies that existing direct-type behavior remains unchanged.

---

## Test 2 — `$ref` to integer

Schema:

```json
{
  "properties": {
    "limit": {
      "$ref": "#/$defs/Limit"
    }
  },
  "$defs": {
    "Limit": {
      "type": "integer"
    }
  }
}
```

Before the fix:

```json
{
  "query": "foo=bar",
  "limit": "10"
}
```

After the fix:

```json
{
  "query": "foo=bar",
  "limit": 10
}
```

Status: PASS

---

## Test 3 — `$ref` to object

Schema:

```json
{
  "properties": {
    "options": {
      "$ref": "#/$defs/SearchOptions"
    }
  },
  "$defs": {
    "SearchOptions": {
      "type": "object",
      "properties": {
        "limit": {
          "type": "integer"
        },
        "language": {
          "type": "string"
        }
      }
    }
  }
}
```

Before the fix:

```json
{
  "query": "foo=bar",
  "options": "{\"limit\": 10, \"language\": \"en\"}"
}
```

After the fix:

```json
{
  "query": "foo=bar",
  "options": {
    "limit": 10,
    "language": "en"
  }
}
```

Status: PASS

---

## Test 4 — `oneOf(integer, null)`

Schema:

```json
{
  "value": {
    "oneOf": [
      {
        "type": "integer"
      },
      {
        "type": "null"
      }
    ]
  }
}
```

Before the fix:

```json
{
  "value": "123"
}
```

After the fix:

```json
{
  "value": 123
}
```

Status: PASS

---

## Test 5 — Streaming `$ref` to integer

The same referenced integer schema was tested using:

```json
{
  "stream": true
}
```

The streamed `function.arguments` chunks reconstructed to:

```json
{
  "query": "foo=bar",
  "limit": 10
}
```

The integer is emitted without quotes.

Final response correctly ends with:

```json
{
  "finish_reason": "tool_calls"
}
```

Status: PASS

---

## Test 6 — Streaming `$ref` to object

A referenced object was tested with streaming enabled.

The streamed chunks reconstructed to:

```json
{
  "query": "foo=bar",
  "options": {
    "limit": 10,
    "language": "en"
  }
}
```

The object is no longer emitted as an escaped JSON string.

Status: PASS

---

## Test 7 — Streaming `oneOf(integer, null)`

The union schema was tested with streaming enabled.

The resulting streamed arguments reconstructed to:

```json
{
  "value": 123
}
```

instead of:

```json
{
  "value": "123"
}
```

Status: PASS

---

## Test 8 — Streaming `$ref` to array

Schema:

```json
{
  "properties": {
    "ids": {
      "$ref": "#/$defs/Ids"
    }
  },
  "$defs": {
    "Ids": {
      "type": "array",
      "items": {
        "type": "integer"
      }
    }
  }
}
```

The streamed arguments reconstructed to:

```json
{
  "ids": [1, 2, 3]
}
```

instead of a JSON-encoded string.

Status: PASS

---

## Test 9 — Chained `$ref`

Schema relationship:

```text
limit
  -> #/$defs/LimitAlias
  -> #/$defs/Limit
  -> integer
```

Result:

```json
{
  "limit": 25
}
```

Status: PASS

This verifies recursive local `$ref` resolution.

---

## Test 10 — `anyOf(integer, null)`

Schema:

```json
{
  "count": {
    "anyOf": [
      {
        "type": "integer"
      },
      {
        "type": "null"
      }
    ]
  }
}
```

Result:

```json
{
  "count": 42
}
```

Status: PASS

---

# Test summary

| Case | Non-streaming | Streaming |
| --- | --- | --- |
| Direct integer | PASS | PASS |
| `$ref` → integer | PASS | PASS |
| `$ref` → object | PASS | PASS |
| `oneOf(integer, null)` | PASS | PASS |
| `$ref` → array | PASS | PASS |
| Chained `$ref` | PASS | N/A |
| `anyOf(integer, null)` | PASS | N/A |

All tested values now preserve their intended JSON types inside OpenAI-compatible `function.arguments`.

# Scope

This PR is intentionally focused on JSON Schema resolution and argument type serialization in `qwen3_coder`.

It does not attempt to address unrelated Qwen reasoning/tool-call parsing behavior, such as cases where a model emits `<tool_call>` before closing a `<think>` block. That should be handled independently to keep this change focused and easier to review.

# Expected impact

The change should improve compatibility with:

- MCP tools
- OpenAI-compatible tool clients
- JSON Schema generated by Pydantic/Zod/TypeBox-style libraries
- schemas using `$defs`
- nullable schemas
- structured object and array arguments
- streaming and non-streaming Qwen tool calls

It also preserves the existing behavior for parameters that directly specify their JSON Schema `type`.